### PR TITLE
Fix: pass session key instead of full authority data in Ed25519SessionAuthority methods

### DIFF
--- a/packages/lib/src/authority/ed25519/session.ts
+++ b/packages/lib/src/authority/ed25519/session.ts
@@ -136,7 +136,7 @@ export class Ed25519SessionAuthority
       {
         actingRoleId: args.actingRoleId,
         actions: args.actions.bytes(),
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         newAuthorityData: args.newAuthorityInfo.data,
         newAuthorityType: args.newAuthorityInfo.type,
         noOfActions: args.actions.count,
@@ -157,7 +157,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         authorityToRemoveId: args.roleIdToRemove,
       },
     );
@@ -177,7 +177,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         authorityToUpdateId: args.roleIdToUpdate,
         updateActionsPayload: args.updateActionsInfo.data,
       },
@@ -223,7 +223,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         bump,
       },
     );
@@ -265,7 +265,7 @@ export class Ed25519SessionAuthority
       {
         subAccountRoleId: args.subAccountRoleId,
         actingRoleId: args.actingRoleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         enabled: args.enabled,
       },
     );
@@ -288,7 +288,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         amount: args.amount,
       },
     );
@@ -335,7 +335,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         amount: args.amount,
       },
     );
@@ -354,7 +354,7 @@ export class Ed25519SessionAuthority
         swigSystemAddress: args.swigSystemAddress,
       },
       {
-        authorityData: this.data,
+        authorityData: this.sessionKey.toBytes(),
         roleId: args.roleId,
       },
     );

--- a/packages/lib/src/authority/ed25519/session.ts
+++ b/packages/lib/src/authority/ed25519/session.ts
@@ -114,7 +114,7 @@ export class Ed25519SessionAuthority
         swigSystemAddress: args.swigSystemAddress,
       },
       {
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         innerInstructions: args.innerInstructions,
         roleId: args.roleId,
       },
@@ -136,7 +136,7 @@ export class Ed25519SessionAuthority
       {
         actingRoleId: args.actingRoleId,
         actions: args.actions.bytes(),
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         newAuthorityData: args.newAuthorityInfo.data,
         newAuthorityType: args.newAuthorityInfo.type,
         noOfActions: args.actions.count,
@@ -157,7 +157,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         authorityToRemoveId: args.roleIdToRemove,
       },
     );
@@ -177,7 +177,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         authorityToUpdateId: args.roleIdToUpdate,
         updateActionsPayload: args.updateActionsInfo.data,
       },
@@ -223,7 +223,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         bump,
       },
     );
@@ -242,7 +242,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         innerInstructions: args.innerInstructions,
       },
     );
@@ -265,7 +265,7 @@ export class Ed25519SessionAuthority
       {
         subAccountRoleId: args.subAccountRoleId,
         actingRoleId: args.actingRoleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         enabled: args.enabled,
       },
     );
@@ -288,7 +288,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         amount: args.amount,
       },
     );
@@ -335,7 +335,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         amount: args.amount,
       },
     );
@@ -354,7 +354,7 @@ export class Ed25519SessionAuthority
         swigSystemAddress: args.swigSystemAddress,
       },
       {
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         roleId: args.roleId,
       },
     );
@@ -373,7 +373,7 @@ export class Ed25519SessionAuthority
         destination: args.destination,
       },
       {
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         roleId: args.roleId,
       },
     );
@@ -395,7 +395,7 @@ export class Ed25519SessionAuthority
         tokenProgram: args.tokenProgram,
       },
       {
-        authorityData: this.id,
+        authorityData: this.sessionKey.toBytes(),
         roleId: args.roleId,
         tokenAccounts: args.tokenAccounts as any,
       },

--- a/packages/lib/src/authority/ed25519/session.ts
+++ b/packages/lib/src/authority/ed25519/session.ts
@@ -114,7 +114,7 @@ export class Ed25519SessionAuthority
         swigSystemAddress: args.swigSystemAddress,
       },
       {
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         innerInstructions: args.innerInstructions,
         roleId: args.roleId,
       },
@@ -136,7 +136,7 @@ export class Ed25519SessionAuthority
       {
         actingRoleId: args.actingRoleId,
         actions: args.actions.bytes(),
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         newAuthorityData: args.newAuthorityInfo.data,
         newAuthorityType: args.newAuthorityInfo.type,
         noOfActions: args.actions.count,
@@ -157,7 +157,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         authorityToRemoveId: args.roleIdToRemove,
       },
     );
@@ -177,7 +177,7 @@ export class Ed25519SessionAuthority
       },
       {
         actingRoleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         authorityToUpdateId: args.roleIdToUpdate,
         updateActionsPayload: args.updateActionsInfo.data,
       },
@@ -223,7 +223,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         bump,
       },
     );
@@ -242,7 +242,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         innerInstructions: args.innerInstructions,
       },
     );
@@ -265,7 +265,7 @@ export class Ed25519SessionAuthority
       {
         subAccountRoleId: args.subAccountRoleId,
         actingRoleId: args.actingRoleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         enabled: args.enabled,
       },
     );
@@ -288,7 +288,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         amount: args.amount,
       },
     );
@@ -335,7 +335,7 @@ export class Ed25519SessionAuthority
       },
       {
         roleId: args.roleId,
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         amount: args.amount,
       },
     );
@@ -354,7 +354,7 @@ export class Ed25519SessionAuthority
         swigSystemAddress: args.swigSystemAddress,
       },
       {
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         roleId: args.roleId,
       },
     );
@@ -373,7 +373,7 @@ export class Ed25519SessionAuthority
         destination: args.destination,
       },
       {
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         roleId: args.roleId,
       },
     );
@@ -395,7 +395,7 @@ export class Ed25519SessionAuthority
         tokenProgram: args.tokenProgram,
       },
       {
-        authorityData: this.sessionKey.toBytes(),
+        authorityData: this.id,
         roleId: args.roleId,
         tokenAccounts: args.tokenAccounts as any,
       },

--- a/packages/lib/tests/authority/ed25519.test.ts
+++ b/packages/lib/tests/authority/ed25519.test.ts
@@ -8,8 +8,10 @@ import {
   createEd25519AuthorityInfo,
   createEd25519SessionAuthorityInfo,
   findSwigPdaRaw,
+  findSwigSubAccountPdaRaw,
   getAddAuthorityInstructionContext,
   getCreateSessionInstructionContext,
+  getCreateSubAccountInstructionContext,
   getCreateSwigInstructionContext,
   isEd25519Authority,
   isEd25519SessionAuthority,
@@ -20,6 +22,7 @@ import {
   generateTestKeypair,
   randomBytes,
   sendSwigSVMTransaction,
+  toPublicKey,
 } from '../helpers';
 
 describe('Ed25519 Authority', () => {
@@ -752,6 +755,90 @@ describe('Ed25519 Authority', () => {
       expect(authority.matchesSigner(sessionKey.publicKey.toBytes())).toBe(
         true,
       );
+    });
+
+    test('session authority can create sub-account after session activation', async () => {
+      const svm = getSvm();
+      const [payer] = getFundedKeys(svm, 1);
+      const sessionKey = generateTestKeypair();
+      const swigId = randomBytes(32);
+
+      const [swigAddress] = await findSwigPdaRaw(swigId);
+
+      const createIx = await getCreateSwigInstructionContext({
+        authorityInfo: createEd25519SessionAuthorityInfo(payer.address, 100n),
+        id: swigId,
+        payer: payer.address,
+        actions: Actions.set().all().get(),
+      });
+      sendSwigSVMTransaction(svm, createIx, payer);
+
+      let swig = fetchSwig(svm, swigAddress);
+
+      const createSessionIx = await getCreateSessionInstructionContext(
+        swig,
+        0,
+        sessionKey.address,
+        50n,
+        { payer: payer.address },
+      );
+      sendSwigSVMTransaction(svm, createSessionIx, payer);
+
+      swig = fetchSwig(svm, swigAddress);
+
+      const createSubAccountIx = await getCreateSubAccountInstructionContext(
+        swig,
+        0,
+        { payer: payer.address },
+      );
+      sendSwigSVMTransaction(svm, createSubAccountIx, payer, [sessionKey]);
+
+      const [subAccountAddress] = await findSwigSubAccountPdaRaw(swigId, 0);
+      const balance = svm.getBalance(toPublicKey(subAccountAddress));
+      expect(balance).toBeGreaterThan(0n);
+    });
+
+    test('session authority builds addAuthority instruction without byte-length error', async () => {
+      const svm = getSvm();
+      const [payer] = getFundedKeys(svm, 1);
+      const sessionKey = generateTestKeypair();
+      const newAuthority = generateTestKeypair();
+      const swigId = randomBytes(32);
+
+      const [swigAddress] = await findSwigPdaRaw(swigId);
+
+      const createIx = await getCreateSwigInstructionContext({
+        authorityInfo: createEd25519SessionAuthorityInfo(payer.address, 100n),
+        id: swigId,
+        payer: payer.address,
+        actions: Actions.set().all().get(),
+      });
+      sendSwigSVMTransaction(svm, createIx, payer);
+
+      let swig = fetchSwig(svm, swigAddress);
+
+      const createSessionIx = await getCreateSessionInstructionContext(
+        swig,
+        0,
+        sessionKey.address,
+        50n,
+        { payer: payer.address },
+      );
+      sendSwigSVMTransaction(svm, createSessionIx, payer);
+
+      swig = fetchSwig(svm, swigAddress);
+
+      // Before the fix, this threw "Invalid PublicKey byte length. Length is 80, not 32 bytes"
+      // because addAuthority passed the full 80-byte authority struct instead of the 32-byte session key
+      const addIx = await getAddAuthorityInstructionContext(
+        swig,
+        0,
+        createEd25519AuthorityInfo(newAuthority.address),
+        Actions.set().solLimit({ amount: 500_000_000n }).get(),
+      );
+
+      const instructions = addIx.getKitInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/lib/tests/authority/ed25519.test.ts
+++ b/packages/lib/tests/authority/ed25519.test.ts
@@ -769,7 +769,7 @@ describe('Ed25519 Authority', () => {
         authorityInfo: createEd25519SessionAuthorityInfo(payer.address, 100n),
         id: swigId,
         payer: payer.address,
-        actions: Actions.set().all().get(),
+        actions: Actions.set().all().subAccount().get(),
       });
       sendSwigSVMTransaction(svm, createIx, payer);
 


### PR DESCRIPTION
I hit this trying to use the SDK to create sub-accounts under a Swig smart wallet.

Stacktrace

```
Error: Invalid PublicKey byte length. Lenght is 80, not 32 bytes
    at new _class (@swig-wallet/lib/dist/index.cjs:37:13)
    at Object.subAccountCreateV1Instruction (@swig-wallet/lib/dist/index.cjs:2405:23)
    at _Ed25519SessionAuthority.subAccountCreate (@swig-wallet/lib/dist/index.cjs:4080:31)
    at async getCreateSubAccountInstructions (@swig-wallet/classic/dist/index.cjs:164:19)
```


This attempts to fix the issue where the SDK's `_Ed25519SessionAuthority.subAccountCreate` passes the full 80-byte authority data to `new PublicKey()`, which expects 32 bytes and crashes with 'Invalid PublicKey byte length. Length is 80, not 32 bytes.'

Instead of passing the entire 80-byte serialized authority struct, just pass the 32 byte session key.

Script which should reproduce the issue:

```typescript
import { Connection, Keypair, PublicKey } from "@solana/web3.js";
import {
  fetchSwig,
  getCreateSubAccountInstructions,
  getCreateSwigInstructionBuilder,
  createEd25519AuthorityInfo,
  createEd25519SessionAuthorityInfo,
  ActionsBuilder,
  findSwigPda,
} from "@swig-wallet/classic";

// Create a Swig with root (Ed25519) + session (Ed25519Session) authorities
const rootActions = ActionsBuilder.new().all().manageAuthority().subAccount().get();
const sessionActions = ActionsBuilder.new().solLimit({ amount: 100000000n }).subAccount().get();

const swigId = new Uint8Array(32);
crypto.getRandomValues(swigId);

const rootAuthInfo = createEd25519AuthorityInfo(rootKeypair.publicKey.toBase58());
const sessionAuthInfo = createEd25519SessionAuthorityInfo(
  sessionKeypair.publicKey.toBase58(),
  1512000n, // ~7 days in slots
);

const builder = getCreateSwigInstructionBuilder({
  payer: rootKeypair.publicKey,
  swigAddress: findSwigPda(swigId),
  id: swigId,
  actions: rootActions,
  authorityInfo: rootAuthInfo,
  options: { signingFn },
});
builder.addAuthority(sessionAuthInfo, sessionActions);
// ... submit transaction, Swig created successfully with 2 roles ...

// Now try to create a sub-account for role 1 (Ed25519Session):
const swig = await fetchSwig(connection, swigAddress);
const instructions = await getCreateSubAccountInstructions(swig, 1, {
  payer: sessionKeypair.publicKey,
  signingFn: sessionSigningFn,
});
// ^ THROWS: Invalid PublicKey byte length. Length is 80, not 32 bytes
```