### PR TITLE
Update developer SDK transaction flows

### DIFF
--- a/.changeset/developer-sdk-transaction-flows.md
+++ b/.changeset/developer-sdk-transaction-flows.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/developer-sdk": minor
+---
+
+Update developer SDK transaction flows for API-prepared wallet creation responses with multiple unsigned transactions, add-authority challenges, Jupiter swap proxy support, and local Surfpool smoke coverage.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -128,11 +128,17 @@ const signingFn = createSecp256r1PasskeySigningFn({
   userVerification: 'preferred',
 });
 
-// 1. Ask the backend to prepare the wallet creation transaction.
+// 1. Ask the backend to prepare the wallet creation transaction(s).
 const wallet = await swig.wallets.create({
   policyId: 'policy_123',
   feePayer,
 });
+
+// Wallet creation can return multiple transactions for policies that also need
+// setup work such as add-authority or recovery configuration.
+for (const prepared of wallet.creationTransactions) {
+  console.log(prepared.kind, prepared.intentId);
+}
 
 const preparedCreate = wallet.creationTransaction;
 
@@ -241,7 +247,7 @@ const swig = new SwigClient({
 
 ## Local transaction smoke
 
-With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/policy in local Postgres, calls the transaction API through the SDK, signs the prepared create, transfer, and Jupiter swap transactions, and submits them to the local RPC:
+With the backend local stack running on `localhost:8080` and Surfpool on `localhost:8899`, the package includes a smoke script that seeds a throwaway org/API key/no-recovery policy in local Postgres, calls the transaction API through the SDK, signs the prepared create, transfer, and Jupiter swap transactions, submits them to the local RPC, then exercises the NestJS proxy handler against the same local API:
 
 ```bash
 bun --filter '@swig-wallet/developer-sdk' build

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -13,6 +13,11 @@ import {
   SwigClient,
   type PreparedTransaction,
 } from '@swig-wallet/developer-sdk';
+import {
+  createSwigNestHandler,
+  type SwigNestHandler,
+  type SwigNestResponseLike,
+} from '../src/server/nest.js';
 
 const apiBaseUrl = 'http://localhost:8080';
 const databaseUrl = 'postgres://swig:swig@localhost:55432/swig';
@@ -24,8 +29,6 @@ const apiKey = `sk_local_transaction_smoke_${runId}`;
 const userId = `local-smoke-user-${runId}`;
 const organizationId = `local-smoke-org-${runId}`;
 const apiKeyId = `local-smoke-api-key-${runId}`;
-const signerId = `local-smoke-signer-${runId}`;
-const permissionId = `local-smoke-permission-${runId}`;
 const policyId = `local-smoke-policy-${runId}`;
 const feePayer = Keypair.generate();
 const requester = Keypair.generate();
@@ -116,6 +119,57 @@ async function main() {
     [feePayer, requester],
   );
   console.log(`swap signature: ${swapSignature}`);
+
+  const nestHandler = createSwigNestHandler({
+    apiKey,
+    transactionApiUrl: apiBaseUrl,
+    feePayer: feePayer.publicKey.toBase58(),
+    resolveRequesterPubkey: () => requester.publicKey.toBase58(),
+  });
+  const nestTransferTransaction = await prepareWithNest(nestHandler, {
+    route: '/swig/transfer/sol',
+    body: {
+      wallet: {
+        swigId: wallet.swigId,
+        swigConfigAddress: wallet.swigConfigAddress,
+        walletAddress: wallet.walletAddress,
+      },
+      network: 'devnet',
+      destination: Keypair.generate().publicKey.toBase58(),
+      amount: '1000',
+    },
+  });
+  const nestTransferSignature = await signAndSendPreparedTransaction(
+    connection,
+    nestTransferTransaction,
+    [feePayer, requester],
+  );
+  console.log(`nest transfer signature: ${nestTransferSignature}`);
+
+  const nestSwapTransaction = await prepareWithNest(nestHandler, {
+    route: '/swig/swap/jupiter',
+    body: {
+      wallet: {
+        swigId: wallet.swigId,
+        swigConfigAddress: wallet.swigConfigAddress,
+        walletAddress: wallet.walletAddress,
+      },
+      network: 'devnet',
+      inputMint: solMint,
+      outputMint: usdcMint,
+      amount: String(swapAmountLamports),
+      slippageBps: swapSlippageBps,
+      wrapAndUnwrapSol: true,
+      maxAccounts: 20,
+      mode: 'fast',
+    },
+  });
+  const nestSwapSignature = await signAndSendPreparedTransaction(
+    connection,
+    nestSwapTransaction,
+    [feePayer, requester],
+  );
+  console.log(`nest swap signature: ${nestSwapSignature}`);
 }
 
 function seedLocalFixture() {
@@ -144,58 +198,16 @@ ON CONFLICT (key) DO UPDATE SET
   "organizationId" = EXCLUDED."organizationId",
   "userId" = EXCLUDED."userId";
 
-INSERT INTO signers (
+INSERT INTO "wallet_policy_templates" (
   id,
   "organizationId",
   name,
-  type,
-  "publicKey",
-  "createdById",
-  "lastUpdatedById",
-  "updatedAt"
-)
-VALUES (
-  ${sqlLiteral(signerId)},
-  ${sqlLiteral(organizationId)},
-  'Local Smoke Signer',
-  'ED25519',
-  ${sqlLiteral(requester.publicKey.toBase58())},
-  ${sqlLiteral(userId)},
-  ${sqlLiteral(userId)},
-  NOW()
-)
-ON CONFLICT (id) DO UPDATE SET
-  "updatedAt" = NOW(),
-  "publicKey" = EXCLUDED."publicKey";
-
-INSERT INTO permissions (
-  id,
-  "organizationId",
-  name,
-  actions,
-  "createdById",
-  "lastUpdatedById",
-  "updatedAt"
-)
-VALUES (
-  ${sqlLiteral(permissionId)},
-  ${sqlLiteral(organizationId)},
-  'Local Smoke Permission',
-  '[{"type":"All"}]'::jsonb,
-  ${sqlLiteral(userId)},
-  ${sqlLiteral(userId)},
-  NOW()
-)
-ON CONFLICT (id) DO UPDATE SET
-  "updatedAt" = NOW(),
-  actions = EXCLUDED.actions;
-
-INSERT INTO policies (
-  id,
-  "organizationId",
-  name,
-  "signerId",
-  "permissionId",
+  "initialUserLabel",
+  "initialAuthoritySource",
+  "initialAuthority",
+  "initialActions",
+  "guardianEnabled",
+  "guardianDelaySeconds",
   "createdById",
   "lastUpdatedById",
   "updatedAt"
@@ -203,17 +215,22 @@ INSERT INTO policies (
 VALUES (
   ${sqlLiteral(policyId)},
   ${sqlLiteral(organizationId)},
-  'Local Smoke Policy',
-  ${sqlLiteral(signerId)},
-  ${sqlLiteral(permissionId)},
+  'Local Smoke Wallet Policy',
+  'Local Smoke Signer',
+  2,
+  decode(${sqlLiteral(encodeEd25519WalletAuthorityHex(requester.publicKey.toBase58()))}, 'hex'),
+  '[{"type":"All"}]'::jsonb,
+  FALSE,
+  0,
   ${sqlLiteral(userId)},
   ${sqlLiteral(userId)},
   NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
   "updatedAt" = NOW(),
-  "signerId" = EXCLUDED."signerId",
-  "permissionId" = EXCLUDED."permissionId";
+  "initialAuthority" = EXCLUDED."initialAuthority",
+  "initialActions" = EXCLUDED."initialActions",
+  "guardianEnabled" = EXCLUDED."guardianEnabled";
 
 COMMIT;
 `;
@@ -341,6 +358,55 @@ async function waitForAccount(connection: Connection, pubkey: PublicKey) {
   throw new Error(`Timed out waiting for account ${pubkey.toBase58()}`);
 }
 
+async function prepareWithNest(
+  handler: SwigNestHandler,
+  input: { route: string; body: Record<string, unknown> },
+): Promise<PreparedTransaction> {
+  const response = new SmokeNestResponse();
+  await handler(
+    {
+      body: input.body,
+      headers: {
+        host: 'localhost:3000',
+      },
+      method: 'POST',
+      originalUrl: input.route,
+      protocol: 'http',
+    },
+    response,
+  );
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(
+      `Nest handler failed with status ${response.statusCode}: ${response.body}`,
+    );
+  }
+
+  const parsed = JSON.parse(response.body ?? '{}') as {
+    prepared?: PreparedTransaction;
+  };
+  if (!parsed.prepared) {
+    throw new Error(`Nest handler response is missing prepared transaction`);
+  }
+  return parsed.prepared;
+}
+
+class SmokeNestResponse implements SwigNestResponseLike {
+  body?: string;
+  statusCode = 200;
+
+  send(body?: string) {
+    this.body = body;
+  }
+
+  setHeader() {}
+
+  status(statusCode: number) {
+    this.statusCode = statusCode;
+    return this;
+  }
+}
+
 function requirePrepared(
   prepared: PreparedTransaction | undefined,
 ): PreparedTransaction {
@@ -361,6 +427,34 @@ function requireWalletAddress(walletAddress: string | undefined): string {
 
 function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
+}
+
+function encodeEd25519WalletAuthorityHex(publicKey: string): string {
+  const authorityMessage = encodeProtoMessage([
+    [1, Buffer.from(publicKey, 'utf8')],
+  ]);
+  return encodeProtoMessage([[1, authorityMessage]]).toString('hex');
+}
+
+function encodeProtoMessage(fields: Array<[number, Buffer]>): Buffer {
+  return Buffer.concat(
+    fields.flatMap(([fieldNumber, value]) => [
+      encodeVarint((fieldNumber << 3) | 2),
+      encodeVarint(value.length),
+      value,
+    ]),
+  );
+}
+
+function encodeVarint(value: number): Buffer {
+  const bytes: number[] = [];
+  let current = value;
+  while (current >= 0x80) {
+    bytes.push((current & 0x7f) | 0x80);
+    current >>= 7;
+  }
+  bytes.push(current);
+  return Buffer.from(bytes);
 }
 
 function sqlLiteral(value: string): string {

--- a/packages/developer-sdk/src/server/fetch.test.ts
+++ b/packages/developer-sdk/src/server/fetch.test.ts
@@ -34,6 +34,84 @@ function jsonFetch(
 }
 
 describe('createSwigFetchHandler', () => {
+  test('prepares wallet creation with the multi-transaction create response', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          intentId: 'intent_create_123',
+          wallet: {
+            swigId: 'swig_123',
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              intentId: 'intent_create_123',
+              transaction: 'base64-create-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+            },
+          ],
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/wallet/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          network: 'devnet',
+          policyId: 'policy_123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      prepared: {
+        intentId: 'intent_create_123',
+        wallet: {
+          swigId: 'swig_123',
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          network: 'devnet',
+        },
+        transactions: [
+          {
+            intentId: 'intent_create_123',
+            transaction: 'base64-create-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+            kind: 'create-swig-wallet',
+          },
+        ],
+        creationTransaction: {
+          intentId: 'intent_create_123',
+          transaction: 'base64-create-tx',
+          transactionEncoding: 'base64',
+          network: 'devnet',
+          kind: 'create-swig-wallet',
+        },
+        network: 'devnet',
+      },
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/wallet/create',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        policyId: 'policy_123',
+      },
+    });
+  });
+
   test('prepares SOL transfers through the API-key server client', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({
@@ -128,6 +206,72 @@ describe('createSwigFetchHandler', () => {
     expect(calls[0]?.body).toMatchObject({
       feePayer: 'payer_123',
       requesterPubkey: 'requester_123',
+    });
+  });
+
+  test('prepares Jupiter swaps through the API-key server client', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      resolveRequesterPubkey: () => 'requester_123',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          intentId: 'intent_swap_123',
+          transaction: 'base64-swap-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/swap/jupiter', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          network: 'devnet',
+          inputMint: 'So11111111111111111111111111111111111111112',
+          outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          amount: '42',
+          slippageBps: 100,
+          wrapAndUnwrapSol: true,
+          maxAccounts: 20,
+          mode: 'fast',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      prepared: {
+        intentId: 'intent_swap_123',
+        transaction: 'base64-swap-tx',
+        transactionEncoding: 'base64',
+        network: 'devnet',
+      },
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/swap/jupiter',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+        requesterPubkey: 'requester_123',
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '42',
+        slippageBps: 100,
+        wrapAndUnwrapSol: true,
+        maxAccounts: 20,
+        mode: 'fast',
+      },
     });
   });
 });

--- a/packages/developer-sdk/src/server/fetch.ts
+++ b/packages/developer-sdk/src/server/fetch.ts
@@ -3,6 +3,7 @@ import type {
   Amount,
   CreateWalletArgs,
   Network,
+  SwapArgs,
   TransferTokenArgs,
   WalletReference,
 } from '../types/index.js';
@@ -10,7 +11,8 @@ import type {
 export type SwigProxyRoute =
   | 'wallet/create'
   | 'transfer/sol'
-  | 'transfer/spl-token';
+  | 'transfer/spl-token'
+  | 'swap/jupiter';
 
 export interface SwigRouteContext {
   request: Request;
@@ -52,6 +54,7 @@ const swigProxyRoutes: SwigProxyRoute[] = [
   'wallet/create',
   'transfer/sol',
   'transfer/spl-token',
+  'swap/jupiter',
 ];
 
 export type SwigFetchHandler = (request: Request) => Promise<Response>;
@@ -100,6 +103,10 @@ async function handlePost(
         return json({
           prepared: await prepareTokenTransfer(swig, body, context, config),
         });
+      case 'swap/jupiter':
+        return json({
+          prepared: await prepareJupiterSwap(swig, body, context, config),
+        });
     }
   } catch (error) {
     const message =
@@ -119,6 +126,12 @@ async function prepareWalletCreation(
   const args: CreateWalletArgs = {
     feePayer,
     policyId: readRequiredString(body, 'policyId'),
+    ...(readWalletAuthority(body.initialUser)
+      ? { initialUser: readWalletAuthority(body.initialUser) }
+      : {}),
+    ...(readOptionalString(body, 'guardianPubkey')
+      ? { guardianPubkey: readOptionalString(body, 'guardianPubkey') }
+      : {}),
     ...(context.network ? { network: context.network } : {}),
     ...(readOptionalString(body, 'idempotencyKey')
       ? { idempotencyKey: readOptionalString(body, 'idempotencyKey') }
@@ -133,7 +146,29 @@ async function prepareWalletCreation(
     );
   }
 
-  return wallet.creationTransaction;
+  return createWalletResult(wallet);
+}
+
+function createWalletResult(
+  wallet: Awaited<ReturnType<SwigClient['wallets']['create']>>,
+) {
+  const intentId =
+    wallet.creationTransaction?.intentId ??
+    wallet.creationTransactions[0]?.intentId;
+
+  return {
+    intentId,
+    wallet: {
+      swigId: wallet.swigId,
+      swigConfigAddress: wallet.swigConfigAddress,
+      walletAddress: wallet.walletAddress,
+      network: wallet.network,
+    },
+    transactions: wallet.creationTransactions,
+    creationTransaction: wallet.creationTransaction,
+    addAuthorityChallenge: wallet.addAuthorityChallenge,
+    network: wallet.network,
+  };
 }
 
 async function prepareSolTransfer(
@@ -221,6 +256,84 @@ async function prepareTokenTransfer(
   };
 
   return handle.transfer(args);
+}
+
+async function prepareJupiterSwap(
+  swig: SwigClient,
+  body: Record<string, unknown>,
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+) {
+  const wallet = requireWallet(context.wallet);
+  const requesterPubkey = await resolveRequesterPubkey(context, config);
+  const feePayer = await resolveFeePayer(context, config, requesterPubkey);
+  const handle = swig.wallets.use(
+    {
+      ...wallet,
+      requesterPubkey,
+    },
+    { network: context.network },
+  );
+  const args: SwapArgs = {
+    feePayer,
+    requesterPubkey,
+    inputMint: readRequiredString(body, 'inputMint'),
+    outputMint: readRequiredString(body, 'outputMint'),
+    amount: readAmount(body),
+    ...(readOptionalNumber(body, 'slippageBps') !== undefined
+      ? { slippageBps: readOptionalNumber(body, 'slippageBps') }
+      : {}),
+    ...(readOptionalString(body, 'destinationTokenAccount')
+      ? {
+          destinationTokenAccount: readOptionalString(
+            body,
+            'destinationTokenAccount',
+          ),
+        }
+      : {}),
+    ...(readOptionalString(body, 'nativeDestinationAccount')
+      ? {
+          nativeDestinationAccount: readOptionalString(
+            body,
+            'nativeDestinationAccount',
+          ),
+        }
+      : {}),
+    ...(readOptionalBoolean(body, 'wrapAndUnwrapSol') !== undefined
+      ? { wrapAndUnwrapSol: readOptionalBoolean(body, 'wrapAndUnwrapSol') }
+      : {}),
+    ...(readOptionalString(body, 'tipAmountLamports')
+      ? { tipAmountLamports: readOptionalString(body, 'tipAmountLamports') }
+      : {}),
+    ...(readOptionalString(body, 'computeUnitPricePercentile')
+      ? {
+          computeUnitPricePercentile: readOptionalString(
+            body,
+            'computeUnitPricePercentile',
+          ),
+        }
+      : {}),
+    ...(readOptionalNumber(body, 'maxAccounts') !== undefined
+      ? { maxAccounts: readOptionalNumber(body, 'maxAccounts') }
+      : {}),
+    ...(readOptionalString(body, 'mode')
+      ? { mode: readOptionalString(body, 'mode') }
+      : {}),
+    ...(readOptionalNumber(body, 'blockhashSlotsToExpiry') !== undefined
+      ? {
+          blockhashSlotsToExpiry: readOptionalNumber(
+            body,
+            'blockhashSlotsToExpiry',
+          ),
+        }
+      : {}),
+    ...(context.network ? { network: context.network } : {}),
+    ...(readOptionalString(body, 'idempotencyKey')
+      ? { idempotencyKey: readOptionalString(body, 'idempotencyKey') }
+      : {}),
+  };
+
+  return handle.swap(args);
 }
 
 async function resolveRequesterPubkey(
@@ -328,6 +441,26 @@ function readWallet(value: unknown): WalletReference | undefined {
   };
 }
 
+function readWalletAuthority(value: unknown): CreateWalletArgs['initialUser'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new SwigRouteError('initialUser must be an object');
+  }
+  for (const scheme of ['ed25519', 'secp256k1', 'secp256r1'] as const) {
+    const authority = value[scheme];
+    if (!isRecord(authority)) {
+      continue;
+    }
+    const publicKey = readOptionalString(authority, 'publicKey');
+    if (publicKey) {
+      return { [scheme]: { publicKey } } as CreateWalletArgs['initialUser'];
+    }
+  }
+  throw new SwigRouteError('initialUser must include a supported authority');
+}
+
 function requireWallet(wallet: WalletReference | undefined): WalletReference {
   if (!wallet) {
     throw new SwigRouteError('wallet is required');
@@ -375,6 +508,16 @@ function readOptionalBoolean(
 ): boolean | undefined {
   const value = body[key];
   return typeof value === 'boolean' ? value : undefined;
+}
+
+function readOptionalNumber(
+  body: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = body[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 function readEnv(...names: string[]): string | undefined {

--- a/packages/developer-sdk/src/server/nest.test.ts
+++ b/packages/developer-sdk/src/server/nest.test.ts
@@ -120,4 +120,74 @@ describe('createSwigNestHandler', () => {
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
   });
+
+  test('adapts a Nest swap request to the fetch proxy handler', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigNestHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      resolveRequesterPubkey: () => 'requester_123',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          intentId: 'intent_swap_123',
+          transaction: 'base64-swap-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+    const response = new TestNestResponse();
+
+    await handler(
+      {
+        body: {
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          network: 'devnet',
+          inputMint: 'So11111111111111111111111111111111111111112',
+          outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          amount: '42',
+          slippageBps: 100,
+          wrapAndUnwrapSol: true,
+        },
+        headers: {
+          host: 'api.example.com',
+        },
+        method: 'POST',
+        originalUrl: '/swig/swap/jupiter',
+        protocol: 'https',
+      },
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body ?? '{}')).toEqual({
+      prepared: {
+        intentId: 'intent_swap_123',
+        transaction: 'base64-swap-tx',
+        transactionEncoding: 'base64',
+        network: 'devnet',
+      },
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/swap/jupiter',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+        requesterPubkey: 'requester_123',
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '42',
+        slippageBps: 100,
+        wrapAndUnwrapSol: true,
+      },
+    });
+  });
 });

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -16,6 +16,20 @@ export type ProtoNetwork =
   | 'NETWORK_MAINNET';
 export type NetworkWire = Network | ProtoNetwork | number;
 
+export type PreparedTransactionKind =
+  | 'create-swig-wallet'
+  | 'add-authority'
+  | 'configure-recovery';
+export type ProtoPreparedTransactionKind =
+  | 'PREPARED_TRANSACTION_KIND_UNSPECIFIED'
+  | 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET'
+  | 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY'
+  | 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY';
+export type PreparedTransactionKindWire =
+  | PreparedTransactionKind
+  | ProtoPreparedTransactionKind
+  | number;
+
 export interface PreparedTransaction {
   intentId: string;
   transaction: string;
@@ -24,6 +38,7 @@ export interface PreparedTransaction {
   expiresAt?: string;
   network?: Network;
   recentBlockhash?: string;
+  kind?: PreparedTransactionKind;
 }
 
 export interface PreparedTransactionWire {
@@ -40,6 +55,46 @@ export interface PreparedTransactionWire {
   network?: NetworkWire;
   recent_blockhash?: string;
   recentBlockhash?: string;
+  kind?: PreparedTransactionKindWire;
+}
+
+export interface AddAuthorityChallenge {
+  transactionIndex: number;
+  scheme: 'secp256r1' | 'secp256k1';
+  signer: string;
+  messageHash: string;
+  slot: number;
+  counter: number;
+}
+
+export interface AddAuthorityChallengeWire {
+  transaction_index?: number;
+  transactionIndex?: number;
+  scheme?:
+    | 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1'
+    | 'AUTHORITY_SIGNATURE_SCHEME_SECP256K1'
+    | number;
+  signer?: string;
+  message_hash?: string;
+  messageHash?: string;
+  slot?: number | string;
+  counter?: number;
+}
+
+export interface CreateWalletResponseWire extends PreparedTransactionWire {
+  wallet?: WalletAddressInfo;
+  transactions?: PreparedTransactionWire[];
+  add_authority_challenge?: AddAuthorityChallengeWire;
+  addAuthorityChallenge?: AddAuthorityChallengeWire;
+}
+
+export interface CreateWalletResult {
+  intentId: string;
+  wallet: WalletAddressInfo;
+  transactions: PreparedTransaction[];
+  creationTransaction?: PreparedTransaction;
+  addAuthorityChallenge?: AddAuthorityChallenge;
+  network?: Network;
 }
 
 export interface SponsorSignedTransactionArgs {

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -1,11 +1,22 @@
 import type { Amount, Network } from './common.js';
 import type { SolanaInstructionInput } from './instruction.js';
-import type { PreparedTransactionWire } from './transaction.js';
+import type {
+  AddAuthorityChallenge,
+  PreparedTransaction,
+  PreparedTransactionWire,
+} from './transaction.js';
 import type { WalletAddressInfo } from './wallet.js';
+
+export type WalletAuthority =
+  | { ed25519: { publicKey: string } }
+  | { secp256k1: { publicKey: string } }
+  | { secp256r1: { publicKey: string } };
 
 export interface CreateWalletArgs {
   policyId: string;
   feePayer: string;
+  initialUser?: WalletAuthority;
+  guardianPubkey?: string;
   network?: Network;
   idempotencyKey?: string;
 }
@@ -15,6 +26,9 @@ export interface CreateWalletResponse
   network?: Network;
   label?: string;
   externalId?: string;
+  transactions?: PreparedTransaction[];
+  creationTransaction?: PreparedTransaction;
+  addAuthorityChallenge?: AddAuthorityChallenge;
 }
 
 export interface BaseTransferArgs {

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -196,16 +196,23 @@ describe('WalletsClient', () => {
         calls.push(request);
         return {
           intentId: 'intent_create_123',
-          transaction: 'base64-create-tx',
-          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
-          recentBlockhash: 'blockhash_123',
-          expiresAt: '2026-05-13T00:00:00Z',
           wallet: {
             swigId: 'swig_123',
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
+          transactions: [
+            {
+              intentId: 'intent_create_123',
+              transaction: 'base64-create-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              recentBlockhash: 'blockhash_123',
+              expiresAt: '2026-05-13T00:00:00Z',
+              kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+            },
+          ],
         };
       }),
     });
@@ -227,12 +234,14 @@ describe('WalletsClient', () => {
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
     expect(wallet.swigId).toBe('swig_123');
+    expect(wallet.creationTransactions).toHaveLength(1);
     expect(wallet.creationTransaction).toMatchObject({
       intentId: 'intent_create_123',
       transaction: 'base64-create-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_123',
+      kind: 'create-swig-wallet',
     });
   });
 

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -1,6 +1,7 @@
 import type { HttpClient } from '../core/index.js';
 import type {
   CreateWalletArgs,
+  CreateWalletResponseWire,
   ExecuteArgs,
   IdpWalletSession,
   Network,
@@ -12,7 +13,10 @@ import type {
   WalletReference,
 } from '../types/index.js';
 import { WalletHandle } from './handle.js';
-import { normalizePreparedTransaction } from './normalizers.js';
+import {
+  normalizeCreateWalletResponse,
+  normalizePreparedTransaction,
+} from './normalizers.js';
 import {
   createWalletRequest,
   executeRequest,
@@ -29,22 +33,18 @@ export class WalletsClient {
   ) {}
 
   create = async (args: CreateWalletArgs): Promise<WalletHandle> => {
-    const response = await this.http.post<PreparedTransactionWire>(
+    const response = await this.http.post<CreateWalletResponseWire>(
       '/transaction/wallet/create',
       createWalletRequest(args, this.defaultNetwork),
     );
-    const creationTransaction = normalizePreparedTransaction(response);
-    const wallet = creationTransaction.wallet;
-
-    if (!wallet) {
-      throw new Error('Create wallet response is missing wallet');
-    }
+    const created = normalizeCreateWalletResponse(response);
 
     return new WalletHandle(this, {
-      ...wallet,
-      network:
-        creationTransaction.network ?? args.network ?? this.defaultNetwork,
-      creationTransaction,
+      ...created.wallet,
+      network: created.network ?? args.network ?? this.defaultNetwork,
+      creationTransaction: created.creationTransaction,
+      creationTransactions: created.transactions,
+      addAuthorityChallenge: created.addAuthorityChallenge,
     });
   };
 

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -1,4 +1,5 @@
 import type {
+  AddAuthorityChallenge,
   ExecuteArgs,
   Network,
   PreparedTransaction,
@@ -10,6 +11,8 @@ import type { WalletsClient } from './client.js';
 
 export interface WalletHandleInit extends WalletReference {
   creationTransaction?: PreparedTransaction;
+  creationTransactions?: PreparedTransaction[];
+  addAuthorityChallenge?: AddAuthorityChallenge;
 }
 
 export class WalletHandle {
@@ -19,6 +22,8 @@ export class WalletHandle {
   readonly network?: Network;
   readonly requesterPubkey?: string;
   readonly creationTransaction?: PreparedTransaction;
+  readonly creationTransactions: PreparedTransaction[];
+  readonly addAuthorityChallenge?: AddAuthorityChallenge;
 
   constructor(
     private readonly wallets: WalletsClient,
@@ -30,6 +35,10 @@ export class WalletHandle {
     this.network = init.network;
     this.requesterPubkey = init.requesterPubkey;
     this.creationTransaction = init.creationTransaction;
+    this.creationTransactions =
+      init.creationTransactions ??
+      (init.creationTransaction ? [init.creationTransaction] : []);
+    this.addAuthorityChallenge = init.addAuthorityChallenge;
   }
 
   transfer = (args: TransferArgs) => this.wallets.transfer(this, args);

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   normalizeAmount,
+  normalizeCreateWalletResponse,
   normalizeInstruction,
   normalizePreparedTransaction,
   normalizeSubmittedTransaction,
@@ -23,6 +24,81 @@ describe('wallet normalizers', () => {
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_123',
+    });
+  });
+
+  test('normalizes create wallet responses with multiple prepared transactions', () => {
+    expect(
+      normalizeCreateWalletResponse({
+        intentId: 'intent_create_123',
+        wallet: {
+          swigId: 'swig_123',
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+        },
+        transactions: [
+          {
+            intentId: 'intent_create_123',
+            transaction: 'base64-create-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+          },
+          {
+            intentId: 'intent_create_123',
+            transaction: 'base64-add-authority-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
+          },
+        ],
+        addAuthorityChallenge: {
+          transactionIndex: 1,
+          scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
+          signer: 'compressed-passkey',
+          messageHash: 'message-hash',
+          slot: '42',
+          counter: 1,
+        },
+        network: 'NETWORK_DEVNET',
+      }),
+    ).toEqual({
+      intentId: 'intent_create_123',
+      wallet: {
+        swigId: 'swig_123',
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+      },
+      creationTransaction: {
+        intentId: 'intent_create_123',
+        transaction: 'base64-create-tx',
+        transactionEncoding: 'base64',
+        kind: 'create-swig-wallet',
+        network: 'devnet',
+      },
+      transactions: [
+        {
+          intentId: 'intent_create_123',
+          transaction: 'base64-create-tx',
+          transactionEncoding: 'base64',
+          kind: 'create-swig-wallet',
+          network: 'devnet',
+        },
+        {
+          intentId: 'intent_create_123',
+          transaction: 'base64-add-authority-tx',
+          transactionEncoding: 'base64',
+          kind: 'add-authority',
+          network: 'devnet',
+        },
+      ],
+      addAuthorityChallenge: {
+        transactionIndex: 1,
+        scheme: 'secp256r1',
+        signer: 'compressed-passkey',
+        messageHash: 'message-hash',
+        slot: 42,
+        counter: 1,
+      },
+      network: 'devnet',
     });
   });
 

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -1,8 +1,14 @@
 import type {
+  AddAuthorityChallenge,
+  AddAuthorityChallengeWire,
   Amount,
+  CreateWalletResponseWire,
+  CreateWalletResult,
   Network,
   NetworkWire,
   PreparedTransaction,
+  PreparedTransactionKind,
+  PreparedTransactionKindWire,
   PreparedTransactionWire,
   SolanaInstruction,
   SolanaInstructionInput,
@@ -38,6 +44,48 @@ export function normalizePreparedTransaction(
     expiresAt: response.expiresAt ?? response.expires_at,
     network: normalizeNetwork(response.network),
     recentBlockhash: response.recentBlockhash ?? response.recent_blockhash,
+    kind: normalizePreparedTransactionKind(response.kind),
+  };
+}
+
+export function normalizeCreateWalletResponse(
+  response: CreateWalletResponseWire,
+): CreateWalletResult {
+  const topLevelIntentId = response.intentId ?? response.intent_id;
+  const topLevelNetwork = normalizeNetwork(response.network);
+  const transactions = Array.isArray(response.transactions)
+    ? response.transactions.map((transaction) =>
+        normalizePreparedTransaction({
+          ...transaction,
+          intentId:
+            transaction.intentId ?? transaction.intent_id ?? topLevelIntentId,
+          network: transaction.network ?? response.network,
+        }),
+      )
+    : [normalizePreparedTransaction(response)];
+  const creationTransaction =
+    transactions.find(
+      (transaction) => transaction.kind === 'create-swig-wallet',
+    ) ?? transactions[0];
+  const wallet = response.wallet ?? creationTransaction?.wallet;
+  const intentId = topLevelIntentId ?? creationTransaction?.intentId;
+
+  if (!intentId) {
+    throw new Error('Create wallet response is missing intent_id');
+  }
+  if (!wallet) {
+    throw new Error('Create wallet response is missing wallet');
+  }
+
+  return {
+    intentId,
+    wallet,
+    transactions,
+    creationTransaction,
+    addAuthorityChallenge: normalizeAddAuthorityChallenge(
+      response.addAuthorityChallenge ?? response.add_authority_challenge,
+    ),
+    network: topLevelNetwork ?? creationTransaction?.network,
   };
 }
 
@@ -108,6 +156,80 @@ export function normalizeTransactionEncoding(
     case 'TRANSACTION_ENCODING_BASE64':
     case 1:
       return 'base64';
+    default:
+      return undefined;
+  }
+}
+
+function normalizePreparedTransactionKind(
+  kind?: PreparedTransactionKindWire,
+): PreparedTransactionKind | undefined {
+  switch (kind) {
+    case 'create-swig-wallet':
+    case 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET':
+    case 1:
+      return 'create-swig-wallet';
+    case 'add-authority':
+    case 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY':
+    case 2:
+      return 'add-authority';
+    case 'configure-recovery':
+    case 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY':
+    case 3:
+      return 'configure-recovery';
+    default:
+      return undefined;
+  }
+}
+
+function normalizeAddAuthorityChallenge(
+  challenge?: AddAuthorityChallengeWire,
+): AddAuthorityChallenge | undefined {
+  if (!challenge) {
+    return undefined;
+  }
+
+  const transactionIndex =
+    challenge.transactionIndex ?? challenge.transaction_index;
+  const messageHash = challenge.messageHash ?? challenge.message_hash;
+  const scheme = normalizeAuthoritySignatureScheme(challenge.scheme);
+
+  if (
+    transactionIndex === undefined ||
+    !scheme ||
+    !challenge.signer ||
+    !messageHash ||
+    challenge.slot === undefined ||
+    challenge.counter === undefined
+  ) {
+    throw new Error(
+      'Create wallet response has invalid add_authority_challenge',
+    );
+  }
+
+  return {
+    transactionIndex,
+    scheme,
+    signer: challenge.signer,
+    messageHash,
+    slot:
+      typeof challenge.slot === 'string'
+        ? Number.parseInt(challenge.slot, 10)
+        : challenge.slot,
+    counter: challenge.counter,
+  };
+}
+
+function normalizeAuthoritySignatureScheme(
+  scheme: AddAuthorityChallengeWire['scheme'],
+): AddAuthorityChallenge['scheme'] | undefined {
+  switch (scheme) {
+    case 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1':
+    case 1:
+      return 'secp256r1';
+    case 'AUTHORITY_SIGNATURE_SCHEME_SECP256K1':
+    case 2:
+      return 'secp256k1';
     default:
       return undefined;
   }

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -22,6 +22,8 @@ export function createWalletRequest(
     network: toProtoNetwork(resolveNetwork(args.network, defaultNetwork)),
     feePayer: args.feePayer,
     policyId: args.policyId,
+    initialUser: args.initialUser,
+    guardianPubkey: args.guardianPubkey,
   };
 }
 


### PR DESCRIPTION
## Summary
- Update developer-sdk wallet creation to consume multi-transaction create responses and add-authority challenges while preserving the existing first-transaction handle field.
- Add Jupiter swap support to the SDK proxy route and Nest handler path.
- Refresh the local Surfpool smoke script to seed wallet_policy_templates with no recovery, then exercise API-level create, transfer, swap, and Nest proxy transfer/swap flows.

## Verification
- bun --filter @swig-wallet/developer-sdk typecheck
- bun --filter @swig-wallet/developer-sdk test
- bun --filter @swig-wallet/developer-sdk lint
- bun --filter @swig-wallet/developer-sdk build
- bun --filter @swig-wallet/developer-sdk smoke:local