### PR TITLE
fix: support targeted sub-account withdrawals for all roles

### DIFF
--- a/.changeset/quick-cobras-protect.md
+++ b/.changeset/quick-cobras-protect.md
@@ -1,0 +1,7 @@
+---
+'@swig-wallet/lib': patch
+---
+
+Allow sub-account withdrawals to target a different role via `subAccountRoleId`, so `.all()` authorities can withdraw from another role's sub-account (including expired session-owned sub-accounts) without being forced to derive the acting role's sub-account PDA.
+
+Also adds a regression test covering root `.all()` recovery of another role's sub-account.

--- a/packages/lib/src/swig/index.ts
+++ b/packages/lib/src/swig/index.ts
@@ -466,7 +466,12 @@ export const getWithdrawFromSubAccountInstructionContext = async <
   );
 
   const subAccount = new SolPublicKey(
-    (await findSwigSubAccountPdaRaw(role.swigId, role.id))[0],
+    (
+      await findSwigSubAccountPdaRaw(
+        role.swigId,
+        args.subAccountRoleId ?? role.id,
+      )
+    )[0],
   );
   const swigSystemAddress = await getSwigSystemAddressRaw(swig);
   return 'mint' in args
@@ -683,11 +688,13 @@ export type WithdrawSubAccountArgs<
 > =
   | {
       amount: bigint;
+      subAccountRoleId?: number;
     }
   | {
       amount: bigint;
       mint: T;
       tokenProgram?: T;
+      subAccountRoleId?: number;
     };
 
 export type WithdrawSubAccountCheckedArgs<
@@ -695,6 +702,7 @@ export type WithdrawSubAccountCheckedArgs<
 > =
   | {
       amount: bigint;
+      subAccountRoleId?: number;
       allowBelowRentExempt?: boolean;
       currentBalance?: bigint;
       allowMax?: boolean;
@@ -703,6 +711,7 @@ export type WithdrawSubAccountCheckedArgs<
       amount: bigint;
       mint: T;
       tokenProgram?: T;
+      subAccountRoleId?: number;
     };
 
 export type SwigFetchFn<

--- a/packages/lib/tests/instructions/subAccountWithdrawV1.test.ts
+++ b/packages/lib/tests/instructions/subAccountWithdrawV1.test.ts
@@ -122,6 +122,94 @@ describe('SubAccountWithdrawV1 Instruction', () => {
       expect(finalSwigBalance - initialSwigBalance).toBe(withdrawAmount);
     });
 
+    test('all authority can withdraw another role sub-account with subAccountRoleId', async () => {
+      const svm = getSvm();
+      const [root, subAccountAuth] = getFundedKeys(svm, 2);
+      const swigId = randomBytes(32);
+
+      const [swigAddress] = await findSwigPdaRaw(swigId);
+
+      // Create swig
+      const createIx = await getCreateSwigInstructionContext({
+        authorityInfo: createEd25519AuthorityInfo(root.publicKey),
+        id: swigId,
+        payer: root.publicKey,
+        actions: Actions.set().all().get(),
+      });
+      sendSwigSVMTransaction(svm, createIx, root);
+
+      let swig = fetchSwig(svm, swigAddress);
+      const rootRole = swig.roles[0];
+
+      // Add sub-account authority
+      const addIx = await getAddAuthorityInstructionContext(
+        swig,
+        rootRole.id,
+        createEd25519AuthorityInfo(subAccountAuth.publicKey),
+        Actions.set().subAccount().get(),
+      );
+      sendSwigSVMTransaction(svm, addIx, root);
+
+      swig = fetchSwig(svm, swigAddress);
+      const subAccountRole = swig.findRolesByEd25519SignerPk(
+        subAccountAuth.publicKey,
+      )[0];
+
+      // Create and fund sub-account owned by subAccountRole
+      const createSubAccountIx = await getCreateSubAccountInstructionContext(
+        swig,
+        subAccountRole.id,
+      );
+      sendSwigSVMTransaction(svm, createSubAccountIx, subAccountAuth);
+
+      const [subAccountAddress] = await findSwigSubAccountPdaRaw(
+        subAccountRole.swigId,
+        subAccountRole.id,
+      );
+      svm.airdrop(toPublicKey(subAccountAddress), SOL);
+
+      const withdrawAmount = SOL / 4n;
+
+      // Default SDK flow derives sub-account from acting role (root role here),
+      // so this fails when root's own sub-account is not funded.
+      swig = fetchSwig(svm, swigAddress);
+      const defaultWithdrawIx =
+        await getWithdrawFromSubAccountInstructionContext(swig, rootRole.id, {
+          amount: withdrawAmount,
+        });
+      expect(() =>
+        sendSwigSVMTransaction(svm, defaultWithdrawIx, root),
+      ).toThrow();
+
+      // Explicitly target the sub-account role. This should succeed with .all()
+      // authority.
+      swig = fetchSwig(svm, swigAddress);
+      const swigWalletAddress = await getSwigWalletAddressRaw(swig);
+      const initialSwigBalance = svm.getBalance(
+        toPublicKey(swigWalletAddress),
+      )!;
+      const initialSubAccountBalance = svm.getBalance(
+        toPublicKey(subAccountAddress),
+      )!;
+
+      const rescueWithdrawIx =
+        await getWithdrawFromSubAccountInstructionContext(swig, rootRole.id, {
+          amount: withdrawAmount,
+          subAccountRoleId: subAccountRole.id,
+        });
+      sendSwigSVMTransaction(svm, rescueWithdrawIx, root);
+
+      const finalSubAccountBalance = svm.getBalance(
+        toPublicKey(subAccountAddress),
+      )!;
+      const finalSwigBalance = svm.getBalance(toPublicKey(swigWalletAddress))!;
+
+      expect(initialSubAccountBalance - finalSubAccountBalance).toBe(
+        withdrawAmount,
+      );
+      expect(finalSwigBalance - initialSwigBalance).toBe(withdrawAmount);
+    });
+
     test('withdraws different amounts', async () => {
       const svm = getSvm();
       const [root, subAccountAuth] = getFundedKeys(svm, 2);


### PR DESCRIPTION
## Summary
- add `subAccountRoleId` to sub-account withdrawal args so callers can authenticate as one role (for example, root or `.all()`) while targeting another role's sub-account PDA
- update `getWithdrawFromSubAccountInstructionContext` to derive the withdrawal sub-account from `subAccountRoleId` when provided, preserving current behavior by default
- add a regression test proving default root withdrawal fails on its own sub-account PDA and succeeds when explicitly targeting another role's sub-account, plus a patch changeset for `@swig-wallet/lib`

## Root/.all() usage example
```ts
import { Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
import { getWithdrawFromSubAccountCheckedInstructions } from '@swig-wallet/classic';

// IMPORTANT:
// - `roleId` is the ACTING role (root or another `.all()` role)
// - `subAccountRoleId` is the OWNER role whose sub-account you want to sweep
const withdrawIxs = await getWithdrawFromSubAccountCheckedInstructions(
  swig,
  rootRole.id,
  {
    amount: 100_000_000n,
    currentBalance: BigInt(await connection.getBalance(subAccountAddress)),
    subAccountRoleId: expiredSessionRole.id,
  },
  {
    payer: root.publicKey,
  },
);

await sendAndConfirmTransaction(
  connection,
  new Transaction().add(...withdrawIxs),
  [root],
);
```

## Testing
- `bun test tests/instructions/subAccountWithdrawV1.test.ts`