### PR TITLE
Remove swig id from developer SDK wallet surface

### DIFF
--- a/.changeset/remove-swig-id-wallet-surface.md
+++ b/.changeset/remove-swig-id-wallet-surface.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Remove `swigId` from wallet handles, wallet references, and prepared wallet responses so SDK consumers use the Swig config address as the wallet identifier.

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -132,7 +132,6 @@ async function main() {
     route: '/swig/transfer/sol',
     body: {
       wallet: {
-        swigId: wallet.swigId,
         swigConfigAddress: wallet.swigConfigAddress,
         walletAddress: wallet.walletAddress,
       },
@@ -152,7 +151,6 @@ async function main() {
     route: '/swig/swap/jupiter',
     body: {
       wallet: {
-        swigId: wallet.swigId,
         swigConfigAddress: wallet.swigConfigAddress,
         walletAddress: wallet.walletAddress,
       },

--- a/packages/developer-sdk/src/browser.test.ts
+++ b/packages/developer-sdk/src/browser.test.ts
@@ -46,7 +46,6 @@ describe('SwigBrowserClient', () => {
           prepared: {
             intentId: 'intent_create_123',
             wallet: {
-              swigId: 'swig_123',
               swigConfigAddress: 'swig_config_123',
               walletAddress: 'wallet_123',
             },

--- a/packages/developer-sdk/src/browser.ts
+++ b/packages/developer-sdk/src/browser.ts
@@ -198,7 +198,6 @@ export class BrowserWalletsClient {
     }
 
     return new BrowserWalletHandle(this, {
-      swigId: wallet.swigId,
       swigConfigAddress: wallet.swigConfigAddress,
       walletAddress: wallet.walletAddress,
       network: options.network ?? wallet.network ?? this.defaultNetwork,
@@ -294,7 +293,6 @@ export class BrowserWalletsClient {
 }
 
 export class BrowserWalletHandle {
-  readonly swigId?: string;
   readonly swigConfigAddress: string;
   readonly walletAddress?: string;
   readonly network?: Network;
@@ -306,7 +304,6 @@ export class BrowserWalletHandle {
   readonly swap: BrowserWalletSwapClient;
 
   constructor(wallets: BrowserWalletsClient, init: BrowserWalletHandleInit) {
-    this.swigId = init.swigId;
     this.swigConfigAddress = init.swigConfigAddress;
     this.walletAddress = init.walletAddress;
     this.network = init.network;
@@ -321,7 +318,6 @@ export class BrowserWalletHandle {
   }
 
   toReference = (): WalletReference => ({
-    swigId: this.swigId,
     swigConfigAddress: this.swigConfigAddress,
     walletAddress: this.walletAddress,
     network: this.network,

--- a/packages/developer-sdk/src/server/fetch.test.ts
+++ b/packages/developer-sdk/src/server/fetch.test.ts
@@ -45,7 +45,6 @@ describe('createSwigFetchHandler', () => {
         return {
           intentId: 'intent_create_123',
           wallet: {
-            swigId: 'swig_123',
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
@@ -78,7 +77,6 @@ describe('createSwigFetchHandler', () => {
       prepared: {
         intentId: 'intent_create_123',
         wallet: {
-          swigId: 'swig_123',
           swigConfigAddress: 'swig_config_123',
           walletAddress: 'wallet_123',
           network: 'devnet',
@@ -123,7 +121,6 @@ describe('createSwigFetchHandler', () => {
         return {
           intentId: 'intent_create_inline_123',
           wallet: {
-            swigId: 'swig_inline_123',
             swigConfigAddress: 'swig_config_inline_123',
             walletAddress: 'wallet_inline_123',
           },

--- a/packages/developer-sdk/src/server/fetch.ts
+++ b/packages/developer-sdk/src/server/fetch.ts
@@ -163,7 +163,6 @@ function createWalletResult(
   return {
     intentId,
     wallet: {
-      swigId: wallet.swigId,
       swigConfigAddress: wallet.swigConfigAddress,
       walletAddress: wallet.walletAddress,
       network: wallet.network,
@@ -410,7 +409,6 @@ function readWallet(value: unknown): WalletReference | undefined {
   }
 
   return {
-    swigId: readOptionalString(value, 'swigId'),
     swigConfigAddress: readRequiredString(value, 'swigConfigAddress'),
     walletAddress: readOptionalString(value, 'walletAddress'),
     requesterPubkey: readOptionalString(value, 'requesterPubkey'),

--- a/packages/developer-sdk/src/types/wallet.ts
+++ b/packages/developer-sdk/src/types/wallet.ts
@@ -1,19 +1,11 @@
 import type { Network } from './common.js';
 
 export interface WalletAddressInfo {
-  swigId?: string;
-  /**
-   * Swig-owned config/metadata account.
-   */
   swigConfigAddress: string;
-  /**
-   * System-owned wallet PDA used as the spendable wallet address.
-   */
   walletAddress: string;
 }
 
 export interface WalletReference {
-  swigId?: string;
   swigConfigAddress: string;
   walletAddress?: string;
   network?: Network;

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -113,7 +113,6 @@ describe('WalletsClient', () => {
       'devnet',
     );
     const wallet = wallets.use({
-      swigId: 'swig_123',
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
       requesterPubkey: 'requester_123',
@@ -147,7 +146,6 @@ describe('WalletsClient', () => {
       'devnet',
     );
     const wallet = wallets.use({
-      swigId: 'swig_123',
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
       requesterPubkey: 'requester_123',
@@ -202,7 +200,6 @@ describe('WalletsClient', () => {
           intentId: 'intent_create_123',
           network: 'NETWORK_DEVNET',
           wallet: {
-            swigId: 'swig_123',
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
@@ -237,7 +234,6 @@ describe('WalletsClient', () => {
       },
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
-    expect(wallet.swigId).toBe('swig_123');
     expect(wallet.creationTransactions).toHaveLength(1);
     expect(wallet.creationTransaction).toMatchObject({
       intentId: 'intent_create_123',
@@ -261,7 +257,6 @@ describe('WalletsClient', () => {
           intentId: 'intent_create_456',
           network: 'NETWORK_DEVNET',
           wallet: {
-            swigId: 'swig_456',
             swigConfigAddress: 'swig_config_456',
             walletAddress: 'wallet_456',
           },
@@ -318,7 +313,6 @@ describe('WalletsClient', () => {
           network: 'NETWORK_DEVNET',
           recentBlockhash: 'blockhash_456',
           wallet: {
-            swigId: 'swig_123',
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
@@ -326,7 +320,6 @@ describe('WalletsClient', () => {
       }),
     });
     const wallet = swig.wallets.use({
-      swigId: 'swig_123',
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
       requesterPubkey: 'requester_123',
@@ -425,7 +418,6 @@ describe('WalletsClient', () => {
           network: 'NETWORK_DEVNET',
           recentBlockhash: 'blockhash_789',
           wallet: {
-            swigId: 'swig_123',
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
@@ -433,7 +425,6 @@ describe('WalletsClient', () => {
       }),
     });
     const wallet = swig.wallets.use({
-      swigId: 'swig_123',
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
       requesterPubkey: 'requester_123',

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -61,7 +61,6 @@ export class WalletsClient {
     }
 
     return new WalletHandle(this, {
-      swigId: wallet.swigId,
       swigConfigAddress: wallet.swigConfigAddress,
       walletAddress: wallet.walletAddress,
       network: options.network ?? wallet.network ?? this.defaultNetwork,

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -30,7 +30,6 @@ export type WalletSwapClient = {
 };
 
 export class WalletHandle {
-  readonly swigId?: string;
   readonly swigConfigAddress: string;
   readonly walletAddress?: string;
   readonly network?: Network;
@@ -45,7 +44,6 @@ export class WalletHandle {
     private readonly wallets: WalletsClient,
     init: WalletHandleInit,
   ) {
-    this.swigId = init.swigId;
     this.swigConfigAddress = init.swigConfigAddress;
     this.walletAddress = init.walletAddress;
     this.network = init.network;

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -32,7 +32,6 @@ describe('wallet normalizers', () => {
       normalizeCreateWalletResponse({
         intentId: 'intent_create_123',
         wallet: {
-          swigId: 'swig_123',
           swigConfigAddress: 'swig_config_123',
           walletAddress: 'wallet_123',
         },
@@ -63,7 +62,6 @@ describe('wallet normalizers', () => {
     ).toEqual({
       intentId: 'intent_create_123',
       wallet: {
-        swigId: 'swig_123',
         swigConfigAddress: 'swig_config_123',
         walletAddress: 'wallet_123',
       },


### PR DESCRIPTION
## Summary
- Remove swigId from developer SDK wallet handles, wallet references, and proxy payloads
- Keep swigConfigAddress as the developer-facing wallet identifier
- Add a changeset for the SDK package

## Tests
- bun --filter '@swig-wallet/developer-sdk' test
- bun --filter '@swig-wallet/developer-sdk' typecheck
- bun --filter '@swig-wallet/developer-sdk' lint
- bun --filter '@swig-wallet/developer-sdk' build