### PR TITLE
fix: configure npm trusted publishing with setup-node and OIDC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Main
 
-permissions:
-  id-token: write  # Required for OIDC
-
 on:
   push:
     branches:
@@ -10,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      
+
 env:
   RUST_VERSION: 1.84.0
   SOLANA_VERSION: 2.2.17
@@ -22,9 +19,19 @@ jobs:
     name: Release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for changesets to create releases/PRs
+      pull-requests: write # Required for changesets to create PRs
+      id-token: write # Required for npm trusted publishing (OIDC)
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun v2
         uses: oven-sh/setup-bun@v2
@@ -40,12 +47,12 @@ jobs:
           publish: bun release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
   docs:
     permissions:
-      id-token: "write"
-      pages: "write"
+      id-token: 'write'
+      pages: 'write'
     name: Docs
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -59,21 +66,21 @@ jobs:
       - name: Install Dependencies
         run: bun install
 
-      - name: "Build repo"
+      - name: 'Build repo'
         run: bun run build:packages
 
-      - name: "Build documentation"
+      - name: 'Build documentation'
         run: bun build:docs
 
-      - name: "Upload Pages artifact"
-        uses: "actions/upload-pages-artifact@v3"
+      - name: 'Upload Pages artifact'
+        uses: 'actions/upload-pages-artifact@v3'
         with:
           name: github-pages
           path: docs/
 
-      - id: "deployment"
-        name: "Deploy documentation to GitHub Pages"
-        uses: "actions/deploy-pages@v4"
+      - id: 'deployment'
+        name: 'Deploy documentation to GitHub Pages'
+        uses: 'actions/deploy-pages@v4'
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

The Release job has been failing with `ENEEDAUTH` on all npm publish attempts because npm had no authentication configured for trusted publishing (OIDC).

## Root Cause

The previous fix (#110) added `id-token: write` at the top level, but that alone is insufficient. npm's trusted publishing requires:

1. **`actions/setup-node` with `registry-url`** — This creates the `.npmrc` file that npm needs to know which registry to authenticate with. Without it, npm has no auth configuration at all, resulting in `ENEEDAUTH`.
2. **`NPM_CONFIG_PROVENANCE: true`** — Tells `changeset publish` (which calls `npm publish` under the hood) to use provenance/OIDC authentication.
3. **Job-level permissions** — `contents: write` and `pull-requests: write` for changesets, plus `id-token: write` for OIDC.

## Changes

- Added `actions/setup-node@v4` with `registry-url: 'https://registry.npmjs.org'` and `node-version: '22'` to the Release job
- Added job-level `permissions` block with `contents: write`, `pull-requests: write`, and `id-token: write`
- Replaced `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` with `NPM_CONFIG_PROVENANCE: true` (trusted publishing uses OIDC tokens, not long-lived npm tokens)
- Removed top-level `permissions` block (was overly restrictive — set all non-specified permissions to `none` for jobs without their own `permissions`)

## Important Note

Ensure that each `@swig-wallet/*` package has the trusted publisher configured on npmjs.com with:
- **Repository:** `anagrambuild/swig-ts`
- **Workflow filename:** `main.yml` (must match exactly, case-sensitive)