### PR TITLE
chore: add missing changesets for PRs 129 and 130

### DIFF
--- a/.changeset/pr129-rent-destination.md
+++ b/.changeset/pr129-rent-destination.md
@@ -1,0 +1,9 @@
+---
+'@swig-wallet/api': minor
+'@swig-wallet/coder': minor
+'@swig-wallet/developer': minor
+'@swig-wallet/lib': minor
+'@swig-wallet/mcp-server': minor
+---
+
+Add `RentDestination` action support across the TypeScript SDK so APIs, action builders, payload decoding, and MCP permission parsing can encode and accept rent-destination configs.

--- a/.changeset/pr130-program-curated-payload.md
+++ b/.changeset/pr130-program-curated-payload.md
@@ -1,0 +1,6 @@
+---
+'@swig-wallet/coder': patch
+'@swig-wallet/lib': patch
+---
+
+Fix `ProgramCurated` action encoding to include the reserved 32-byte payload so generated SignV2 instructions match on-chain expectations.


### PR DESCRIPTION
## Summary
- add a missing changeset for PR #129 with `minor` bumps for `@swig-wallet/api`, `@swig-wallet/coder`, `@swig-wallet/developer`, `@swig-wallet/lib`, and `@swig-wallet/mcp-server`
- add a missing changeset for PR #130 with `patch` bumps for `@swig-wallet/coder` and `@swig-wallet/lib`
- capture the release notes needed for the already-merged feature/fix work without changing runtime code

## Validation
- reviewed the generated changeset entries for package names and bump types