### PR TITLE
Remove intent id from developer SDK

### DIFF
--- a/.changeset/remove-intent-id-developer-sdk.md
+++ b/.changeset/remove-intent-id-developer-sdk.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/developer-sdk": minor
+---
+
+Remove internal intent IDs from prepared transaction and wallet creation SDK responses to match the transaction API.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -8,8 +8,8 @@ prepared transaction from a client.
 The SDK is prepare-first:
 
 1. Your server creates a `SwigClient` with an API key.
-2. Your server prepares a wallet operation and receives a prepared transaction
-   with an intent ID.
+2. Your server prepares a wallet operation and receives one or more unsigned
+   transactions.
 3. Your client signs the prepared transaction locally.
 4. Your app either sends the signed transaction directly or submits it to a
    backend sponsor endpoint.
@@ -27,6 +27,8 @@ prepared transactions, use the framework route helpers:
 Use the TypeScript server SDK when you want control over the route shape, auth
 context, request validation, response format, or any transaction massage before
 returning a prepared payload to the client.
+
+Create an API key from the [Swig dashboard](https://dashboard.onswig.com).
 
 ```typescript
 import { SwigClient } from '@swig-wallet/developer-sdk/server/typescript';
@@ -66,7 +68,8 @@ return preparedCreate;
 ```
 
 If `policyId` is omitted, the backend can create a no-recovery policy from an
-inline `initialUser`:
+inline `initialUser`. For a passkey initial user, provide the secp256r1 public
+key:
 
 ```typescript
 const wallet = await swig.wallets.create({
@@ -138,28 +141,6 @@ return preparedSwap;
 
 Client code should only sign prepared transactions. It should not hold the API
 key or call the Swig backend directly.
-
-### Passkey Message Signing
-
-`createSecp256r1PasskeySigningFn` creates a WebAuthn-backed message signer.
-Most apps pass this into the transaction-level Swig signing helper, but it can
-also be called directly if you need the raw passkey signing result.
-
-```typescript
-import { createSecp256r1PasskeySigningFn } from '@swig-wallet/developer-sdk/client';
-
-const passkeySigningFn = createSecp256r1PasskeySigningFn({
-  allowCredentials: [{ id: credentialId, type: 'public-key' }],
-  userVerification: 'preferred',
-});
-
-const challenge = crypto.getRandomValues(new Uint8Array(32));
-const passkeySigningResult = await passkeySigningFn(challenge);
-
-// passkeySigningResult.signature
-// passkeySigningResult.prefix
-// passkeySigningResult.message
-```
 
 ### Prepared Transaction Signing
 

--- a/packages/developer-sdk/nest/README.md
+++ b/packages/developer-sdk/nest/README.md
@@ -47,6 +47,8 @@ SWIG_TRANSACTION_API_URL=...
 SWIG_FEE_PAYER=...
 ```
 
+Create an API key from the [Swig dashboard](https://dashboard.onswig.com).
+
 `SWIG_TRANSACTION_API_URL` and `SWIG_FEE_PAYER` are optional. If no transaction
 API URL is provided, the SDK uses its production default. If no fee payer is
 configured for a transfer, the helper falls back to the requester public key.

--- a/packages/developer-sdk/next/README.md
+++ b/packages/developer-sdk/next/README.md
@@ -38,6 +38,8 @@ SWIG_TRANSACTION_API_URL=...
 SWIG_FEE_PAYER=...
 ```
 
+Create an API key from the [Swig dashboard](https://dashboard.onswig.com).
+
 `SWIG_TRANSACTION_API_URL` and `SWIG_FEE_PAYER` are optional. If no transaction
 API URL is provided, the SDK uses its production default. If no fee payer is
 configured for a transfer, the helper falls back to the requester public key.

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -64,7 +64,6 @@ async function main() {
     },
   });
   const createTransaction = requirePrepared(wallet.creationTransaction);
-  console.log(`create intent: ${createTransaction.intentId}`);
   console.log(`swig config: ${wallet.swigConfigAddress}`);
   console.log(`wallet: ${requireWalletAddress(wallet.walletAddress)}`);
 
@@ -87,7 +86,6 @@ async function main() {
     destination: destination.publicKey.toBase58(),
     amount: 1_000,
   });
-  console.log(`transfer intent: ${transferTransaction.intentId}`);
 
   const before = await connection.getBalance(destination.publicKey);
   const transferSignature = await signAndSendPreparedTransaction(
@@ -110,7 +108,6 @@ async function main() {
     maxAccounts: 20,
     mode: 'fast',
   });
-  console.log(`swap intent: ${swapTransaction.intentId}`);
   console.log(
     `swap transaction bytes: ${Buffer.from(swapTransaction.transaction, 'base64').length}`,
   );

--- a/packages/developer-sdk/src/client/index.test.ts
+++ b/packages/developer-sdk/src/client/index.test.ts
@@ -4,20 +4,18 @@ import type { PreparedTransaction } from '../types/index.js';
 import { signPreparedTransaction } from './index.js';
 
 const prepared: PreparedTransaction = {
-  intentId: 'intent_123',
   transaction: 'base64-prepared-tx',
   transactionEncoding: 'base64',
   network: 'devnet',
 };
 
 describe('client signing helpers', () => {
-  test('signPreparedTransaction signs the transaction and preserves intent metadata', async () => {
+  test('signPreparedTransaction signs the transaction and preserves preparation metadata', async () => {
     await expect(
       signPreparedTransaction(prepared, {
         signTransaction: async (transaction) => `${transaction}.signed`,
       }),
     ).resolves.toEqual({
-      intentId: 'intent_123',
       transaction: 'base64-prepared-tx.signed',
       transactionEncoding: 'base64',
       network: 'devnet',

--- a/packages/developer-sdk/src/client/index.ts
+++ b/packages/developer-sdk/src/client/index.ts
@@ -9,7 +9,6 @@ export type {
 } from '../types/index.js';
 
 export interface SignedPreparedTransaction {
-  intentId: string;
   transaction: string;
   transactionEncoding?: PreparedTransaction['transactionEncoding'];
   network?: PreparedTransaction['network'];
@@ -29,7 +28,6 @@ export async function signPreparedTransaction(
   options: SignPreparedOptions,
 ): Promise<SignedPreparedTransaction> {
   return {
-    intentId: prepared.intentId,
     transaction: await options.signTransaction(prepared.transaction, prepared),
     transactionEncoding: prepared.transactionEncoding,
     network: prepared.network,

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -43,14 +43,12 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_create_123',
           wallet: {
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
           },
           transactions: [
             {
-              intentId: 'intent_create_123',
               transaction: 'base64-create-tx',
               transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
               network: 'NETWORK_DEVNET',
@@ -75,7 +73,6 @@ describe('createSwigFetchHandler', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       prepared: {
-        intentId: 'intent_create_123',
         wallet: {
           swigConfigAddress: 'swig_config_123',
           walletAddress: 'wallet_123',
@@ -83,7 +80,6 @@ describe('createSwigFetchHandler', () => {
         },
         transactions: [
           {
-            intentId: 'intent_create_123',
             transaction: 'base64-create-tx',
             transactionEncoding: 'base64',
             network: 'devnet',
@@ -91,7 +87,6 @@ describe('createSwigFetchHandler', () => {
           },
         ],
         creationTransaction: {
-          intentId: 'intent_create_123',
           transaction: 'base64-create-tx',
           transactionEncoding: 'base64',
           network: 'devnet',
@@ -119,14 +114,12 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_create_inline_123',
           wallet: {
             swigConfigAddress: 'swig_config_inline_123',
             walletAddress: 'wallet_inline_123',
           },
           transactions: [
             {
-              intentId: 'intent_create_inline_123',
               transaction: 'base64-create-tx',
               transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
               network: 'NETWORK_DEVNET',
@@ -178,7 +171,6 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_transfer_123',
           transaction: 'base64-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -206,7 +198,6 @@ describe('createSwigFetchHandler', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       prepared: {
-        intentId: 'intent_transfer_123',
         transaction: 'base64-transfer-tx',
         transactionEncoding: 'base64',
         network: 'devnet',
@@ -239,7 +230,6 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_transfer_123',
           transaction: 'base64-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
         };
@@ -276,7 +266,6 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_token_transfer_123',
           transaction: 'base64-token-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -303,7 +292,6 @@ describe('createSwigFetchHandler', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       prepared: {
-        intentId: 'intent_token_transfer_123',
         transaction: 'base64-token-transfer-tx',
         transactionEncoding: 'base64',
         network: 'devnet',
@@ -333,7 +321,6 @@ describe('createSwigFetchHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_swap_123',
           transaction: 'base64-swap-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -364,7 +351,6 @@ describe('createSwigFetchHandler', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       prepared: {
-        intentId: 'intent_swap_123',
         transaction: 'base64-swap-tx',
         transactionEncoding: 'base64',
         network: 'devnet',

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -156,12 +156,7 @@ async function prepareWalletCreation(
 function createWalletResult(
   wallet: Awaited<ReturnType<SwigClient['wallets']['create']>>,
 ) {
-  const intentId =
-    wallet.creationTransaction?.intentId ??
-    wallet.creationTransactions[0]?.intentId;
-
   return {
-    intentId,
     wallet: {
       swigConfigAddress: wallet.swigConfigAddress,
       walletAddress: wallet.walletAddress,

--- a/packages/developer-sdk/src/server/nest/index.test.ts
+++ b/packages/developer-sdk/src/server/nest/index.test.ts
@@ -65,7 +65,6 @@ describe('createSwigNestHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_transfer_123',
           transaction: 'base64-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -99,7 +98,6 @@ describe('createSwigNestHandler', () => {
     expect(response.headers.get('content-type')).toContain('application/json');
     expect(JSON.parse(response.body ?? '{}')).toEqual({
       prepared: {
-        intentId: 'intent_transfer_123',
         transaction: 'base64-transfer-tx',
         transactionEncoding: 'base64',
         network: 'devnet',
@@ -131,7 +129,6 @@ describe('createSwigNestHandler', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_swap_123',
           transaction: 'base64-swap-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -167,7 +164,6 @@ describe('createSwigNestHandler', () => {
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body ?? '{}')).toEqual({
       prepared: {
-        intentId: 'intent_swap_123',
         transaction: 'base64-swap-tx',
         transactionEncoding: 'base64',
         network: 'devnet',

--- a/packages/developer-sdk/src/server/next/index.test.ts
+++ b/packages/developer-sdk/src/server/next/index.test.ts
@@ -10,7 +10,6 @@ describe('createSwigRouteHandlers', () => {
       fetch: (async () =>
         new Response(
           JSON.stringify({
-            intentId: 'intent_transfer_123',
             transaction: 'base64-transfer-tx',
             transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           }),
@@ -36,7 +35,6 @@ describe('createSwigRouteHandlers', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       prepared: {
-        intentId: 'intent_transfer_123',
         transaction: 'base64-transfer-tx',
       },
     });

--- a/packages/developer-sdk/src/transactions/client.ts
+++ b/packages/developer-sdk/src/transactions/client.ts
@@ -19,7 +19,6 @@ export class TransactionsClient {
     const response = await this.http.post<SubmittedTransactionWire>(
       '/v1/transactions/sponsor',
       {
-        intentId: args.intentId,
         transaction: args.transaction,
         transactionEncoding: args.transactionEncoding,
         network: args.network ?? this.defaultNetwork,

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -31,7 +31,6 @@ export type PreparedTransactionKindWire =
   | number;
 
 export interface PreparedTransaction {
-  intentId: string;
   transaction: string;
   transactionEncoding?: TransactionEncoding;
   wallet?: WalletAddressInfo;
@@ -42,8 +41,6 @@ export interface PreparedTransaction {
 }
 
 export interface PreparedTransactionWire {
-  intent_id?: string;
-  intentId?: string;
   transaction?: string;
   unsigned_transaction?: string;
   unsignedTransaction?: string;
@@ -89,7 +86,6 @@ export interface CreateWalletResponseWire extends PreparedTransactionWire {
 }
 
 export interface CreateWalletResult {
-  intentId: string;
   wallet: WalletAddressInfo;
   transactions: PreparedTransaction[];
   creationTransaction?: PreparedTransaction;
@@ -98,7 +94,6 @@ export interface CreateWalletResult {
 }
 
 export interface SponsorSignedTransactionArgs {
-  intentId?: string;
   transaction: string;
   transactionEncoding?: TransactionEncoding;
   network?: Network;
@@ -107,14 +102,11 @@ export interface SponsorSignedTransactionArgs {
 }
 
 export interface SubmittedTransaction {
-  intentId?: string;
   signature: string;
   status?: 'submitted' | 'confirmed';
 }
 
 export interface SubmittedTransactionWire {
-  intent_id?: string;
-  intentId?: string;
   signature?: string;
   status?: 'submitted' | 'confirmed';
 }

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -197,7 +197,6 @@ describe('WalletsClient', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_create_123',
           network: 'NETWORK_DEVNET',
           wallet: {
             swigConfigAddress: 'swig_config_123',
@@ -205,7 +204,6 @@ describe('WalletsClient', () => {
           },
           transactions: [
             {
-              intentId: 'intent_create_123',
               transaction: 'base64-create-tx',
               transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
               network: 'NETWORK_DEVNET',
@@ -236,7 +234,6 @@ describe('WalletsClient', () => {
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
     expect(wallet.creationTransactions).toHaveLength(1);
     expect(wallet.creationTransaction).toMatchObject({
-      intentId: 'intent_create_123',
       transaction: 'base64-create-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
@@ -254,7 +251,6 @@ describe('WalletsClient', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_create_456',
           network: 'NETWORK_DEVNET',
           wallet: {
             swigConfigAddress: 'swig_config_456',
@@ -262,7 +258,6 @@ describe('WalletsClient', () => {
           },
           transactions: [
             {
-              intentId: 'intent_create_456',
               transaction: 'base64-create-tx',
               transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
               network: 'NETWORK_DEVNET',
@@ -307,7 +302,6 @@ describe('WalletsClient', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_transfer_123',
           transaction: 'base64-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -345,7 +339,6 @@ describe('WalletsClient', () => {
       },
     });
     expect(prepared).toMatchObject({
-      intentId: 'intent_transfer_123',
       transaction: 'base64-transfer-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
@@ -362,7 +355,6 @@ describe('WalletsClient', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_token_transfer_123',
           transaction: 'base64-token-transfer-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -396,7 +388,6 @@ describe('WalletsClient', () => {
       },
     });
     expect(prepared).toMatchObject({
-      intentId: 'intent_token_transfer_123',
       transaction: 'base64-token-transfer-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
@@ -412,7 +403,6 @@ describe('WalletsClient', () => {
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
-          intentId: 'intent_swap_123',
           transaction: 'base64-swap-tx',
           transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
           network: 'NETWORK_DEVNET',
@@ -454,7 +444,6 @@ describe('WalletsClient', () => {
       },
     });
     expect(prepared).toMatchObject({
-      intentId: 'intent_swap_123',
       transaction: 'base64-swap-tx',
       transactionEncoding: 'base64',
       network: 'devnet',

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -12,14 +12,12 @@ describe('wallet normalizers', () => {
   test('normalizes snake_case prepared transaction responses', () => {
     expect(
       normalizePreparedTransaction({
-        intent_id: 'intent_123',
         unsigned_transaction: 'base64-tx',
         transaction_encoding: 'TRANSACTION_ENCODING_BASE64',
         network: 'NETWORK_DEVNET',
         recent_blockhash: 'blockhash_123',
       }),
     ).toEqual({
-      intentId: 'intent_123',
       transaction: 'base64-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
@@ -30,20 +28,17 @@ describe('wallet normalizers', () => {
   test('normalizes create wallet responses with multiple prepared transactions', () => {
     expect(
       normalizeCreateWalletResponse({
-        intentId: 'intent_create_123',
         wallet: {
           swigConfigAddress: 'swig_config_123',
           walletAddress: 'wallet_123',
         },
         transactions: [
           {
-            intentId: 'intent_create_123',
             transaction: 'base64-create-tx',
             transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
             kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
           },
           {
-            intentId: 'intent_create_123',
             transaction: 'base64-add-authority-tx',
             transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
             kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
@@ -60,13 +55,11 @@ describe('wallet normalizers', () => {
         network: 'NETWORK_DEVNET',
       }),
     ).toEqual({
-      intentId: 'intent_create_123',
       wallet: {
         swigConfigAddress: 'swig_config_123',
         walletAddress: 'wallet_123',
       },
       creationTransaction: {
-        intentId: 'intent_create_123',
         transaction: 'base64-create-tx',
         transactionEncoding: 'base64',
         kind: 'create-swig-wallet',
@@ -74,14 +67,12 @@ describe('wallet normalizers', () => {
       },
       transactions: [
         {
-          intentId: 'intent_create_123',
           transaction: 'base64-create-tx',
           transactionEncoding: 'base64',
           kind: 'create-swig-wallet',
           network: 'devnet',
         },
         {
-          intentId: 'intent_create_123',
           transaction: 'base64-add-authority-tx',
           transactionEncoding: 'base64',
           kind: 'add-authority',
@@ -128,12 +119,10 @@ describe('wallet normalizers', () => {
   test('normalizes sponsored submission responses', () => {
     expect(
       normalizeSubmittedTransaction({
-        intent_id: 'intent_123',
         signature: 'signature_123',
         status: 'submitted',
       }),
     ).toEqual({
-      intentId: 'intent_123',
       signature: 'signature_123',
       status: 'submitted',
     });

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -21,11 +21,6 @@ import type {
 export function normalizePreparedTransaction(
   response: PreparedTransactionWire,
 ): PreparedTransaction {
-  const intentId = response.intentId ?? response.intent_id;
-  if (!intentId) {
-    throw new Error('Backend response is missing intent_id');
-  }
-
   const transaction =
     response.transaction ??
     response.unsignedTransaction ??
@@ -35,7 +30,6 @@ export function normalizePreparedTransaction(
   }
 
   return {
-    intentId,
     wallet: response.wallet,
     transaction,
     transactionEncoding: normalizeTransactionEncoding(
@@ -51,14 +45,11 @@ export function normalizePreparedTransaction(
 export function normalizeCreateWalletResponse(
   response: CreateWalletResponseWire,
 ): CreateWalletResult {
-  const topLevelIntentId = response.intentId ?? response.intent_id;
   const topLevelNetwork = normalizeNetwork(response.network);
   const transactions = Array.isArray(response.transactions)
     ? response.transactions.map((transaction) =>
         normalizePreparedTransaction({
           ...transaction,
-          intentId:
-            transaction.intentId ?? transaction.intent_id ?? topLevelIntentId,
           network: transaction.network ?? response.network,
         }),
       )
@@ -68,17 +59,12 @@ export function normalizeCreateWalletResponse(
       (transaction) => transaction.kind === 'create-swig-wallet',
     ) ?? transactions[0];
   const wallet = response.wallet ?? creationTransaction?.wallet;
-  const intentId = topLevelIntentId ?? creationTransaction?.intentId;
 
-  if (!intentId) {
-    throw new Error('Create wallet response is missing intent_id');
-  }
   if (!wallet) {
     throw new Error('Create wallet response is missing wallet');
   }
 
   return {
-    intentId,
     wallet,
     transactions,
     creationTransaction,
@@ -97,7 +83,6 @@ export function normalizeSubmittedTransaction(
   }
 
   return {
-    intentId: response.intentId ?? response.intent_id,
     signature: response.signature,
     status: response.status,
   };


### PR DESCRIPTION
## Summary
- remove internal intent IDs from developer SDK prepared/create/sponsor/submission types
- stop forwarding intent IDs through sponsor requests and signing helpers
- update developer SDK tests/smoke logs and add a changeset for publish

## Tests
- bun --filter "@swig-wallet/developer-sdk" typecheck
- bun --filter "@swig-wallet/developer-sdk" test
- bun --filter "@swig-wallet/developer-sdk" lint
- bun --filter "@swig-wallet/developer-sdk" build
- git diff --check