### PR TITLE
Add Relay support tooling and off-curve workaround validation

### DIFF
--- a/scripts/README.relay-swig.md
+++ b/scripts/README.relay-swig.md
@@ -1,0 +1,79 @@
+# Relay + Swig reusable adapter
+
+This folder now includes a reusable adapter for converting Relay quote routes into
+Swig-signable instructions.
+
+## Module
+
+- `scripts/lib/relay-swig-adapter.ts`
+
+Core functions:
+
+- `fetchRelayQuote(request, options)`
+- `resolveRelayQuoteInstructions(quote, { connection })`
+- `buildUserAndAtaRewrites({ fromUser, toUser, mints })`
+- `prepareRelayRouteForSwig({ quote, swig, roleId, rewrites, resolveOptions })`
+
+The adapter keeps per-step/per-item batch boundaries so multi-step Relay routes
+can be executed sequentially.
+
+## Validation script (USDC + cheatcode funding)
+
+- `scripts/relay-usdc-cheatcode-validation.ts`
+
+Runs baseline (quote user) and mutated (Swig) executions and compares token
+spend deltas.
+
+Example:
+
+```bash
+SURFPOOL_RPC=http://127.0.0.1:18999 bun scripts/relay-usdc-cheatcode-validation.ts
+```
+
+## One-command end-to-end runner
+
+- `scripts/run-relay-swig-validation.sh`
+
+This script:
+
+- starts Surfpool (mainnet fork) on custom ports
+- runs the full USDC cheatcode validation flow
+- prints Explorer links using `cluster=custom` + Surfpool RPC
+- leaves Surfpool running for manual inspection
+
+Example:
+
+```bash
+./scripts/run-relay-swig-validation.sh
+```
+
+Optional env overrides:
+
+- `SURFPOOL_HOST` (default `127.0.0.1`)
+- `SURFPOOL_PORT` (default `18999`)
+- `SURFPOOL_WS_PORT` (default `SURFPOOL_PORT + 1`)
+
+## Generic route runner
+
+- `scripts/relay-generic-route-runner.ts`
+
+Environment variables:
+
+- `RELAY_ORIGIN_CHAIN_ID`
+- `RELAY_DESTINATION_CHAIN_ID`
+- `RELAY_ORIGIN_CURRENCY`
+- `RELAY_DESTINATION_CURRENCY`
+- `RELAY_AMOUNT`
+- optional `RELAY_TRADE_TYPE`, `RELAY_RECIPIENT`, `RELAY_REWRITE_MINTS`
+
+Example:
+
+```bash
+RELAY_ORIGIN_CHAIN_ID=792703809 \
+RELAY_DESTINATION_CHAIN_ID=8453 \
+RELAY_ORIGIN_CURRENCY=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+RELAY_DESTINATION_CURRENCY=0x833589fCD6eDb6E08f4c7c32D4f71b54bdA02913 \
+RELAY_AMOUNT=1000000 \
+SURFPOOL_RPC=http://127.0.0.1:18999 \
+bun scripts/relay-generic-route-runner.ts
+```

--- a/scripts/lib/relay-swig-adapter.ts
+++ b/scripts/lib/relay-swig-adapter.ts
@@ -1,0 +1,411 @@
+import { getAssociatedTokenAddressSync } from '@solana/spl-token';
+import {
+  type AddressLookupTableAccount,
+  type Connection,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import { getSignInstructions, type Swig } from '@swig-wallet/classic';
+
+const RELAY_API = 'https://api.relay.link';
+
+export interface RelayQuoteRequest {
+  user: string;
+  originChainId: number;
+  destinationChainId: number;
+  originCurrency: string;
+  destinationCurrency: string;
+  amount: string;
+  tradeType: 'EXACT_INPUT' | 'EXACT_OUTPUT';
+  recipient: string;
+}
+
+export interface RelayInstructionAccountMeta {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+
+export interface RelayInstruction {
+  programId: string;
+  keys: RelayInstructionAccountMeta[];
+  data: string;
+}
+
+export interface RelayQuoteItemData {
+  instructions?: RelayInstruction[];
+  txData?: string;
+  addressLookupTableAddresses?: string[];
+  [key: string]: unknown;
+}
+
+export interface RelayQuoteItem {
+  status?: string;
+  data?: RelayQuoteItemData;
+  [key: string]: unknown;
+}
+
+export interface RelayQuoteStep {
+  id?: string;
+  action?: string;
+  kind?: string;
+  items?: RelayQuoteItem[];
+  [key: string]: unknown;
+}
+
+export interface RelayQuoteResponse {
+  steps?: RelayQuoteStep[];
+  requestId?: string;
+  [key: string]: unknown;
+}
+
+export interface FetchRelayQuoteOptions {
+  apiBaseUrl?: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}
+
+export interface RelayInstructionBatch {
+  stepIndex: number;
+  itemIndex: number;
+  stepId?: string;
+  stepAction?: string;
+  source: 'instructions' | 'txData';
+  instructions: TransactionInstruction[];
+}
+
+export interface ResolveRelayInstructionsOptions {
+  connection?: Connection;
+}
+
+export interface RelayAccountRewrite {
+  from: string | PublicKey;
+  to: string | PublicKey;
+}
+
+export type RelayAccountRewrites =
+  | RelayAccountRewrite[]
+  | Map<string, string | PublicKey>
+  | Record<string, string | PublicKey>;
+
+export interface PreparedSwigRelayBatch {
+  stepIndex: number;
+  itemIndex: number;
+  stepId?: string;
+  stepAction?: string;
+  source: 'instructions' | 'txData';
+  originalInstructions: TransactionInstruction[];
+  rewrittenInstructions: TransactionInstruction[];
+  swigSignInstructions: TransactionInstruction[];
+  replacements: number;
+}
+
+export interface PrepareRelayRouteForSwigResult {
+  batches: PreparedSwigRelayBatch[];
+  totalReplacements: number;
+}
+
+export async function fetchRelayQuote(
+  request: RelayQuoteRequest,
+  options: FetchRelayQuoteOptions = {},
+): Promise<RelayQuoteResponse> {
+  const response = await fetch(`${options.apiBaseUrl ?? RELAY_API}/quote/v2`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.apiKey
+        ? {
+            Authorization: `Bearer ${options.apiKey}`,
+          }
+        : {}),
+    },
+    body: JSON.stringify(request),
+    signal: options.signal,
+  });
+
+  const data: any = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `Relay quote failed (${response.status}): ${JSON.stringify(data)}`,
+    );
+  }
+
+  return data as RelayQuoteResponse;
+}
+
+export function relayInstructionToWeb3(
+  instruction: RelayInstruction,
+): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(instruction.programId),
+    keys: instruction.keys.map((k) => ({
+      pubkey: new PublicKey(k.pubkey),
+      isSigner: k.isSigner,
+      isWritable: k.isWritable,
+    })),
+    data: Buffer.from(instruction.data, 'hex'),
+  });
+}
+
+export function getBatchSignerPubkeys(batch: RelayInstructionBatch): string[] {
+  return [
+    ...new Set(
+      batch.instructions.flatMap((ix) =>
+        ix.keys.filter((k) => k.isSigner).map((k) => k.pubkey.toBase58()),
+      ),
+    ),
+  ];
+}
+
+async function decodeRelayTxDataToInstructions(
+  txData: string,
+  options: ResolveRelayInstructionsOptions,
+): Promise<TransactionInstruction[]> {
+  const txBytes = Buffer.from(txData, 'base64');
+
+  let versioned: VersionedTransaction | null = null;
+  try {
+    versioned = VersionedTransaction.deserialize(txBytes);
+  } catch {
+    versioned = null;
+  }
+
+  if (versioned) {
+    const lookups = versioned.message.addressTableLookups;
+    let lookupTableAccounts: AddressLookupTableAccount[] = [];
+
+    if (lookups.length > 0) {
+      if (!options.connection) {
+        throw new Error(
+          'Cannot decode Relay txData with lookup tables without a Connection',
+        );
+      }
+
+      const fetched = await Promise.all(
+        lookups.map((lookup) =>
+          options.connection!.getAddressLookupTable(lookup.accountKey),
+        ),
+      );
+
+      const missing = fetched
+        .map((res, i) => ({
+          value: res.value,
+          accountKey: lookups[i]!.accountKey.toBase58(),
+        }))
+        .filter((x) => !x.value)
+        .map((x) => x.accountKey);
+
+      if (missing.length > 0) {
+        throw new Error(
+          `Missing lookup table accounts for txData decode: ${missing.join(', ')}`,
+        );
+      }
+
+      lookupTableAccounts = fetched
+        .map((res) => res.value)
+        .filter(Boolean) as AddressLookupTableAccount[];
+    }
+
+    const decompiled = TransactionMessage.decompile(
+      versioned.message,
+      lookupTableAccounts.length
+        ? { addressLookupTableAccounts: lookupTableAccounts }
+        : undefined,
+    );
+
+    return decompiled.instructions;
+  }
+
+  const legacy = Transaction.from(txBytes);
+  return legacy.instructions;
+}
+
+export async function resolveRelayQuoteInstructions(
+  quote: RelayQuoteResponse,
+  options: ResolveRelayInstructionsOptions = {},
+): Promise<RelayInstructionBatch[]> {
+  const steps = quote.steps ?? [];
+  const batches: RelayInstructionBatch[] = [];
+
+  for (const [stepIndex, step] of steps.entries()) {
+    const items = step.items ?? [];
+    for (const [itemIndex, item] of items.entries()) {
+      const itemData = item.data;
+      if (!itemData) continue;
+
+      if (itemData.instructions && itemData.instructions.length > 0) {
+        batches.push({
+          stepIndex,
+          itemIndex,
+          stepId: step.id,
+          stepAction: step.action,
+          source: 'instructions',
+          instructions: itemData.instructions.map(relayInstructionToWeb3),
+        });
+        continue;
+      }
+
+      if (itemData.txData) {
+        const instructions = await decodeRelayTxDataToInstructions(
+          itemData.txData,
+          options,
+        );
+        batches.push({
+          stepIndex,
+          itemIndex,
+          stepId: step.id,
+          stepAction: step.action,
+          source: 'txData',
+          instructions,
+        });
+      }
+    }
+  }
+
+  return batches;
+}
+
+function toPublicKey(value: string | PublicKey): PublicKey {
+  return typeof value === 'string' ? new PublicKey(value) : value;
+}
+
+function normalizeRewrites(
+  rewrites: RelayAccountRewrites,
+): Map<string, PublicKey> {
+  if (rewrites instanceof Map) {
+    return new Map(
+      [...rewrites.entries()].map(([from, to]) => [
+        toPublicKey(from).toBase58(),
+        toPublicKey(to),
+      ]),
+    );
+  }
+
+  if (Array.isArray(rewrites)) {
+    return new Map(
+      rewrites.map((x) => [toPublicKey(x.from).toBase58(), toPublicKey(x.to)]),
+    );
+  }
+
+  return new Map(
+    Object.entries(rewrites).map(([from, to]) => [
+      toPublicKey(from).toBase58(),
+      toPublicKey(to),
+    ]),
+  );
+}
+
+export function rewriteTransactionInstructions(
+  instructions: TransactionInstruction[],
+  rewrites: RelayAccountRewrites,
+): { instructions: TransactionInstruction[]; replacements: number } {
+  const rewriteMap = normalizeRewrites(rewrites);
+  let replacements = 0;
+
+  const rewritten = instructions.map((ix) => {
+    const replacementProgramId = rewriteMap.get(ix.programId.toBase58());
+    if (replacementProgramId) replacements += 1;
+
+    const keys = ix.keys.map((key) => {
+      const replacement = rewriteMap.get(key.pubkey.toBase58());
+      if (!replacement) {
+        return {
+          pubkey: key.pubkey,
+          isSigner: key.isSigner,
+          isWritable: key.isWritable,
+        };
+      }
+
+      replacements += 1;
+      return {
+        pubkey: replacement,
+        isSigner: key.isSigner,
+        isWritable: key.isWritable,
+      };
+    });
+
+    return new TransactionInstruction({
+      programId: replacementProgramId ?? ix.programId,
+      keys,
+      data: Buffer.from(ix.data),
+    });
+  });
+
+  return { instructions: rewritten, replacements };
+}
+
+export function buildUserAndAtaRewrites(args: {
+  fromUser: string | PublicKey;
+  toUser: string | PublicKey;
+  mints?: Array<string | PublicKey>;
+}): RelayAccountRewrite[] {
+  const fromUser = toPublicKey(args.fromUser);
+  const toUser = toPublicKey(args.toUser);
+  const rewrites: RelayAccountRewrite[] = [{ from: fromUser, to: toUser }];
+
+  for (const mintInput of args.mints ?? []) {
+    const mint = toPublicKey(mintInput);
+    const fromAta = getAssociatedTokenAddressSync(
+      mint,
+      fromUser,
+      !PublicKey.isOnCurve(fromUser.toBytes()),
+    );
+    const toAta = getAssociatedTokenAddressSync(
+      mint,
+      toUser,
+      !PublicKey.isOnCurve(toUser.toBytes()),
+    );
+    rewrites.push({ from: fromAta, to: toAta });
+  }
+
+  return rewrites;
+}
+
+export async function prepareRelayRouteForSwig(args: {
+  quote: RelayQuoteResponse;
+  swig: Swig;
+  roleId: number;
+  rewrites: RelayAccountRewrites;
+  resolveOptions?: ResolveRelayInstructionsOptions;
+}): Promise<PrepareRelayRouteForSwigResult> {
+  const rawBatches = await resolveRelayQuoteInstructions(
+    args.quote,
+    args.resolveOptions,
+  );
+
+  const prepared: PreparedSwigRelayBatch[] = [];
+  let totalReplacements = 0;
+
+  for (const batch of rawBatches) {
+    const rewritten = rewriteTransactionInstructions(
+      batch.instructions,
+      args.rewrites,
+    );
+    const swigSignInstructions = await getSignInstructions(
+      args.swig,
+      args.roleId,
+      rewritten.instructions,
+    );
+
+    totalReplacements += rewritten.replacements;
+    prepared.push({
+      stepIndex: batch.stepIndex,
+      itemIndex: batch.itemIndex,
+      stepId: batch.stepId,
+      stepAction: batch.stepAction,
+      source: batch.source,
+      originalInstructions: batch.instructions,
+      rewrittenInstructions: rewritten.instructions,
+      swigSignInstructions,
+      replacements: rewritten.replacements,
+    });
+  }
+
+  return {
+    batches: prepared,
+    totalReplacements,
+  };
+}

--- a/scripts/relay-generic-route-runner.ts
+++ b/scripts/relay-generic-route-runner.ts
@@ -1,0 +1,181 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  Actions,
+  createEd25519AuthorityInfo,
+  fetchSwig,
+  findSwigPda,
+  getCreateSwigInstruction,
+  getSwigWalletAddress,
+} from '@swig-wallet/classic';
+import { randomBytes } from 'node:crypto';
+import {
+  buildUserAndAtaRewrites,
+  fetchRelayQuote,
+  getBatchSignerPubkeys,
+  prepareRelayRouteForSwig,
+  resolveRelayQuoteInstructions,
+  type RelayQuoteRequest,
+} from './lib/relay-swig-adapter';
+
+const SURFPOOL_RPC = process.env.SURFPOOL_RPC ?? 'http://127.0.0.1:18999';
+
+function envRequired(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function parseOptionalMint(value: string): PublicKey | null {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+function buildRelayRequest(user: PublicKey): RelayQuoteRequest {
+  return {
+    user: user.toBase58(),
+    originChainId: Number(envRequired('RELAY_ORIGIN_CHAIN_ID')),
+    destinationChainId: Number(envRequired('RELAY_DESTINATION_CHAIN_ID')),
+    originCurrency: envRequired('RELAY_ORIGIN_CURRENCY'),
+    destinationCurrency: envRequired('RELAY_DESTINATION_CURRENCY'),
+    amount: envRequired('RELAY_AMOUNT'),
+    tradeType:
+      (process.env.RELAY_TRADE_TYPE as 'EXACT_INPUT' | 'EXACT_OUTPUT') ??
+      'EXACT_INPUT',
+    recipient:
+      process.env.RELAY_RECIPIENT ??
+      '0x000000000000000000000000000000000000dEaD',
+  };
+}
+
+function getRewriteMints(request: RelayQuoteRequest): PublicKey[] {
+  const fromEnv = process.env.RELAY_REWRITE_MINTS;
+  if (fromEnv) {
+    return fromEnv
+      .split(',')
+      .map((x) => x.trim())
+      .filter(Boolean)
+      .map((x) => new PublicKey(x));
+  }
+
+  const inferred = parseOptionalMint(request.originCurrency);
+  if (!inferred) return [];
+
+  // Native SOL routes do not use ATA source accounts.
+  if (inferred.equals(SystemProgram.programId)) {
+    return [];
+  }
+
+  return inferred ? [inferred] : [];
+}
+
+async function buildTx(
+  connection: Connection,
+  feePayer: PublicKey,
+  instructions: TransactionInstruction[],
+): Promise<Transaction> {
+  const tx = new Transaction().add(...instructions);
+  tx.feePayer = feePayer;
+  tx.recentBlockhash = (
+    await connection.getLatestBlockhash('confirmed')
+  ).blockhash;
+  return tx;
+}
+
+async function main() {
+  const connection = new Connection(SURFPOOL_RPC, 'confirmed');
+  const authority = Keypair.generate();
+  const quoteUser = Keypair.generate();
+
+  const airdropSig = await connection.requestAirdrop(
+    authority.publicKey,
+    2_000_000_000,
+  );
+  await connection.confirmTransaction(airdropSig, 'confirmed');
+
+  const swigId = randomBytes(32);
+  const swigAddress = findSwigPda(swigId);
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: authority.publicKey,
+    id: swigId,
+    actions: Actions.set().all().get(),
+    authorityInfo: createEd25519AuthorityInfo(authority.publicKey),
+  });
+
+  const createSwigTx = await buildTx(connection, authority.publicKey, [
+    createSwigIx,
+  ]);
+  createSwigTx.sign(authority);
+  const createSig = await connection.sendRawTransaction(
+    createSwigTx.serialize(),
+  );
+  await connection.confirmTransaction(createSig, 'confirmed');
+
+  const swig = await fetchSwig(connection as any, swigAddress);
+  const swigWallet = await getSwigWalletAddress(swig);
+  const role = swig.findRolesByEd25519SignerPk(authority.publicKey)[0];
+  if (!role) throw new Error('Authority role not found on swig account');
+
+  const relayRequest = buildRelayRequest(quoteUser.publicKey);
+  const quote = await fetchRelayQuote(relayRequest);
+  const rawBatches = await resolveRelayQuoteInstructions(quote, { connection });
+  const rewriteMints = getRewriteMints(relayRequest);
+
+  const rewrites = buildUserAndAtaRewrites({
+    fromUser: quoteUser.publicKey,
+    toUser: swigWallet,
+    mints: rewriteMints,
+  });
+  const prepared = await prepareRelayRouteForSwig({
+    quote,
+    swig,
+    roleId: role.id,
+    rewrites,
+    resolveOptions: { connection },
+  });
+
+  console.log(`Surfpool RPC: ${SURFPOOL_RPC}`);
+  console.log(`Quote user:   ${quoteUser.publicKey.toBase58()}`);
+  console.log(`Swig wallet:  ${swigWallet.toBase58()}`);
+  console.log(`Route request: ${JSON.stringify(relayRequest)}`);
+  console.log(`Detected batches: ${rawBatches.length}`);
+  console.log(
+    `Rewrite mints: ${rewriteMints.map((x) => x.toBase58()).join(', ') || '(none)'}`,
+  );
+  console.log(`Total replacements: ${prepared.totalReplacements}`);
+
+  for (const batch of rawBatches) {
+    console.log(
+      `- raw batch step=${batch.stepIndex}/${batch.stepId ?? '?'} item=${batch.itemIndex} source=${batch.source} signers=${getBatchSignerPubkeys(batch).join(',')}`,
+    );
+  }
+
+  for (const batch of prepared.batches) {
+    const tx = await buildTx(
+      connection,
+      authority.publicKey,
+      batch.swigSignInstructions,
+    );
+    tx.sign(authority);
+    const sim = await connection.simulateTransaction(tx);
+    console.log(
+      `- swig batch step=${batch.stepIndex}/${batch.stepId ?? '?'} item=${batch.itemIndex} replacements=${batch.replacements} simulationErr=${JSON.stringify(sim.value.err)}`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/relay-quote-mutation-test.ts
+++ b/scripts/relay-quote-mutation-test.ts
@@ -1,0 +1,298 @@
+import {
+  createAssociatedTokenAccountInstruction,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token';
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  Actions,
+  createEd25519AuthorityInfo,
+  fetchSwig,
+  findSwigPda,
+  getCreateSwigInstruction,
+  getSignInstructions,
+  getSwigWalletAddress,
+} from '@swig-wallet/classic';
+import { randomBytes } from 'node:crypto';
+
+const SURFPOOL_RPC = process.env.SURFPOOL_RPC ?? 'http://127.0.0.1:18999';
+
+const RELAY_API = 'https://api.relay.link';
+const RELAY_SOLANA_CHAIN_ID = 792703809;
+const USDT_MINT = new PublicKey('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB');
+const BASE_CHAIN_ID = 8453;
+const BASE_USDT = '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2';
+
+interface RelayInstruction {
+  programId: string;
+  keys: Array<{ pubkey: string; isSigner: boolean; isWritable: boolean }>;
+  data: string;
+}
+
+function toWeb3Instruction(ix: RelayInstruction): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(ix.programId),
+    keys: ix.keys.map((k) => ({
+      pubkey: new PublicKey(k.pubkey),
+      isSigner: k.isSigner,
+      isWritable: k.isWritable,
+    })),
+    data: Buffer.from(ix.data, 'hex'),
+  });
+}
+
+function cloneRelayInstruction(ix: RelayInstruction): RelayInstruction {
+  return {
+    programId: ix.programId,
+    data: ix.data,
+    keys: ix.keys.map((k) => ({ ...k })),
+  };
+}
+
+function replacePubkey(ix: RelayInstruction, from: string, to: string): number {
+  let count = 0;
+  for (const key of ix.keys) {
+    if (key.pubkey === from) {
+      key.pubkey = to;
+      count += 1;
+    }
+  }
+  return count;
+}
+
+async function buildTx(
+  connection: Connection,
+  feePayer: PublicKey,
+  ixs: TransactionInstruction[],
+): Promise<Transaction> {
+  const tx = new Transaction().add(...ixs);
+  tx.feePayer = feePayer;
+  tx.recentBlockhash = (
+    await connection.getLatestBlockhash('confirmed')
+  ).blockhash;
+  return tx;
+}
+
+async function ensureAta(
+  connection: Connection,
+  payer: Keypair,
+  owner: PublicKey,
+  mint: PublicKey,
+): Promise<PublicKey> {
+  const ata = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    !PublicKey.isOnCurve(owner),
+  );
+  const account = await connection.getAccountInfo(ata, 'confirmed');
+  if (account) {
+    return ata;
+  }
+
+  const createAtaIx = createAssociatedTokenAccountInstruction(
+    payer.publicKey,
+    ata,
+    owner,
+    mint,
+  );
+  const tx = await buildTx(connection, payer.publicKey, [createAtaIx]);
+  tx.sign(payer);
+  const sig = await connection.sendRawTransaction(tx.serialize());
+  await connection.confirmTransaction(sig, 'confirmed');
+  return ata;
+}
+
+async function callRelayQuote(user: string): Promise<RelayInstruction[]> {
+  const quoteBody = {
+    user,
+    originChainId: RELAY_SOLANA_CHAIN_ID,
+    destinationChainId: BASE_CHAIN_ID,
+    originCurrency: USDT_MINT.toBase58(),
+    destinationCurrency: BASE_USDT,
+    amount: '1000000',
+    tradeType: 'EXACT_INPUT',
+    recipient: '0x000000000000000000000000000000000000dEaD',
+  };
+
+  const response = await fetch(`${RELAY_API}/quote/v2`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(quoteBody),
+  });
+
+  const data: any = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `Relay quote failed for user=${user}: ${JSON.stringify(data)}`,
+    );
+  }
+
+  const instructions: RelayInstruction[] = (data.steps ?? [])
+    .flatMap((step: any) => step.items ?? [])
+    .flatMap((item: any) => item.data?.instructions ?? []);
+
+  if (!instructions.length) {
+    throw new Error('Relay quote returned no raw instructions');
+  }
+
+  return instructions;
+}
+
+async function simulate(
+  connection: Connection,
+  tx: Transaction,
+  label: string,
+): Promise<void> {
+  try {
+    tx.serialize();
+  } catch (error: any) {
+    console.log(`${label}: serialize FAILED -> ${error.message}`);
+    return;
+  }
+
+  const sim = await connection.simulateTransaction(tx);
+  console.log(`${label}: simulation err -> ${JSON.stringify(sim.value.err)}`);
+  if (sim.value.logs?.length) {
+    for (const line of sim.value.logs.slice(0, 10)) {
+      console.log(`  ${line}`);
+    }
+  }
+}
+
+async function main() {
+  const connection = new Connection(SURFPOOL_RPC, 'confirmed');
+
+  const authority = Keypair.generate();
+  const quoteUser = Keypair.generate();
+
+  for (const kp of [authority, quoteUser]) {
+    const sig = await connection.requestAirdrop(kp.publicKey, 2_000_000_000);
+    await connection.confirmTransaction(sig, 'confirmed');
+  }
+
+  const swigId = randomBytes(32);
+  const swigAddress = findSwigPda(swigId);
+
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: authority.publicKey,
+    id: swigId,
+    actions: Actions.set().all().get(),
+    authorityInfo: createEd25519AuthorityInfo(authority.publicKey),
+  });
+
+  const createTx = await buildTx(connection, authority.publicKey, [
+    createSwigIx,
+  ]);
+  createTx.sign(authority);
+  const createSig = await connection.sendRawTransaction(createTx.serialize());
+  await connection.confirmTransaction(createSig, 'confirmed');
+
+  const swig = await fetchSwig(connection as any, swigAddress);
+  const swigWallet = await getSwigWalletAddress(swig);
+  const role = swig.findRolesByEd25519SignerPk(authority.publicKey)[0];
+  if (!role) throw new Error('Could not find authority role on swig');
+
+  console.log(`Surfpool:         ${SURFPOOL_RPC}`);
+  console.log(`Quote user:       ${quoteUser.publicKey.toBase58()} (on-curve)`);
+  console.log(
+    `Swig wallet:      ${swigWallet.toBase58()} (on-curve=${PublicKey.isOnCurve(swigWallet.toBytes())})`,
+  );
+
+  const relayIxs = await callRelayQuote(quoteUser.publicKey.toBase58());
+  const relayIx = cloneRelayInstruction(relayIxs[0]!);
+
+  const quoteUserAta = getAssociatedTokenAddressSync(
+    USDT_MINT,
+    quoteUser.publicKey,
+    false,
+  );
+  const swigAta = getAssociatedTokenAddressSync(USDT_MINT, swigWallet, true);
+
+  await ensureAta(connection, authority, quoteUser.publicKey, USDT_MINT);
+  await ensureAta(connection, authority, swigWallet, USDT_MINT);
+
+  console.log(`Quote user ATA:   ${quoteUserAta.toBase58()}`);
+  console.log(`Swig wallet ATA:  ${swigAta.toBase58()}`);
+
+  const userSignerIndexes = relayIx.keys
+    .map((k, i) => ({ k, i }))
+    .filter(({ k }) => k.pubkey === quoteUser.publicKey.toBase58())
+    .map(({ i }) => i);
+
+  const sourceAtaIndexes = relayIx.keys
+    .map((k, i) => ({ k, i }))
+    .filter(({ k }) => k.pubkey === quoteUserAta.toBase58())
+    .map(({ i }) => i);
+
+  console.log(
+    `User pubkey indexes in quote ix: ${JSON.stringify(userSignerIndexes)}`,
+  );
+  console.log(
+    `Source ATA indexes in quote ix:  ${JSON.stringify(sourceAtaIndexes)}`,
+  );
+
+  const originalTx = await buildTx(connection, quoteUser.publicKey, [
+    toWeb3Instruction(relayIx),
+  ]);
+  originalTx.sign(quoteUser);
+  await simulate(
+    connection,
+    originalTx,
+    'Original quote (direct, quote user signer)',
+  );
+
+  const swapUserOnly = cloneRelayInstruction(relayIx);
+  replacePubkey(
+    swapUserOnly,
+    quoteUser.publicKey.toBase58(),
+    swigWallet.toBase58(),
+  );
+
+  const wrappedUserOnly = await getSignInstructions(swig, role.id, [
+    toWeb3Instruction(swapUserOnly),
+  ]);
+  const wrappedUserOnlyTx = await buildTx(
+    connection,
+    authority.publicKey,
+    wrappedUserOnly,
+  );
+  wrappedUserOnlyTx.sign(authority);
+  await simulate(
+    connection,
+    wrappedUserOnlyTx,
+    'Mutated quote A (swap user only, wrapped with swig)',
+  );
+
+  const swapUserAndAta = cloneRelayInstruction(relayIx);
+  replacePubkey(
+    swapUserAndAta,
+    quoteUser.publicKey.toBase58(),
+    swigWallet.toBase58(),
+  );
+  replacePubkey(swapUserAndAta, quoteUserAta.toBase58(), swigAta.toBase58());
+
+  const wrappedUserAndAta = await getSignInstructions(swig, role.id, [
+    toWeb3Instruction(swapUserAndAta),
+  ]);
+  const wrappedUserAndAtaTx = await buildTx(
+    connection,
+    authority.publicKey,
+    wrappedUserAndAta,
+  );
+  wrappedUserAndAtaTx.sign(authority);
+  await simulate(
+    connection,
+    wrappedUserAndAtaTx,
+    'Mutated quote B (swap user + source ATA, wrapped with swig)',
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/relay-surfpool-repro.ts
+++ b/scripts/relay-surfpool-repro.ts
@@ -1,0 +1,303 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  Actions,
+  createEd25519AuthorityInfo,
+  fetchSwig,
+  findSwigPda,
+  getCreateSwigInstruction,
+  getSignInstructions,
+  getSwigWalletAddress,
+} from '@swig-wallet/classic';
+import { randomBytes } from 'node:crypto';
+
+const SURFPOOL_RPC = process.env.SURFPOOL_RPC ?? 'http://127.0.0.1:8899';
+
+const RELAY_API = 'https://api.relay.link';
+const RELAY_SOLANA_CHAIN_ID = 792703809;
+const USDT_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+const SOL_MINT = '11111111111111111111111111111111';
+const BASE_CHAIN_ID = 8453;
+const BASE_USDT = '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2';
+const SWIG_PROGRAM_ID = new PublicKey(
+  'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB',
+);
+
+interface RelayQuoteBody {
+  user: string;
+  originCurrency: string;
+  amount: string;
+}
+
+type RelayQuoteResult =
+  | { ok: true; status: number; data: any }
+  | { ok: false; status: number; data: any };
+
+interface RelayInstruction {
+  programId: string;
+  keys: Array<{ pubkey: string; isSigner: boolean; isWritable: boolean }>;
+  data: string;
+}
+
+async function buildTx(
+  connection: Connection,
+  feePayer: PublicKey,
+  instructions: TransactionInstruction[],
+): Promise<Transaction> {
+  const tx = new Transaction().add(...instructions);
+  tx.feePayer = feePayer;
+  tx.recentBlockhash = (
+    await connection.getLatestBlockhash('confirmed')
+  ).blockhash;
+  return tx;
+}
+
+function instructionSigners(instructions: RelayInstruction[]): string[] {
+  return [
+    ...new Set(
+      instructions.flatMap((ix) =>
+        ix.keys.filter((k) => k.isSigner).map((k) => k.pubkey),
+      ),
+    ),
+  ];
+}
+
+function toWeb3Instruction(ix: RelayInstruction): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(ix.programId),
+    keys: ix.keys.map((key) => ({
+      pubkey: new PublicKey(key.pubkey),
+      isSigner: key.isSigner,
+      isWritable: key.isWritable,
+    })),
+    data: Buffer.from(ix.data, 'hex'),
+  });
+}
+
+async function callRelayQuote(body: RelayQuoteBody): Promise<RelayQuoteResult> {
+  const quoteBody = {
+    user: body.user,
+    originChainId: RELAY_SOLANA_CHAIN_ID,
+    destinationChainId: BASE_CHAIN_ID,
+    originCurrency: body.originCurrency,
+    destinationCurrency: BASE_USDT,
+    amount: body.amount,
+    tradeType: 'EXACT_INPUT',
+    recipient: '0x000000000000000000000000000000000000dEaD',
+  };
+
+  const response = await fetch(`${RELAY_API}/quote/v2`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(quoteBody),
+  });
+
+  const data: any = await response.json();
+  return { ok: response.ok, status: response.status, data };
+}
+
+function extractInstructions(data: any): RelayInstruction[] {
+  return (data?.steps ?? [])
+    .flatMap((step: any) => step.items ?? [])
+    .flatMap((item: any) => item.data?.instructions ?? []);
+}
+
+function printQuoteResult(label: string, result: RelayQuoteResult): void {
+  if (result.ok) {
+    const ixs = extractInstructions(result.data);
+    if (!ixs.length) {
+      console.log(`${label}: OK (no raw instructions returned)`);
+      return;
+    }
+    console.log(
+      `${label}: OK (${ixs.length} ix, signers: ${instructionSigners(ixs).join(', ')})`,
+    );
+    return;
+  }
+
+  const errorCode = result.data?.errorCode ?? 'UNKNOWN';
+  const message = result.data?.message ?? 'Unknown error';
+  console.log(`${label}: FAILED (${result.status} ${errorCode} - ${message})`);
+}
+
+async function main() {
+  const connection = new Connection(SURFPOOL_RPC, 'confirmed');
+  const authority = Keypair.generate();
+
+  console.log(`Surfpool RPC: ${SURFPOOL_RPC}`);
+  console.log(`Authority:    ${authority.publicKey.toBase58()}`);
+
+  const airdropSig = await connection.requestAirdrop(
+    authority.publicKey,
+    2_000_000_000,
+  );
+  await connection.confirmTransaction(airdropSig, 'confirmed');
+
+  const swigId = randomBytes(32);
+  const swigAddress = findSwigPda(swigId);
+
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: authority.publicKey,
+    id: swigId,
+    actions: Actions.set().all().get(),
+    authorityInfo: createEd25519AuthorityInfo(authority.publicKey),
+  });
+
+  const createSwigTx = await buildTx(connection, authority.publicKey, [
+    createSwigIx,
+  ]);
+  createSwigTx.sign(authority);
+  const createSig = await connection.sendRawTransaction(
+    createSwigTx.serialize(),
+  );
+  await connection.confirmTransaction(createSig, 'confirmed');
+
+  const swig = await fetchSwig(connection as any, swigAddress);
+  const swigWalletAddress = await getSwigWalletAddress(swig);
+
+  const fundSwigSig = await connection.requestAirdrop(
+    swigWalletAddress,
+    1_000_000_000,
+  );
+  await connection.confirmTransaction(fundSwigSig, 'confirmed');
+
+  console.log(`Swig PDA:      ${swigAddress.toBase58()}`);
+  console.log(`Swig wallet:   ${swigWalletAddress.toBase58()}`);
+  console.log(
+    `Swig wallet on curve: ${PublicKey.isOnCurve(swigWalletAddress.toBytes())}`,
+  );
+  console.log();
+
+  console.log('USDT quote behavior (mainnet route lookup):');
+  const randomOnCurveUser = Keypair.generate().publicKey;
+  const randomOffCurveUser = PublicKey.findProgramAddressSync(
+    [Buffer.from('relay-offcurve-check'), authority.publicKey.toBuffer()],
+    SWIG_PROGRAM_ID,
+  )[0];
+
+  const usdtRandomOnCurveQuote = await callRelayQuote({
+    user: randomOnCurveUser.toBase58(),
+    originCurrency: USDT_MINT,
+    amount: '1000000',
+  });
+  const usdtRandomOffCurveQuote = await callRelayQuote({
+    user: randomOffCurveUser.toBase58(),
+    originCurrency: USDT_MINT,
+    amount: '1000000',
+  });
+  const usdtAuthorityQuote = await callRelayQuote({
+    user: authority.publicKey.toBase58(),
+    originCurrency: USDT_MINT,
+    amount: '1000000',
+  });
+  const usdtSwigQuote = await callRelayQuote({
+    user: swigWalletAddress.toBase58(),
+    originCurrency: USDT_MINT,
+    amount: '1000000',
+  });
+  printQuoteResult('- random on-curve user', usdtRandomOnCurveQuote);
+  printQuoteResult('- random off-curve user', usdtRandomOffCurveQuote);
+  printQuoteResult('- user = authority', usdtAuthorityQuote);
+  printQuoteResult('- user = swig wallet', usdtSwigQuote);
+  console.log();
+
+  console.log(
+    'SOL quote behavior (same Relay program, off-curve user accepted):',
+  );
+  const solSwigQuote = await callRelayQuote({
+    user: swigWalletAddress.toBase58(),
+    originCurrency: SOL_MINT,
+    amount: '1000000',
+  });
+  printQuoteResult('- user = swig wallet', solSwigQuote);
+  console.log();
+
+  if (!solSwigQuote.ok) {
+    console.log('Cannot continue execution tests because SOL quote failed.');
+    return;
+  }
+
+  const relayIxs = extractInstructions(solSwigQuote.data);
+  if (!relayIxs.length) {
+    console.log(
+      'SOL quote returned no raw instructions; cannot test execution.',
+    );
+    return;
+  }
+
+  const directTx = await buildTx(
+    connection,
+    authority.publicKey,
+    relayIxs.map(toWeb3Instruction),
+  );
+  directTx.sign(authority);
+
+  try {
+    directTx.serialize();
+    console.log(
+      'Direct submit (swig wallet user): serialize unexpectedly succeeded',
+    );
+  } catch (error: any) {
+    console.log(
+      `Direct submit (swig wallet user): serialize failed as expected -> ${error.message}`,
+    );
+  }
+
+  const authorityRole = swig.findRolesByEd25519SignerPk(authority.publicKey)[0];
+  if (!authorityRole) {
+    throw new Error('Authority role not found on newly created swig account');
+  }
+
+  const wrappedIxs = await getSignInstructions(
+    swig,
+    authorityRole.id,
+    relayIxs.map(toWeb3Instruction),
+  );
+
+  const wrappedTx = await buildTx(connection, authority.publicKey, wrappedIxs);
+  wrappedTx.sign(authority);
+
+  try {
+    wrappedTx.serialize();
+    console.log('Wrapped submit (swig getSignInstructions): serialize OK');
+  } catch (error: any) {
+    console.log(
+      `Wrapped submit (swig getSignInstructions): serialize FAILED -> ${error.message}`,
+    );
+  }
+
+  const simulation = await connection.simulateTransaction(wrappedTx);
+
+  console.log(
+    `Wrapped submit (swig getSignInstructions): simulation err -> ${JSON.stringify(simulation.value.err)}`,
+  );
+  if (simulation.value.logs?.length) {
+    console.log('Simulation logs (first 8):');
+    for (const line of simulation.value.logs.slice(0, 8)) {
+      console.log(`  ${line}`);
+    }
+  }
+
+  if (simulation.value.err === null) {
+    try {
+      const sig = await connection.sendRawTransaction(wrappedTx.serialize());
+      await connection.confirmTransaction(sig, 'confirmed');
+      console.log(`Wrapped submit (swig getSignInstructions): sent tx ${sig}`);
+    } catch (error: any) {
+      console.log(
+        `Wrapped submit (swig getSignInstructions): send failed -> ${error.message}`,
+      );
+    }
+  }
+  console.log('Done.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/relay-usdc-cheatcode-validation.ts
+++ b/scripts/relay-usdc-cheatcode-validation.ts
@@ -1,0 +1,354 @@
+import {
+  createAssociatedTokenAccountInstruction,
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  Actions,
+  createEd25519AuthorityInfo,
+  fetchSwig,
+  findSwigPda,
+  getCreateSwigInstruction,
+  getSwigWalletAddress,
+} from '@swig-wallet/classic';
+import { randomBytes } from 'node:crypto';
+import {
+  buildUserAndAtaRewrites,
+  fetchRelayQuote,
+  prepareRelayRouteForSwig,
+  resolveRelayQuoteInstructions,
+  type RelayQuoteRequest,
+} from './lib/relay-swig-adapter';
+
+const SURFPOOL_RPC = process.env.SURFPOOL_RPC ?? 'http://127.0.0.1:18999';
+
+const DEFAULT_ORIGIN_CHAIN_ID = 792703809;
+const DEFAULT_DESTINATION_CHAIN_ID = 8453;
+const DEFAULT_ORIGIN_CURRENCY = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'; // Solana USDC
+const DEFAULT_DESTINATION_CURRENCY =
+  '0x833589fCD6eDb6E08f4c7c32D4f71b54bdA02913'; // Base USDC
+const DEFAULT_AMOUNT = '1000000'; // 1 USDC
+const INITIAL_FUNDED_AMOUNT = 4_000_000; // 4 USDC
+
+interface RpcResponse<T = unknown> {
+  jsonrpc: string;
+  id: number;
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+async function buildTx(
+  connection: Connection,
+  feePayer: PublicKey,
+  instructions: TransactionInstruction[],
+): Promise<Transaction> {
+  const tx = new Transaction().add(...instructions);
+  tx.feePayer = feePayer;
+  tx.recentBlockhash = (
+    await connection.getLatestBlockhash('confirmed')
+  ).blockhash;
+  return tx;
+}
+
+async function sendAndConfirm(
+  connection: Connection,
+  tx: Transaction,
+  label: string,
+): Promise<string> {
+  const sim = await connection.simulateTransaction(tx);
+  if (sim.value.err) {
+    throw new Error(
+      `${label} simulation failed: ${JSON.stringify(sim.value.err)}\n${(sim.value.logs ?? []).join('\n')}`,
+    );
+  }
+
+  const sig = await connection.sendRawTransaction(tx.serialize());
+  await connection.confirmTransaction(sig, 'confirmed');
+  return sig;
+}
+
+async function ensureAta(
+  connection: Connection,
+  payer: Keypair,
+  owner: PublicKey,
+  mint: PublicKey,
+): Promise<PublicKey> {
+  const ata = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    !PublicKey.isOnCurve(owner.toBytes()),
+  );
+  const existing = await connection.getAccountInfo(ata, 'confirmed');
+  if (existing) return ata;
+
+  const ix = createAssociatedTokenAccountInstruction(
+    payer.publicKey,
+    ata,
+    owner,
+    mint,
+  );
+  const tx = await buildTx(connection, payer.publicKey, [ix]);
+  tx.sign(payer);
+  await sendAndConfirm(connection, tx, 'create ATA');
+  return ata;
+}
+
+async function surfnetSetTokenAccount(args: {
+  rpcUrl: string;
+  owner: PublicKey;
+  mint: PublicKey;
+  amount: number;
+}): Promise<void> {
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'surfnet_setTokenAccount',
+    params: [
+      args.owner.toBase58(),
+      args.mint.toBase58(),
+      {
+        amount: args.amount,
+        state: 'initialized',
+      },
+      TOKEN_PROGRAM_ID.toBase58(),
+    ],
+  };
+
+  const response = await fetch(args.rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const json: RpcResponse = await response.json();
+  if (!response.ok || json.error) {
+    throw new Error(
+      `surfnet_setTokenAccount failed for owner=${args.owner.toBase58()}: ${JSON.stringify(json.error ?? json)}`,
+    );
+  }
+}
+
+async function getTokenBalance(
+  connection: Connection,
+  ata: PublicKey,
+): Promise<number> {
+  const bal = await connection.getTokenAccountBalance(ata, 'confirmed');
+  return Number(bal.value.amount);
+}
+
+function getRelayRequestForUser(user: PublicKey): RelayQuoteRequest {
+  return {
+    user: user.toBase58(),
+    originChainId: Number(
+      process.env.RELAY_ORIGIN_CHAIN_ID ?? DEFAULT_ORIGIN_CHAIN_ID,
+    ),
+    destinationChainId: Number(
+      process.env.RELAY_DESTINATION_CHAIN_ID ?? DEFAULT_DESTINATION_CHAIN_ID,
+    ),
+    originCurrency:
+      process.env.RELAY_ORIGIN_CURRENCY ?? DEFAULT_ORIGIN_CURRENCY,
+    destinationCurrency:
+      process.env.RELAY_DESTINATION_CURRENCY ?? DEFAULT_DESTINATION_CURRENCY,
+    amount: process.env.RELAY_AMOUNT ?? DEFAULT_AMOUNT,
+    tradeType: 'EXACT_INPUT',
+    recipient:
+      process.env.RELAY_RECIPIENT ??
+      '0x000000000000000000000000000000000000dEaD',
+  };
+}
+
+function parseOriginMint(originCurrency: string): PublicKey {
+  try {
+    return new PublicKey(originCurrency);
+  } catch {
+    throw new Error(
+      `This validation script requires a Solana SPL-token origin currency. Got: ${originCurrency}`,
+    );
+  }
+}
+
+async function main() {
+  const connection = new Connection(SURFPOOL_RPC, 'confirmed');
+
+  const authority = Keypair.generate();
+  const quoteUser = Keypair.generate();
+
+  for (const kp of [authority, quoteUser]) {
+    const sig = await connection.requestAirdrop(kp.publicKey, 2_000_000_000);
+    await connection.confirmTransaction(sig, 'confirmed');
+  }
+
+  const swigId = randomBytes(32);
+  const swigAddress = findSwigPda(swigId);
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: authority.publicKey,
+    id: swigId,
+    actions: Actions.set().all().get(),
+    authorityInfo: createEd25519AuthorityInfo(authority.publicKey),
+  });
+
+  const createSwigTx = await buildTx(connection, authority.publicKey, [
+    createSwigIx,
+  ]);
+  createSwigTx.sign(authority);
+  await sendAndConfirm(connection, createSwigTx, 'create swig');
+
+  const swig = await fetchSwig(connection as any, swigAddress);
+  const swigWallet = await getSwigWalletAddress(swig);
+  const role = swig.findRolesByEd25519SignerPk(authority.publicKey)[0];
+  if (!role) throw new Error('Could not find authority role on swig');
+
+  const relayRequest = getRelayRequestForUser(quoteUser.publicKey);
+  const originMint = parseOriginMint(relayRequest.originCurrency);
+  const relayAmount = Number(relayRequest.amount);
+
+  const quoteUserAta = await ensureAta(
+    connection,
+    authority,
+    quoteUser.publicKey,
+    originMint,
+  );
+  const swigAta = await ensureAta(
+    connection,
+    authority,
+    swigWallet,
+    originMint,
+  );
+
+  await surfnetSetTokenAccount({
+    rpcUrl: SURFPOOL_RPC,
+    owner: quoteUser.publicKey,
+    mint: originMint,
+    amount: INITIAL_FUNDED_AMOUNT,
+  });
+  await surfnetSetTokenAccount({
+    rpcUrl: SURFPOOL_RPC,
+    owner: swigWallet,
+    mint: originMint,
+    amount: INITIAL_FUNDED_AMOUNT,
+  });
+
+  console.log(`Surfpool RPC:               ${SURFPOOL_RPC}`);
+  console.log(`Relay route origin chain:   ${relayRequest.originChainId}`);
+  console.log(`Relay route destination:    ${relayRequest.destinationChainId}`);
+  console.log(`Relay origin currency:      ${relayRequest.originCurrency}`);
+  console.log(
+    `Relay destination currency: ${relayRequest.destinationCurrency}`,
+  );
+  console.log(`Relay input amount:         ${relayRequest.amount}`);
+  console.log(`Quote user:                 ${quoteUser.publicKey.toBase58()}`);
+  console.log(`Quote user ATA:             ${quoteUserAta.toBase58()}`);
+  console.log(`Swig wallet:                ${swigWallet.toBase58()}`);
+  console.log(`Swig wallet ATA:            ${swigAta.toBase58()}`);
+  console.log(
+    `Funded each ATA with:       ${INITIAL_FUNDED_AMOUNT} base units`,
+  );
+
+  const quote = await fetchRelayQuote(relayRequest);
+  const quoteBatches = await resolveRelayQuoteInstructions(quote, {
+    connection,
+  });
+  if (quoteBatches.length === 0) {
+    throw new Error(
+      'Relay quote did not contain executable Solana instructions',
+    );
+  }
+
+  const baselineBefore = await getTokenBalance(connection, quoteUserAta);
+  const baselineSigs: string[] = [];
+  for (const batch of quoteBatches) {
+    const baselineTx = await buildTx(
+      connection,
+      quoteUser.publicKey,
+      batch.instructions,
+    );
+    baselineTx.sign(quoteUser);
+    baselineSigs.push(
+      await sendAndConfirm(
+        connection,
+        baselineTx,
+        `baseline step=${batch.stepIndex} item=${batch.itemIndex}`,
+      ),
+    );
+  }
+  const baselineAfter = await getTokenBalance(connection, quoteUserAta);
+
+  const rewrites = buildUserAndAtaRewrites({
+    fromUser: quoteUser.publicKey,
+    toUser: swigWallet,
+    mints: [originMint],
+  });
+  const prepared = await prepareRelayRouteForSwig({
+    quote,
+    swig,
+    roleId: role.id,
+    rewrites,
+    resolveOptions: { connection },
+  });
+  if (prepared.batches.length === 0) {
+    throw new Error('Swig preparation produced no instruction batches');
+  }
+
+  const mutatedBefore = await getTokenBalance(connection, swigAta);
+  const mutatedSigs: string[] = [];
+  for (const batch of prepared.batches) {
+    const mutatedTx = await buildTx(
+      connection,
+      authority.publicKey,
+      batch.swigSignInstructions,
+    );
+    mutatedTx.sign(authority);
+    mutatedSigs.push(
+      await sendAndConfirm(
+        connection,
+        mutatedTx,
+        `swig step=${batch.stepIndex} item=${batch.itemIndex}`,
+      ),
+    );
+  }
+  const mutatedAfter = await getTokenBalance(connection, swigAta);
+
+  const baselineSpent = baselineBefore - baselineAfter;
+  const mutatedSpent = mutatedBefore - mutatedAfter;
+  if (baselineSpent <= 0 || mutatedSpent <= 0) {
+    throw new Error(
+      `Expected positive token spend. baselineSpent=${baselineSpent}, mutatedSpent=${mutatedSpent}`,
+    );
+  }
+
+  console.log();
+  console.log('Validation Results:');
+  console.log(`- baseline signatures: ${baselineSigs.join(', ')}`);
+  console.log(
+    `  quote user ATA delta: ${baselineBefore} -> ${baselineAfter} (spent ${baselineSpent})`,
+  );
+  console.log(`- swig signatures:     ${mutatedSigs.join(', ')}`);
+  console.log(
+    `  swig ATA delta:       ${mutatedBefore} -> ${mutatedAfter} (spent ${mutatedSpent})`,
+  );
+  console.log(
+    `- replacements applied: ${prepared.totalReplacements} across ${prepared.batches.length} batch(es)`,
+  );
+  console.log(
+    `- expected per-tx spend target: ${relayAmount} (baseline actual ${baselineSpent}, swig actual ${mutatedSpent})`,
+  );
+  console.log(
+    'Success: modified Relay quote executed via reusable Swig adapter.',
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/run-relay-swig-validation.sh
+++ b/scripts/run-relay-swig-validation.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Relay + Swig End-to-End Validation
+#
+# Starts surfpool, runs the USDC cheatcode validation, prints explorer links,
+# and leaves surfpool running so you can inspect transactions.
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SURFPOOL_HOST="${SURFPOOL_HOST:-127.0.0.1}"
+SURFPOOL_PORT="${SURFPOOL_PORT:-18999}"
+SURFPOOL_WS_PORT="${SURFPOOL_WS_PORT:-$((SURFPOOL_PORT + 1))}"
+SURFPOOL_RPC="http://${SURFPOOL_HOST}:${SURFPOOL_PORT}"
+SURFPOOL_PID=""
+SURFPOOL_LOG="${REPO_DIR}/surfpool.log"
+
+# Explorer base URL - uses Solana Explorer with custom RPC
+EXPLORER_BASE="https://explorer.solana.com/tx"
+
+cleanup() {
+  if [[ -n "$SURFPOOL_PID" ]] && kill -0 "$SURFPOOL_PID" 2>/dev/null; then
+    echo ""
+    echo "=========================================="
+    echo "Surfpool is still running (PID $SURFPOOL_PID)"
+    echo "RPC: $SURFPOOL_RPC"
+    echo "WS:  ws://${SURFPOOL_HOST}:${SURFPOOL_WS_PORT}"
+    echo "Log: $SURFPOOL_LOG"
+    echo ""
+    echo "To stop it:  kill $SURFPOOL_PID"
+    echo "=========================================="
+  fi
+}
+trap cleanup EXIT
+
+echo "=== Relay + Swig E2E Validation ==="
+echo ""
+
+# ---- 1. Check prerequisites ----
+echo "[1/4] Checking prerequisites..."
+
+if ! command -v surfpool &>/dev/null; then
+  echo "ERROR: surfpool not found in PATH. Install it first."
+  exit 1
+fi
+
+if ! command -v bun &>/dev/null; then
+  echo "ERROR: bun not found in PATH. Install it first."
+  exit 1
+fi
+
+if [[ ! -f "$REPO_DIR/scripts/relay-usdc-cheatcode-validation.ts" ]]; then
+  echo "ERROR: Validation script not found at scripts/relay-usdc-cheatcode-validation.ts"
+  exit 1
+fi
+
+echo "  surfpool: $(which surfpool)"
+echo "  bun:      $(which bun)"
+echo ""
+
+# ---- 2. Start surfpool ----
+echo "[2/4] Starting surfpool on $SURFPOOL_RPC ..."
+
+# Kill any existing process on the selected ports
+if lsof -ti:"$SURFPOOL_PORT" &>/dev/null; then
+  echo "  Port $SURFPOOL_PORT already in use. Killing existing process..."
+  lsof -ti:"$SURFPOOL_PORT" | xargs kill -9 2>/dev/null || true
+  sleep 1
+fi
+
+if lsof -ti:"$SURFPOOL_WS_PORT" &>/dev/null; then
+  echo "  WS port $SURFPOOL_WS_PORT already in use. Killing existing process..."
+  lsof -ti:"$SURFPOOL_WS_PORT" | xargs kill -9 2>/dev/null || true
+  sleep 1
+fi
+
+surfpool start \
+  --port "$SURFPOOL_PORT" \
+  --ws-port "$SURFPOOL_WS_PORT" \
+  --host "$SURFPOOL_HOST" \
+  --network mainnet \
+  --no-tui \
+  --no-deploy \
+  --yes \
+  --log-level warn \
+  --daemon \
+  > "$SURFPOOL_LOG" 2>&1 || true
+
+# Wait for surfpool to be ready
+echo "  Waiting for surfpool RPC to respond..."
+MAX_WAIT=30
+WAITED=0
+while ! curl -s "$SURFPOOL_RPC" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' \
+  2>/dev/null | grep -q "result\|ok" 2>/dev/null; do
+  sleep 1
+  WAITED=$((WAITED + 1))
+  if [[ $WAITED -ge $MAX_WAIT ]]; then
+    echo "  ERROR: surfpool did not start within ${MAX_WAIT}s"
+    echo "  Check log: $SURFPOOL_LOG"
+    cat "$SURFPOOL_LOG" 2>/dev/null | tail -20
+    exit 1
+  fi
+done
+
+# Find the surfpool PID
+SURFPOOL_PID=$(lsof -ti:"$SURFPOOL_PORT" 2>/dev/null | head -1 || true)
+echo "  Surfpool ready (PID: ${SURFPOOL_PID:-unknown})"
+echo ""
+
+# ---- 3. Run validation ----
+echo "[3/4] Running Relay + Swig USDC cheatcode validation..."
+echo "      (this fetches a live Relay quote, funds with cheatcodes, and executes)"
+echo ""
+
+# Run the validation and capture output
+cd "$REPO_DIR"
+VALIDATION_OUTPUT=$(SURFPOOL_RPC="$SURFPOOL_RPC" bun scripts/relay-usdc-cheatcode-validation.ts 2>&1) || {
+  echo "ERROR: Validation script failed!"
+  echo ""
+  echo "$VALIDATION_OUTPUT"
+  exit 1
+}
+
+echo "$VALIDATION_OUTPUT"
+echo ""
+
+# ---- 4. Extract signatures and print explorer links ----
+echo "[4/4] Transaction Explorer Links"
+echo "=========================================="
+echo ""
+echo "Use these links to inspect transactions in Solana Explorer"
+echo "with surfpool as the custom RPC endpoint."
+echo ""
+
+# Extract signatures from output
+BASELINE_SIGS=$(echo "$VALIDATION_OUTPUT" | grep "baseline signatures:" | sed 's/.*baseline signatures: //')
+SWIG_SIGS=$(echo "$VALIDATION_OUTPUT" | grep "swig signatures:" | sed 's/.*swig signatures: *//')
+
+# URL-encode the RPC for the explorer custom param
+ENCODED_RPC=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$SURFPOOL_RPC', safe=''))" 2>/dev/null || echo "$SURFPOOL_RPC")
+
+print_explorer_links() {
+  local label="$1"
+  local sigs="$2"
+
+  # Split by comma
+  IFS=',' read -ra SIG_ARRAY <<< "$sigs"
+  for sig in "${SIG_ARRAY[@]}"; do
+    sig=$(echo "$sig" | xargs)  # trim whitespace
+    if [[ -n "$sig" ]]; then
+      echo "  $label:"
+      echo "    Signature: $sig"
+      echo "    Explorer:  ${EXPLORER_BASE}/${sig}?cluster=custom&customUrl=${ENCODED_RPC}"
+      echo ""
+    fi
+  done
+}
+
+print_explorer_links "Baseline (quote user)" "$BASELINE_SIGS"
+print_explorer_links "Swig-wrapped (mutated)" "$SWIG_SIGS"
+
+echo "=========================================="


### PR DESCRIPTION
## Summary
- add reusable Relay-to-Swig adapter utilities for fetching quotes, resolving route instructions, rewriting account metas, and preparing `getSignInstructions` batches
- add reproducible Surfpool scripts to validate Relay routes end-to-end, including a one-command runner that starts Surfpool, executes transactions, and prints custom-RPC Explorer links

## Problem
Relay token routes currently fail quote construction when the Solana `user` is an off-curve address (for example a PDA wallet), returning `NO_SWAP_ROUTES_FOUND`. That prevents directly requesting token-route instructions for Swig wallet PDAs.

## Current workaround in this PR
- request quote data for an on-curve user
- rewrite owner-coupled account metas (user + relevant source ATAs) to the Swig wallet context
- execute via Swig CPI signing (`getSignInstructions`)

This preserves execution for supported routes while Relay off-curve user support is pending.

## Validation
- validated on Surfpool mainnet fork with USDC token flow and cheatcode-funded token accounts
- baseline quote-user transaction and rewritten Swig-wrapped transaction both execute successfully and spend the expected token amount
- added generic and focused repro scripts so this can be rerun/debugged quickly

## Follow-up
Once Relay supports off-curve Solana users for token-route quoting, this rewrite workaround can be removed in favor of direct quote generation for the Swig wallet address.