### PR TITLE
Add Jupiter swap prepare to developer SDK

### DIFF
--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -241,24 +241,12 @@ const swig = new SwigClient({
 
 ## Local transaction smoke
 
-With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/policy in local Postgres, calls the transaction API through the SDK, signs the prepared create and transfer transactions, submits them to the local RPC, and prepares a Jupiter swap transaction:
+With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/policy in local Postgres, calls the transaction API through the SDK, signs the prepared create, transfer, and Jupiter swap transactions, and submits them to the local RPC:
 
 ```bash
 bun --filter '@swig-wallet/developer-sdk' build
 bun --filter '@swig-wallet/developer-sdk' smoke:local
 ```
-
-The script defaults to:
-
-```bash
-SWIG_TRANSACTION_API_URL=http://localhost:8080
-SOLANA_RPC_URL=http://localhost:8899
-DATABASE_URL=postgres://swig:swig@localhost:55432/swig
-SWIG_LOCAL_SMOKE_SWAP=true
-SWIG_LOCAL_SMOKE_SWAP_SUBMIT=false
-```
-
-Set `SWIG_LOCAL_SMOKE_SUBMIT=false` to stop after preparing transactions without submitting them.
 
 ## Source layout
 

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -183,6 +183,33 @@ const transferSubmission = await swig.transactions.sponsor({
 console.log(transferSubmission.signature);
 ```
 
+And swaps use the same wallet handle. The backend prepares a Jupiter swap transaction, the client signs locally, then the signed transaction is sent or sponsored:
+
+```typescript
+const preparedSwap = await wallet.swap({
+  feePayer,
+  requesterPubkey: memberPubkey,
+  inputMint: 'So11111111111111111111111111111111111111112',
+  outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  amount: 10_000n,
+  slippageBps: 100,
+  wrapAndUnwrapSol: true,
+});
+
+const signedSwapTransaction = await signPreparedSwigTransaction(
+  preparedSwap.transaction,
+  signingFn,
+);
+
+const swapSubmission = await swig.transactions.sponsor({
+  intentId: preparedSwap.intentId,
+  transaction: signedSwapTransaction,
+  transactionEncoding: preparedSwap.transactionEncoding,
+});
+
+console.log(swapSubmission.signature);
+```
+
 If the wallet comes from `@swig-wallet/expo-idp-sdk`, use the persisted session directly:
 
 ```typescript
@@ -214,7 +241,7 @@ const swig = new SwigClient({
 
 ## Local transaction smoke
 
-With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/policy in local Postgres, calls the transaction API through the SDK, signs the prepared create and transfer transactions, and submits them to the local RPC:
+With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/policy in local Postgres, calls the transaction API through the SDK, signs the prepared create and transfer transactions, submits them to the local RPC, and prepares a Jupiter swap transaction:
 
 ```bash
 bun --filter '@swig-wallet/developer-sdk' build
@@ -227,6 +254,8 @@ The script defaults to:
 SWIG_TRANSACTION_API_URL=http://localhost:8080
 SOLANA_RPC_URL=http://localhost:8899
 DATABASE_URL=postgres://swig:swig@localhost:55432/swig
+SWIG_LOCAL_SMOKE_SWAP=true
+SWIG_LOCAL_SMOKE_SWAP_SUBMIT=false
 ```
 
 Set `SWIG_LOCAL_SMOKE_SUBMIT=false` to stop after preparing transactions without submitting them.

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -7,6 +7,7 @@ import {
   LAMPORTS_PER_SOL,
   PublicKey,
   Transaction,
+  VersionedTransaction,
 } from '@solana/web3.js';
 import {
   SwigClient,
@@ -19,6 +20,8 @@ const databaseUrl =
   process.env.DATABASE_URL ?? 'postgres://swig:swig@localhost:55432/swig';
 const rpcUrl = process.env.SOLANA_RPC_URL ?? 'http://localhost:8899';
 const shouldSubmit = process.env.SWIG_LOCAL_SMOKE_SUBMIT !== 'false';
+const shouldPrepareSwap = process.env.SWIG_LOCAL_SMOKE_SWAP !== 'false';
+const shouldSubmitSwap = process.env.SWIG_LOCAL_SMOKE_SWAP_SUBMIT === 'true';
 const runId = randomUUID();
 const apiKey = `sk_local_transaction_smoke_${runId}`;
 const userId = `local-smoke-user-${runId}`;
@@ -30,6 +33,8 @@ const policyId = `local-smoke-policy-${runId}`;
 const feePayer = Keypair.generate();
 const requester = Keypair.generate();
 const destination = Keypair.generate();
+const solMint = 'So11111111111111111111111111111111111111112';
+const usdcMint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
 await main();
 
@@ -94,6 +99,31 @@ async function main() {
     const after = await connection.getBalance(destination.publicKey);
     console.log(`transfer signature: ${transferSignature}`);
     console.log(`destination balance delta: ${after - before} lamports`);
+  }
+
+  if (shouldPrepareSwap) {
+    const swapTransaction = await wallet.swap({
+      feePayer: feePayer.publicKey.toBase58(),
+      requesterPubkey: requester.publicKey.toBase58(),
+      inputMint: solMint,
+      outputMint: usdcMint,
+      amount: 10_000,
+      slippageBps: 100,
+      wrapAndUnwrapSol: true,
+    });
+    console.log(`swap intent: ${swapTransaction.intentId}`);
+    console.log(
+      `swap transaction bytes: ${Buffer.from(swapTransaction.transaction, 'base64').length}`,
+    );
+
+    if (shouldSubmitSwap) {
+      const swapSignature = await signAndSendPreparedTransaction(
+        connection,
+        swapTransaction,
+        [feePayer, requester],
+      );
+      console.log(`swap signature: ${swapSignature}`);
+    }
   }
 }
 
@@ -223,13 +253,8 @@ async function signAndSendPreparedTransaction(
     );
   }
 
-  const transaction = Transaction.from(
-    Buffer.from(prepared.transaction, 'base64'),
-  );
-  const message = transaction.compileMessage();
-  const requiredSigners = message.accountKeys
-    .slice(0, message.header.numRequiredSignatures)
-    .map((key) => key.toBase58());
+  const transaction = deserializePreparedTransaction(prepared);
+  const requiredSigners = getRequiredSigners(transaction);
   const availableSigners = signers.filter((signer) =>
     requiredSigners.includes(signer.publicKey.toBase58()),
   );
@@ -246,7 +271,11 @@ async function signAndSendPreparedTransaction(
     );
   }
 
-  transaction.partialSign(...availableSigners);
+  if (transaction instanceof VersionedTransaction) {
+    transaction.sign(availableSigners);
+  } else {
+    transaction.partialSign(...availableSigners);
+  }
 
   const signature = await connection.sendRawTransaction(
     transaction.serialize(),
@@ -256,6 +285,32 @@ async function signAndSendPreparedTransaction(
   );
   await confirmSignature(connection, signature);
   return signature;
+}
+
+function getRequiredSigners(
+  transaction: Transaction | VersionedTransaction,
+): string[] {
+  if (transaction instanceof VersionedTransaction) {
+    return transaction.message.staticAccountKeys
+      .slice(0, transaction.message.header.numRequiredSignatures)
+      .map((key) => key.toBase58());
+  }
+
+  const message = transaction.compileMessage();
+  return message.accountKeys
+    .slice(0, message.header.numRequiredSignatures)
+    .map((key) => key.toBase58());
+}
+
+function deserializePreparedTransaction(
+  prepared: PreparedTransaction,
+): Transaction | VersionedTransaction {
+  const bytes = Buffer.from(prepared.transaction, 'base64');
+  try {
+    return VersionedTransaction.deserialize(bytes);
+  } catch {
+    return Transaction.from(bytes);
+  }
 }
 
 async function airdropIfNeeded(

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -14,14 +14,11 @@ import {
   type PreparedTransaction,
 } from '@swig-wallet/developer-sdk';
 
-const apiBaseUrl =
-  process.env.SWIG_TRANSACTION_API_URL ?? 'http://localhost:8080';
-const databaseUrl =
-  process.env.DATABASE_URL ?? 'postgres://swig:swig@localhost:55432/swig';
-const rpcUrl = process.env.SOLANA_RPC_URL ?? 'http://localhost:8899';
-const shouldSubmit = process.env.SWIG_LOCAL_SMOKE_SUBMIT !== 'false';
-const shouldPrepareSwap = process.env.SWIG_LOCAL_SMOKE_SWAP !== 'false';
-const shouldSubmitSwap = process.env.SWIG_LOCAL_SMOKE_SWAP_SUBMIT === 'true';
+const apiBaseUrl = 'http://localhost:8080';
+const databaseUrl = 'postgres://swig:swig@localhost:55432/swig';
+const rpcUrl = 'http://localhost:8899';
+const swapAmountLamports = 10_000_000;
+const swapSlippageBps = 1_000;
 const runId = randomUUID();
 const apiKey = `sk_local_transaction_smoke_${runId}`;
 const userId = `local-smoke-user-${runId}`;
@@ -66,20 +63,18 @@ async function main() {
   console.log(`swig config: ${wallet.swigConfigAddress}`);
   console.log(`wallet: ${requireWalletAddress(wallet.walletAddress)}`);
 
-  if (shouldSubmit) {
-    const createSignature = await signAndSendPreparedTransaction(
-      connection,
-      createTransaction,
-      [feePayer],
-    );
-    console.log(`create signature: ${createSignature}`);
-    await waitForAccount(connection, new PublicKey(wallet.swigConfigAddress));
-    await airdropIfNeeded(
-      connection,
-      new PublicKey(requireWalletAddress(wallet.walletAddress)),
-      LAMPORTS_PER_SOL / 10,
-    );
-  }
+  const createSignature = await signAndSendPreparedTransaction(
+    connection,
+    createTransaction,
+    [feePayer],
+  );
+  console.log(`create signature: ${createSignature}`);
+  await waitForAccount(connection, new PublicKey(wallet.swigConfigAddress));
+  await airdropIfNeeded(
+    connection,
+    new PublicKey(requireWalletAddress(wallet.walletAddress)),
+    LAMPORTS_PER_SOL / 10,
+  );
 
   const transferTransaction = await wallet.transfer({
     feePayer: feePayer.publicKey.toBase58(),
@@ -89,42 +84,38 @@ async function main() {
   });
   console.log(`transfer intent: ${transferTransaction.intentId}`);
 
-  if (shouldSubmit) {
-    const before = await connection.getBalance(destination.publicKey);
-    const transferSignature = await signAndSendPreparedTransaction(
-      connection,
-      transferTransaction,
-      [feePayer, requester],
-    );
-    const after = await connection.getBalance(destination.publicKey);
-    console.log(`transfer signature: ${transferSignature}`);
-    console.log(`destination balance delta: ${after - before} lamports`);
-  }
+  const before = await connection.getBalance(destination.publicKey);
+  const transferSignature = await signAndSendPreparedTransaction(
+    connection,
+    transferTransaction,
+    [feePayer, requester],
+  );
+  const after = await connection.getBalance(destination.publicKey);
+  console.log(`transfer signature: ${transferSignature}`);
+  console.log(`destination balance delta: ${after - before} lamports`);
 
-  if (shouldPrepareSwap) {
-    const swapTransaction = await wallet.swap({
-      feePayer: feePayer.publicKey.toBase58(),
-      requesterPubkey: requester.publicKey.toBase58(),
-      inputMint: solMint,
-      outputMint: usdcMint,
-      amount: 10_000,
-      slippageBps: 100,
-      wrapAndUnwrapSol: true,
-    });
-    console.log(`swap intent: ${swapTransaction.intentId}`);
-    console.log(
-      `swap transaction bytes: ${Buffer.from(swapTransaction.transaction, 'base64').length}`,
-    );
+  const swapTransaction = await wallet.swap({
+    feePayer: feePayer.publicKey.toBase58(),
+    requesterPubkey: requester.publicKey.toBase58(),
+    inputMint: solMint,
+    outputMint: usdcMint,
+    amount: swapAmountLamports,
+    slippageBps: swapSlippageBps,
+    wrapAndUnwrapSol: true,
+    maxAccounts: 20,
+    mode: 'fast',
+  });
+  console.log(`swap intent: ${swapTransaction.intentId}`);
+  console.log(
+    `swap transaction bytes: ${Buffer.from(swapTransaction.transaction, 'base64').length}`,
+  );
 
-    if (shouldSubmitSwap) {
-      const swapSignature = await signAndSendPreparedTransaction(
-        connection,
-        swapTransaction,
-        [feePayer, requester],
-      );
-      console.log(`swap signature: ${swapSignature}`);
-    }
-  }
+  const swapSignature = await signAndSendPreparedTransaction(
+    connection,
+    swapTransaction,
+    [feePayer, requester],
+  );
+  console.log(`swap signature: ${swapSignature}`);
 }
 
 function seedLocalFixture() {

--- a/packages/developer-sdk/src/server/fetch.test.ts
+++ b/packages/developer-sdk/src/server/fetch.test.ts
@@ -79,7 +79,7 @@ describe('createSwigFetchHandler', () => {
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/transfer/sol',
+      url: 'http://localhost:8080/transaction/transfer/sol',
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',

--- a/packages/developer-sdk/src/server/nest.test.ts
+++ b/packages/developer-sdk/src/server/nest.test.ts
@@ -107,7 +107,7 @@ describe('createSwigNestHandler', () => {
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/transfer/sol',
+      url: 'http://localhost:8080/transaction/transfer/sol',
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -43,10 +43,20 @@ export interface TransferTokenArgs extends BaseTransferArgs {
 export type TransferArgs = TransferSolArgs | TransferTokenArgs;
 
 export interface SwapArgs {
+  feePayer: string;
+  requesterPubkey?: string;
   inputMint: string;
   outputMint: string;
   amount: Amount;
   slippageBps?: number;
+  destinationTokenAccount?: string;
+  nativeDestinationAccount?: string;
+  wrapAndUnwrapSol?: boolean;
+  tipAmountLamports?: Amount;
+  computeUnitPricePercentile?: string;
+  maxAccounts?: number;
+  mode?: string;
+  blockhashSlotsToExpiry?: number;
   network?: Network;
   idempotencyKey?: string;
 }

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test';
 
 import { SwigClient } from '../client.js';
 import { WalletsClient } from './client.js';
-import { transferSolRequest, transferTokenRequest } from './requests.js';
+import {
+  swapRequest,
+  transferSolRequest,
+  transferTokenRequest,
+} from './requests.js';
 
 type CapturedRequest = {
   url: string;
@@ -131,6 +135,57 @@ describe('WalletsClient', () => {
     });
   });
 
+  test('builds Jupiter swap requests for the transaction API', () => {
+    const wallets = new WalletsClient(
+      { post: async () => ({}) } as never,
+      'devnet',
+    );
+    const wallet = wallets.use({
+      swigId: 'swig_123',
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterPubkey: 'requester_123',
+    });
+
+    expect(
+      swapRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+          inputMint: 'input_mint_123',
+          outputMint: 'output_mint_123',
+          amount: 1_000n,
+          slippageBps: 75,
+          tipAmountLamports: '5000',
+          computeUnitPricePercentile: 'high',
+          maxAccounts: 32,
+          mode: 'fast',
+          blockhashSlotsToExpiry: 10,
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigId: 'swig_123',
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterPubkey: 'requester_123',
+      inputMint: 'input_mint_123',
+      outputMint: 'output_mint_123',
+      amount: '1000',
+      slippageBps: 75,
+      destinationTokenAccount: undefined,
+      nativeDestinationAccount: undefined,
+      wrapAndUnwrapSol: undefined,
+      tipAmountLamports: '5000',
+      computeUnitPricePercentile: 'high',
+      maxAccounts: 32,
+      mode: 'fast',
+      blockhashSlotsToExpiry: 10,
+    });
+  });
+
   test('prepares wallet creation through the local transaction endpoint', async () => {
     const calls: CapturedRequest[] = [];
     const swig = new SwigClient({
@@ -162,7 +217,7 @@ describe('WalletsClient', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/wallet/create',
+      url: 'http://localhost:8080/transaction/wallet/create',
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',
@@ -218,7 +273,7 @@ describe('WalletsClient', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/transfer/sol',
+      url: 'http://localhost:8080/transaction/transfer/sol',
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',
@@ -237,6 +292,69 @@ describe('WalletsClient', () => {
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_456',
+    });
+  });
+
+  test('prepares Jupiter swaps through the local transaction endpoint', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          intentId: 'intent_swap_123',
+          transaction: 'base64-swap-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+          recentBlockhash: 'blockhash_789',
+          wallet: {
+            swigId: 'swig_123',
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigId: 'swig_123',
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterPubkey: 'requester_123',
+    });
+
+    const prepared = await wallet.swap({
+      feePayer: 'payer_123',
+      inputMint: 'input_mint_123',
+      outputMint: 'output_mint_123',
+      amount: 42n,
+      slippageBps: 100,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/swap/jupiter',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigId: 'swig_123',
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+        requesterPubkey: 'requester_123',
+        inputMint: 'input_mint_123',
+        outputMint: 'output_mint_123',
+        amount: '42',
+        slippageBps: 100,
+      },
+    });
+    expect(prepared).toMatchObject({
+      intentId: 'intent_swap_123',
+      transaction: 'base64-swap-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+      recentBlockhash: 'blockhash_789',
     });
   });
 });

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -20,7 +20,6 @@ import {
   swapRequest,
   transferSolRequest,
   transferTokenRequest,
-  walletActionPath,
 } from './requests.js';
 
 export class WalletsClient {
@@ -31,7 +30,7 @@ export class WalletsClient {
 
   create = async (args: CreateWalletArgs): Promise<WalletHandle> => {
     const response = await this.http.post<PreparedTransactionWire>(
-      '/wallet/create',
+      '/transaction/wallet/create',
       createWalletRequest(args, this.defaultNetwork),
     );
     const creationTransaction = normalizePreparedTransaction(response);
@@ -87,8 +86,8 @@ export class WalletsClient {
     args: TransferArgs,
   ): Promise<PreparedTransaction> => {
     const path = isTokenTransfer(args)
-      ? '/transfer/spl-token'
-      : '/transfer/sol';
+      ? '/transaction/transfer/spl-token'
+      : '/transaction/transfer/sol';
     const body = isTokenTransfer(args)
       ? transferTokenRequest(wallet, args, this.defaultNetwork)
       : transferSolRequest(wallet, args, this.defaultNetwork);
@@ -101,7 +100,7 @@ export class WalletsClient {
     args: SwapArgs,
   ): Promise<PreparedTransaction> => {
     const response = await this.http.post<PreparedTransactionWire>(
-      walletActionPath(wallet, 'swap'),
+      '/transaction/swap/jupiter',
       swapRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePreparedTransaction(response);
@@ -112,7 +111,7 @@ export class WalletsClient {
     args: ExecuteArgs,
   ): Promise<PreparedTransaction> => {
     const response = await this.http.post<PreparedTransactionWire>(
-      walletActionPath(wallet, 'execute'),
+      `/v1/wallets/${encodeURIComponent(wallet.swigConfigAddress)}/execute`,
       executeRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePreparedTransaction(response);

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -14,15 +14,6 @@ import {
   toProtoNetwork,
 } from './normalizers.js';
 
-export type WalletAction = 'transfer' | 'swap' | 'execute';
-
-export function walletActionPath(
-  wallet: WalletHandle,
-  action: WalletAction,
-): string {
-  return `/v1/wallets/${encodeURIComponent(wallet.swigConfigAddress)}/${action}`;
-}
-
 export function createWalletRequest(
   args: CreateWalletArgs,
   defaultNetwork?: Network,
@@ -83,13 +74,29 @@ export function swapRequest(
   defaultNetwork?: Network,
 ) {
   return {
-    wallet: wallet.swigConfigAddress,
-    network: args.network ?? wallet.network ?? defaultNetwork,
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigId: wallet.swigId,
+    swigConfigAddress: wallet.swigConfigAddress,
+    walletAddress: wallet.walletAddress,
+    requesterPubkey: resolveRequesterPubkey(wallet, args),
     inputMint: args.inputMint,
     outputMint: args.outputMint,
     amount: normalizeAmount(args.amount),
     slippageBps: args.slippageBps,
-    idempotencyKey: args.idempotencyKey,
+    destinationTokenAccount: args.destinationTokenAccount,
+    nativeDestinationAccount: args.nativeDestinationAccount,
+    wrapAndUnwrapSol: args.wrapAndUnwrapSol,
+    tipAmountLamports:
+      args.tipAmountLamports === undefined
+        ? undefined
+        : normalizeAmount(args.tipAmountLamports),
+    computeUnitPricePercentile: args.computeUnitPricePercentile,
+    maxAccounts: args.maxAccounts,
+    mode: args.mode,
+    blockhashSlotsToExpiry: args.blockhashSlotsToExpiry,
   };
 }
 
@@ -123,7 +130,7 @@ function resolveNetwork(...networks: Array<Network | undefined>): Network {
 
 function resolveRequesterPubkey(
   wallet: WalletHandle,
-  args: TransferArgs,
+  args: TransferArgs | SwapArgs,
 ): string {
   const requesterPubkey = args.requesterPubkey ?? wallet.requesterPubkey;
   if (!requesterPubkey) {


### PR DESCRIPTION
## Summary
- send developer SDK wallet operations to the /transaction/* API paths
- add Jupiter swap prepare support and request typing
- extend local smoke coverage to create, transfer, and prepare a Jupiter swap

## Verification
- bun --filter '@swig-wallet/developer-sdk' build
- bun --filter '@swig-wallet/developer-sdk' typecheck
- bun --filter '@swig-wallet/developer-sdk' test
- SWIG_LOCAL_SMOKE_SWAP=true SWIG_LOCAL_SMOKE_SWAP_SUBMIT=false bun --filter '@swig-wallet/developer-sdk' smoke:local