### PR TITLE
fix: add repository field to all packages for npm provenance

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.0",
   "description": "API clients for the Swig ecosystem (Portal and Paymaster services)",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/api"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/classic/package.json
+++ b/packages/classic/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/classic",
   "version": "1.6.0",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/classic"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/coder/package.json
+++ b/packages/coder/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/coder",
   "version": "1.6.0",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/coder"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/developer/package.json
+++ b/packages/developer/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/developer",
   "version": "1.1.0",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/developer"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/kit",
   "version": "1.6.0",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/kit"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/lib",
   "version": "1.6.0",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/lib"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/mcp-server",
   "version": "1.0.1",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/mcp-server"
+  },
   "type": "module",
   "description": "MCP server for Swig smart wallet operations on Solana",
   "bin": {

--- a/packages/paymaster/classic/package.json
+++ b/packages/paymaster/classic/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/paymaster-classic",
   "version": "1.0.2",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/paymaster/classic"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/paymaster/core/package.json
+++ b/packages/paymaster/core/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/paymaster-core",
   "version": "1.0.2",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/paymaster/core"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",

--- a/packages/paymaster/kit/package.json
+++ b/packages/paymaster/kit/package.json
@@ -2,6 +2,11 @@
   "name": "@swig-wallet/paymaster-kit",
   "version": "1.0.2",
   "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anagrambuild/swig-ts",
+    "directory": "packages/paymaster/kit"
+  },
   "type": "module",
   "scripts": {
     "build-pkg": "tsup-node",


### PR DESCRIPTION
## Summary

npm provenance verification requires each package.json to have a `repository.url` matching the GitHub repo in the signed attestation. All 10 packages were missing this field, causing `E422 Unprocessable Entity` errors on publish:

```
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/anagrambuild/swig-ts" from provenance
```

Adds `repository` with the correct `url` and `directory` to every package.

**Note:** `@swig-wallet/developer` also failed with `ENEEDAUTH` — its trusted publisher config likely needs to be added on npmjs.com.