### PR TITLE
fix: mark fee payer as signer in accounts list before hash computation

### DIFF
--- a/.changeset/fix-fee-payer-signer-mismatch.md
+++ b/.changeset/fix-fee-payer-signer-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/lib": minor
+---
+
+Fix fee payer is_signer mismatch in message hash computation for secp256r1/secp256k1 authorities. When the fee payer appeared as a transfer destination in inner instructions, the client computed the hash with is_signer=false while the on-chain program saw is_signer=true, causing error 0xbd2 (PermissionDeniedSecp256r1InvalidMessageHash). The payer is now correctly marked as a signer in the accounts list before hash computation.

--- a/packages/lib/src/authority/instructions/interface.ts
+++ b/packages/lib/src/authority/instructions/interface.ts
@@ -26,7 +26,11 @@ import {
   type TransferAssetsV1InstructionAccounts,
   type UpdateAuthorityV1InstructionAccounts,
 } from '../../instructions';
-import type { SolInstruction, SwigInstructionContext } from '../../solana';
+import type {
+  SolInstruction,
+  SolPublicKeyData,
+  SwigInstructionContext,
+} from '../../solana';
 
 /**
  * Authority Instruction Interface
@@ -184,4 +188,8 @@ export type InstructionDataOptions = {
   odometer?: number;
   preInstructions?: SolInstruction[];
   postInstructions?: SolInstruction[];
+  /** Transaction fee payer. Used by secp256r1/secp256k1 authorities to ensure
+   *  the payer account is marked as a signer before computing the message hash,
+   *  matching the Solana runtime behavior. See https://github.com/anagrambuild/swig-ts/issues/107 */
+  payer?: SolPublicKeyData;
 };

--- a/packages/lib/src/authority/instructions/secp256k1.ts
+++ b/packages/lib/src/authority/instructions/secp256k1.ts
@@ -182,6 +182,18 @@ export const Secp256k1Instruction: AuthorityInstruction = {
       [accounts.swigSystemAddress],
     );
 
+    // The Solana runtime always marks the fee payer as is_signer=true on all
+    // AccountInfos. If the payer appears in metas (e.g. as a transfer destination),
+    // it must be marked as signer here so the client-side hash matches the on-chain
+    // hash. See: https://github.com/anagrambuild/swig-ts/issues/107
+    if (options.payer) {
+      const payerKey = new SolPublicKey(options.payer).toBase58();
+      const payerMeta = metas.find((m) => m.publicKey.toBase58() === payerKey);
+      if (payerMeta) {
+        payerMeta.setSigner(true);
+      }
+    }
+
     const encodedCompactInstructions = getArrayEncoder(
       getCompactInstructionEncoder(),
       {

--- a/packages/lib/src/authority/instructions/secp256r1.ts
+++ b/packages/lib/src/authority/instructions/secp256r1.ts
@@ -251,6 +251,18 @@ export const Secp256r1Instruction: AuthorityInstruction = {
       [accounts.swigSystemAddress],
     );
 
+    // The Solana runtime always marks the fee payer as is_signer=true on all
+    // AccountInfos. If the payer appears in metas (e.g. as a transfer destination),
+    // it must be marked as signer here so the client-side hash matches the on-chain
+    // hash. See: https://github.com/anagrambuild/swig-ts/issues/107
+    if (options.payer) {
+      const payerKey = new SolPublicKey(options.payer).toBase58();
+      const payerMeta = metas.find((m) => m.publicKey.toBase58() === payerKey);
+      if (payerMeta) {
+        payerMeta.setSigner(true);
+      }
+    }
+
     const encodedCompactInstructions = getArrayEncoder(
       getCompactInstructionEncoder(),
       {

--- a/packages/lib/tests/instructions/sign.test.ts
+++ b/packages/lib/tests/instructions/sign.test.ts
@@ -257,6 +257,67 @@ describe('Sign Instruction', () => {
       expect(svm.getBalance(recipient1.publicKey)).toBe(amount1);
       expect(svm.getBalance(recipient2.publicKey)).toBe(amount2);
     });
+
+    test('signs multi-transfer with fee payer as destination (issue #107)', async () => {
+      const svm = getSvm();
+      const [payer] = getFundedKeys(svm, 1);
+      const recipient = Keypair.generate();
+      const swigId = randomBytes(32);
+      const authority = createTestSecp256k1Authority();
+
+      const [swigAddress] = await findSwigPdaRaw(swigId);
+
+      const createIx = await getCreateSwigInstructionContext({
+        authorityInfo: authority.authorityInfo,
+        id: swigId,
+        payer: payer.publicKey,
+        actions: Actions.set().all().get(),
+      });
+      sendSwigSVMTransaction(svm, createIx, payer);
+
+      const swig = fetchSwig(svm, swigAddress);
+      const walletAddress = toPublicKey(await getSwigWalletAddressRaw(swig));
+      const role = swig.roles[0];
+
+      svm.airdrop(walletAddress, SOL);
+
+      const slot = svm.getClock().slot;
+      const payerBalanceBefore = svm.getBalance(payer.publicKey)!;
+      const amount1 = SOL / 10n;
+      const amount2 = SOL / 20n;
+
+      const transfer1 = getTransferSolInstruction({
+        source: address(walletAddress.toBase58()),
+        destination: address(recipient.publicKey.toBase58()),
+        amount: amount1,
+      });
+
+      const transfer2 = getTransferSolInstruction({
+        source: address(walletAddress.toBase58()),
+        destination: address(payer.publicKey.toBase58()),
+        amount: amount2,
+      });
+
+      const signIx = await getSignInstructionContext(
+        swig,
+        role.id,
+        [transfer1, transfer2].map(SolInstruction.from),
+        false,
+        {
+          payer: payer.publicKey,
+          currentSlot: slot,
+          signingFn: authority.signingFn ?? undefined,
+        },
+      );
+
+      sendSwigSVMTransaction(svm, signIx, payer);
+
+      expect(svm.getBalance(recipient.publicKey)).toBe(amount1);
+      const payerBalanceAfter = svm.getBalance(payer.publicKey)!;
+      expect(payerBalanceAfter).toBeGreaterThan(
+        payerBalanceBefore - SOL / 100n,
+      );
+    });
   });
 
   // ============================================================================
@@ -370,6 +431,74 @@ describe('Sign Instruction', () => {
 
       expect(svm.getBalance(recipient1.publicKey)).toBe(amount1);
       expect(svm.getBalance(recipient2.publicKey)).toBe(amount2);
+    });
+
+    test('signs multi-transfer with fee payer as destination (issue #107)', async () => {
+      // This test reproduces the scenario from https://github.com/anagrambuild/swig-ts/issues/107
+      // When the fee payer is also a transfer destination, the on-chain program sees
+      // is_signer=true for the payer account, but the client was computing the hash
+      // with is_signer=false, causing a message hash mismatch (error 0xbd2).
+      const svm = getSvm();
+      const [payer] = getFundedKeys(svm, 1);
+      const recipient = Keypair.generate();
+      const swigId = randomBytes(32);
+      const authority = createTestSecp256r1Authority();
+
+      const [swigAddress] = await findSwigPdaRaw(swigId);
+
+      const createIx = await getCreateSwigInstructionContext({
+        authorityInfo: authority.authorityInfo,
+        id: swigId,
+        payer: payer.publicKey,
+        actions: Actions.set().all().get(),
+      });
+      sendSwigSVMTransaction(svm, createIx, payer);
+
+      const swig = fetchSwig(svm, swigAddress);
+      const walletAddress = toPublicKey(await getSwigWalletAddressRaw(swig));
+      const role = swig.roles[0];
+
+      svm.airdrop(walletAddress, SOL);
+
+      const slot = svm.getClock().slot;
+      const payerBalanceBefore = svm.getBalance(payer.publicKey)!;
+      const amount1 = SOL / 10n;
+      const amount2 = SOL / 20n;
+
+      // Transfer 1: swig wallet -> random recipient
+      const transfer1 = getTransferSolInstruction({
+        source: address(walletAddress.toBase58()),
+        destination: address(recipient.publicKey.toBase58()),
+        amount: amount1,
+      });
+
+      // Transfer 2: swig wallet -> fee payer (this is the problematic case)
+      const transfer2 = getTransferSolInstruction({
+        source: address(walletAddress.toBase58()),
+        destination: address(payer.publicKey.toBase58()),
+        amount: amount2,
+      });
+
+      const signIx = await getSignInstructionContext(
+        swig,
+        role.id,
+        [transfer1, transfer2].map(SolInstruction.from),
+        false,
+        {
+          payer: payer.publicKey,
+          currentSlot: slot,
+          signingFn: authority.signingFn ?? undefined,
+        },
+      );
+
+      sendSwigSVMTransaction(svm, signIx, payer);
+
+      expect(svm.getBalance(recipient.publicKey)).toBe(amount1);
+      // Payer should have received amount2 (minus tx fees)
+      const payerBalanceAfter = svm.getBalance(payer.publicKey)!;
+      expect(payerBalanceAfter).toBeGreaterThan(
+        payerBalanceBefore - SOL / 100n,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #107 — Transaction simulation fails with `custom program error: 0xbd2` (`PermissionDeniedSecp256r1InvalidMessageHash`) when a secp256r1/secp256k1-signed Swig wallet transaction includes transfer instructions where one sends SOL back to the fee payer.

## Root Cause

The Solana runtime **always** marks the transaction fee payer as `is_signer=true` on **all** `AccountInfo`s in every instruction. When the fee payer appears as a destination in inner instructions (e.g., `system_instruction::transfer` back to the payer), `compactInstructions()` adds it to the accounts list with `is_signer=false` (since it's just a recipient). The on-chain program then computes the message hash with `is_signer=true` for the payer, but the client computed it with `is_signer=false`, causing the keccak256 hash to differ.

## Fix

The `payer` public key already flows from `SwigOptions` through the call chain to the secp256r1/secp256k1 signing functions via `InstructionDataOptions`. The fix:

1. Declares `payer` on `InstructionDataOptions` so it can be accessed type-safely in the signing functions
2. In `secp256r1.ts` and `secp256k1.ts` `signV2Instruction`: after `compactInstructions()` returns and before hash computation, finds the payer in the account metas and marks it as `isSigner=true`

This is the minimal-surface fix — only 3 source files changed, no modifications to `compactInstructions`, `swig/index.ts`, token authority classes, or any other shared code.

## Usage

**No code changes are required for users of `getSignInstructionContext` or `getSignInstructions`.** The `payer` option was already part of `SwigOptions` and already being passed through the call chain — this fix simply makes the signing functions aware of it.

The following pattern that previously failed with `0xbd2` now works correctly:

```ts
import {
  getSignInstructionContext,
  SolInstruction,
} from '@swig-wallet/lib';

// Transfer 1: swig wallet -> some recipient
const transfer1 = getTransferSolInstruction({
  source: swigWalletAddress,
  destination: recipientAddress,
  amount: 100_000_000n,
});

// Transfer 2: swig wallet -> fee payer (previously caused 0xbd2)
const transfer2 = getTransferSolInstruction({
  source: swigWalletAddress,
  destination: payerAddress,  // <-- sending back to the fee payer
  amount: 50_000_000n,
});

const signIx = await getSignInstructionContext(
  swig,
  roleId,
  [transfer1, transfer2].map(SolInstruction.from),
  false,
  {
    payer: payer.publicKey,     // already required by existing API
    currentSlot: slot,
    signingFn: authority.signingFn,
  },
);
```

For users of the lower-level `Secp256r1Instruction.signV2Instruction` or `Secp256k1Instruction.signV2Instruction` directly, pass `payer` in the `options` parameter:

```ts
const ctx = await Secp256r1Instruction.signV2Instruction(
  { swig: swigAddress, swigSystemAddress },
  { authorityData, innerInstructions, roleId },
  {
    signingFn,
    currentSlot,
    odometer,
    payer: payerPublicKey,   // <-- new: ensures correct hash when payer is in inner instructions
  },
);
```

## Files Changed

| File | Change |
|------|--------|
| `packages/lib/src/authority/instructions/interface.ts` | Added optional `payer` to `InstructionDataOptions` type |
| `packages/lib/src/authority/instructions/secp256r1.ts` | Mark payer as signer in metas after `compactInstructions()`, before hash |
| `packages/lib/src/authority/instructions/secp256k1.ts` | Same fix |
| `packages/lib/tests/instructions/sign.test.ts` | 2 regression tests (secp256r1 + secp256k1) |

## Testing

- Added 2 new tests: `signs multi-transfer with fee payer as destination (issue #107)` for both secp256r1 and secp256k1 authorities
- All 350 existing tests pass with 0 failures
- Lint, typecheck, and format all pass
- Companion program-level tests in swig-wallet: https://github.com/anagrambuild/swig-wallet/pull/139