### PR TITLE
Make wallet create return explicit transaction groups

### DIFF
--- a/.changeset/explicit-create-transactions.md
+++ b/.changeset/explicit-create-transactions.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Return explicit ordered wallet creation transactions plus client-authority and operator-signed transaction buckets from wallet creation.

--- a/.changeset/explicit-create-transactions.md
+++ b/.changeset/explicit-create-transactions.md
@@ -2,4 +2,4 @@
 '@swig-wallet/developer-sdk': minor
 ---
 
-Return explicit ordered wallet creation transactions plus client-authority and operator-signed transaction buckets from wallet creation.
+Return explicit ordered wallet creation transactions, expose per-transaction signature requests, and use requesterAuthority across create, transfer, token transfer, and swap preparation.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -10,9 +10,9 @@ The SDK is prepare-first:
 1. Your server creates a `SwigClient` with an API key.
 2. Your server prepares a wallet operation and receives one or more unsigned
    transactions.
-3. Your client signs the prepared transaction locally.
-4. Your app either sends the signed transaction directly or submits it to a
-   backend sponsor endpoint.
+3. Your client signs any transactions that require client authority.
+4. Your app submits the ordered transactions directly or through a backend
+   sponsor endpoint.
 
 ## Framework Proxy Routes
 
@@ -53,18 +53,15 @@ const swig = new SwigClient({
 ### Create Wallet
 
 ```typescript
-const wallet = await swig.wallets.create({
+const created = await swig.wallets.create({
   feePayer,
   policyId,
 });
 
-const preparedCreate = wallet.creationTransaction;
-
-if (!preparedCreate) {
-  throw new Error('Wallet creation response did not include a transaction');
-}
-
-return preparedCreate;
+return {
+  wallet: created.wallet,
+  transactions: created.transactions,
+};
 ```
 
 If `policyId` is omitted, the backend can create a no-recovery policy from an
@@ -72,7 +69,7 @@ inline `initialUser`. For a passkey initial user, provide the secp256r1 public
 key:
 
 ```typescript
-const wallet = await swig.wallets.create({
+const created = await swig.wallets.create({
   feePayer,
   initialUser: {
     secp256r1: {
@@ -81,11 +78,22 @@ const wallet = await swig.wallets.create({
   },
 });
 
-return wallet.creationTransaction;
+return {
+  wallet: created.wallet,
+  transactions: created.transactions,
+  clientAuthorityTransactions: created.clientAuthorityTransactions,
+  operatorSignedTransactions: created.operatorSignedTransactions,
+  feePayerOnlyTransactions: created.feePayerOnlyTransactions,
+  addAuthorityChallenge: created.addAuthorityChallenge,
+};
 ```
 
-Wallet creation can return multiple prepared transactions when policy setup
-requires additional work, such as add-authority or recovery configuration.
+Wallet creation returns `transactions` in the order they should be submitted.
+For recovery-enabled create flows, the create transaction is fee-payer only, the
+add-authority transaction is signed by the initial user, and the
+configure-recovery transaction is signed by the backend recovery operator before
+it is returned. Submit each transaction in order after applying any required
+client authority signature.
 
 ### Prepare Transfer
 
@@ -176,6 +184,11 @@ SDK stops at producing the signed prepared transaction payload.
 `signPreparedSwigTransaction` is intentionally app-provided for now. It should
 wrap the Swig passkey transaction signing flow for the specific transaction
 format returned by the backend.
+
+For wallet creation, sign only `created.clientAuthorityTransactions` on the
+client. Do not passkey-sign `created.operatorSignedTransactions`; those already
+include the backend recovery operator signature and only need the final
+fee-payer or sponsor signature before submission.
 
 ## Public Entrypoints
 

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -55,12 +55,17 @@ const swig = new SwigClient({
 ```typescript
 const created = await swig.wallets.create({
   feePayer,
-  policyId,
+  initialUser: {
+    ed25519: {
+      publicKey: userPublicKey,
+    },
+  },
 });
 
 return {
   wallet: created.wallet,
   transactions: created.transactions,
+  transactionsToSign: created.clientAuthorityTransactions,
 };
 ```
 
@@ -84,7 +89,6 @@ return {
   clientAuthorityTransactions: created.clientAuthorityTransactions,
   operatorSignedTransactions: created.operatorSignedTransactions,
   feePayerOnlyTransactions: created.feePayerOnlyTransactions,
-  addAuthorityChallenge: created.addAuthorityChallenge,
 };
 ```
 
@@ -93,20 +97,24 @@ For recovery-enabled create flows, the create transaction is fee-payer only, the
 add-authority transaction is signed by the initial user, and the
 configure-recovery transaction is signed by the backend recovery operator before
 it is returned. Submit each transaction in order after applying any required
-client authority signature.
+client authority signature. A prepared transaction needs a client authority
+signature when `signatureRequests.length > 0`.
 
-### Prepare Transfer
+### Prepare SOL Transfer
 
 ```typescript
 const wallet = swig.wallets.use({
   swigConfigAddress,
   walletAddress,
-  requesterPubkey,
+  requesterAuthority: {
+    ed25519: {
+      publicKey: userPublicKey,
+    },
+  },
 });
 
 const preparedTransfer = await wallet.transfer.sol({
   feePayer,
-  requesterPubkey,
   destination,
   amount: 1_000_000n,
 });
@@ -114,13 +122,14 @@ const preparedTransfer = await wallet.transfer.sol({
 return preparedTransfer;
 ```
 
+### Prepare Token Transfer
+
 Token transfers derive backend-only fields such as token program, source ATA,
 destination ATA, and destination ATA creation:
 
 ```typescript
 const preparedTokenTransfer = await wallet.transfer.token({
   feePayer,
-  requesterPubkey,
   mint,
   destinationOwner,
   amount: 10_000n,
@@ -134,7 +143,6 @@ return preparedTokenTransfer;
 ```typescript
 const preparedSwap = await wallet.swap.jupiter({
   feePayer,
-  requesterPubkey,
   inputMint: 'So11111111111111111111111111111111111111112',
   outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
   amount: 10_000n,
@@ -150,7 +158,35 @@ return preparedSwap;
 Client code should only sign prepared transactions. It should not hold the API
 key or call the Swig backend directly.
 
-### Prepared Transaction Signing
+### Solana Transaction Signing
+
+Use this for prepared transactions whose requester authority is Ed25519.
+
+```typescript
+import {
+  signPreparedTransaction,
+  type PreparedTransaction,
+} from '@swig-wallet/developer-sdk/client';
+import { VersionedTransaction } from '@solana/web3.js';
+
+declare const prepared: PreparedTransaction;
+
+const signed = await signPreparedTransaction(prepared, {
+  signTransaction: async (transaction) => {
+    const versioned = VersionedTransaction.deserialize(
+      Buffer.from(transaction.transaction, 'base64'),
+    );
+    versioned.sign([userKeypair]);
+    return Buffer.from(versioned.serialize()).toString('base64');
+  },
+});
+```
+
+### Passkey Transaction Signing
+
+Use this for any prepared transaction whose `signatureRequests` contains a
+`secp256r1` request. The same pattern applies to create, transfer, token
+transfer, and swap.
 
 ```typescript
 import {
@@ -171,10 +207,15 @@ const passkeySigningFn = createSecp256r1PasskeySigningFn({
 //   response.json(),
 // );
 declare const prepared: PreparedTransaction;
+const [signatureRequest] = prepared.signatureRequests;
 
 const signed = await signPreparedTransaction(prepared, {
   signTransaction: (transaction) =>
-    signPreparedSwigTransaction(transaction, passkeySigningFn),
+    signPreparedSwigTransaction(
+      transaction,
+      signatureRequest,
+      passkeySigningFn,
+    ),
 });
 ```
 
@@ -186,8 +227,8 @@ wrap the Swig passkey transaction signing flow for the specific transaction
 format returned by the backend.
 
 For wallet creation, sign only `created.clientAuthorityTransactions` on the
-client. Do not passkey-sign `created.operatorSignedTransactions`; those already
-include the backend recovery operator signature and only need the final
+client. Do not authority-sign `created.operatorSignedTransactions`; those
+already include the backend recovery operator signature and only need the final
 fee-payer or sponsor signature before submission.
 
 ## Public Entrypoints

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -64,7 +64,9 @@ async function main() {
     },
   });
   const wallet = swig.wallets.use(created.wallet, {
-    requesterPubkey: requester.publicKey.toBase58(),
+    requesterAuthority: {
+      ed25519: { publicKey: requester.publicKey.toBase58() },
+    },
   });
   const createTransaction = requirePrepared(created.creationTransaction);
   console.log(`swig config: ${created.wallet.swigConfigAddress}`);
@@ -88,7 +90,9 @@ async function main() {
 
   const transferTransaction = await wallet.transfer.sol({
     feePayer: feePayer.publicKey.toBase58(),
-    requesterPubkey: requester.publicKey.toBase58(),
+    requesterAuthority: {
+      ed25519: { publicKey: requester.publicKey.toBase58() },
+    },
     destination: destination.publicKey.toBase58(),
     amount: 1_000,
   });
@@ -105,7 +109,9 @@ async function main() {
 
   const swapTransaction = await wallet.swap.jupiter({
     feePayer: feePayer.publicKey.toBase58(),
-    requesterPubkey: requester.publicKey.toBase58(),
+    requesterAuthority: {
+      ed25519: { publicKey: requester.publicKey.toBase58() },
+    },
     inputMint: solMint,
     outputMint: usdcMint,
     amount: swapAmountLamports,
@@ -129,7 +135,9 @@ async function main() {
     apiKey,
     transactionApiUrl: apiBaseUrl,
     feePayer: feePayer.publicKey.toBase58(),
-    resolveRequesterPubkey: () => requester.publicKey.toBase58(),
+    resolveRequesterAuthority: () => ({
+      ed25519: { publicKey: requester.publicKey.toBase58() },
+    }),
   });
   const nestTransferTransaction = await prepareWithNest(nestHandler, {
     route: '/swig/transfer/sol',

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -55,7 +55,7 @@ async function main() {
   console.log(`fee payer: ${feePayer.publicKey.toBase58()}`);
   console.log(`requester: ${requester.publicKey.toBase58()}`);
 
-  const wallet = await swig.wallets.create({
+  const created = await swig.wallets.create({
     feePayer: feePayer.publicKey.toBase58(),
     initialUser: {
       ed25519: {
@@ -63,9 +63,12 @@ async function main() {
       },
     },
   });
-  const createTransaction = requirePrepared(wallet.creationTransaction);
-  console.log(`swig config: ${wallet.swigConfigAddress}`);
-  console.log(`wallet: ${requireWalletAddress(wallet.walletAddress)}`);
+  const wallet = swig.wallets.use(created.wallet, {
+    requesterPubkey: requester.publicKey.toBase58(),
+  });
+  const createTransaction = requirePrepared(created.creationTransaction);
+  console.log(`swig config: ${created.wallet.swigConfigAddress}`);
+  console.log(`wallet: ${requireWalletAddress(created.wallet.walletAddress)}`);
 
   const createSignature = await signAndSendPreparedTransaction(
     connection,
@@ -73,10 +76,13 @@ async function main() {
     [feePayer],
   );
   console.log(`create signature: ${createSignature}`);
-  await waitForAccount(connection, new PublicKey(wallet.swigConfigAddress));
+  await waitForAccount(
+    connection,
+    new PublicKey(created.wallet.swigConfigAddress),
+  );
   await airdropIfNeeded(
     connection,
-    new PublicKey(requireWalletAddress(wallet.walletAddress)),
+    new PublicKey(requireWalletAddress(created.wallet.walletAddress)),
     LAMPORTS_PER_SOL / 10,
   );
 

--- a/packages/developer-sdk/src/client/index.test.ts
+++ b/packages/developer-sdk/src/client/index.test.ts
@@ -7,6 +7,7 @@ const prepared: PreparedTransaction = {
   transaction: 'base64-prepared-tx',
   transactionEncoding: 'base64',
   network: 'devnet',
+  signatureRequests: [],
 };
 
 describe('client signing helpers', () => {

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -7,6 +7,7 @@ export type {
   Amount,
   CreateWalletArgs,
   CreateWalletResponse,
+  CreateWalletResult,
   ExecuteArgs,
   IdpWalletSession,
   JsonObject,

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -86,6 +86,16 @@ describe('createSwigFetchHandler', () => {
             kind: 'create-swig-wallet',
           },
         ],
+        clientAuthorityTransactions: [],
+        operatorSignedTransactions: [],
+        feePayerOnlyTransactions: [
+          {
+            transaction: 'base64-create-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+            kind: 'create-swig-wallet',
+          },
+        ],
         creationTransaction: {
           transaction: 'base64-create-tx',
           transactionEncoding: 'base64',

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -71,7 +71,7 @@ describe('createSwigFetchHandler', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
+    expect(await response.json()).toMatchObject({
       prepared: {
         wallet: {
           swigConfigAddress: 'swig_config_123',
@@ -196,9 +196,10 @@ describe('createSwigFetchHandler', () => {
           wallet: {
             swigConfigAddress: 'swig_config_123',
             walletAddress: 'wallet_123',
-            requesterPubkey: 'requester_123',
+            requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
           },
           network: 'devnet',
+          feePayer: 'payer_123',
           destination: 'destination_123',
           amount: '42',
         }),
@@ -206,7 +207,7 @@ describe('createSwigFetchHandler', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
+    expect(await response.json()).toMatchObject({
       prepared: {
         transaction: 'base64-transfer-tx',
         transactionEncoding: 'base64',
@@ -220,9 +221,9 @@ describe('createSwigFetchHandler', () => {
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',
-        feePayer: 'requester_123',
+        feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         destination: 'destination_123',
         lamports: '42',
       },
@@ -236,7 +237,9 @@ describe('createSwigFetchHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       feePayer: 'payer_123',
-      resolveRequesterPubkey: () => 'requester_123',
+      resolveRequesterAuthority: () => ({
+        ed25519: { publicKey: 'requester_123' },
+      }),
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
@@ -262,7 +265,7 @@ describe('createSwigFetchHandler', () => {
 
     expect(calls[0]?.body).toMatchObject({
       feePayer: 'payer_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
   });
 
@@ -272,7 +275,9 @@ describe('createSwigFetchHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       feePayer: 'payer_123',
-      resolveRequesterPubkey: () => 'requester_123',
+      resolveRequesterAuthority: () => ({
+        ed25519: { publicKey: 'requester_123' },
+      }),
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
@@ -300,7 +305,7 @@ describe('createSwigFetchHandler', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
+    expect(await response.json()).toMatchObject({
       prepared: {
         transaction: 'base64-token-transfer-tx',
         transactionEncoding: 'base64',
@@ -313,7 +318,7 @@ describe('createSwigFetchHandler', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         mint: 'mint_123',
         destinationOwner: 'owner_123',
         amount: '42',
@@ -327,7 +332,9 @@ describe('createSwigFetchHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       feePayer: 'payer_123',
-      resolveRequesterPubkey: () => 'requester_123',
+      resolveRequesterAuthority: () => ({
+        ed25519: { publicKey: 'requester_123' },
+      }),
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
@@ -359,7 +366,7 @@ describe('createSwigFetchHandler', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
+    expect(await response.json()).toMatchObject({
       prepared: {
         transaction: 'base64-swap-tx',
         transactionEncoding: 'base64',
@@ -372,7 +379,7 @@ describe('createSwigFetchHandler', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         inputMint: 'So11111111111111111111111111111111111111112',
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         amount: '42',

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -141,29 +141,30 @@ async function prepareWalletCreation(
       ? { idempotencyKey: readOptionalString(body, 'idempotencyKey') }
       : {}),
   };
-  const wallet = await swig.wallets.create(args);
+  const created = await swig.wallets.create(args);
 
-  if (!wallet.creationTransaction) {
+  if (created.transactions.length === 0) {
     throw new SwigRouteError(
       'Wallet creation response is missing transaction',
       502,
     );
   }
 
-  return createWalletResult(wallet);
+  return createWalletResult(created);
 }
 
 function createWalletResult(
   wallet: Awaited<ReturnType<SwigClient['wallets']['create']>>,
 ) {
   return {
-    wallet: {
-      swigConfigAddress: wallet.swigConfigAddress,
-      walletAddress: wallet.walletAddress,
-      network: wallet.network,
-    },
-    transactions: wallet.creationTransactions,
+    wallet: wallet.wallet,
+    transactions: wallet.transactions,
+    clientAuthorityTransactions: wallet.clientAuthorityTransactions,
+    operatorSignedTransactions: wallet.operatorSignedTransactions,
+    feePayerOnlyTransactions: wallet.feePayerOnlyTransactions,
     creationTransaction: wallet.creationTransaction,
+    addAuthorityTransaction: wallet.addAuthorityTransaction,
+    configureRecoveryTransaction: wallet.configureRecoveryTransaction,
     addAuthorityChallenge: wallet.addAuthorityChallenge,
     network: wallet.network,
   };

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -4,6 +4,7 @@ import type {
   Network,
   SwapArgs,
   TransferTokenArgs,
+  WalletAuthority,
   WalletReference,
 } from '../../types/index.js';
 import { SwigClient } from '../typescript/index.js';
@@ -33,9 +34,9 @@ export interface CreateSwigFetchHandlerConfig {
   feePayer?:
     | string
     | ((context: SwigRouteContext) => MaybePromise<string | undefined>);
-  resolveRequesterPubkey?: (
+  resolveRequesterAuthority?: (
     context: SwigRouteContext,
-  ) => MaybePromise<string | undefined>;
+  ) => MaybePromise<WalletAuthority | undefined>;
   fetch?: typeof fetch;
 }
 
@@ -165,7 +166,6 @@ function createWalletResult(
     creationTransaction: wallet.creationTransaction,
     addAuthorityTransaction: wallet.addAuthorityTransaction,
     configureRecoveryTransaction: wallet.configureRecoveryTransaction,
-    addAuthorityChallenge: wallet.addAuthorityChallenge,
     network: wallet.network,
   };
 }
@@ -177,19 +177,19 @@ async function prepareSolTransfer(
   config: CreateSwigFetchHandlerConfig,
 ) {
   const wallet = requireWallet(context.wallet);
-  const requesterPubkey = await resolveRequesterPubkey(context, config);
-  const feePayer = await resolveFeePayer(context, config, requesterPubkey);
+  const requesterAuthority = await resolveRequesterAuthority(context, config);
+  const feePayer = await resolveFeePayer(context, config);
   const handle = swig.wallets.use(
     {
       ...wallet,
-      requesterPubkey,
+      requesterAuthority,
     },
     { network: context.network },
   );
 
   return handle.transfer({
     feePayer,
-    requesterPubkey,
+    requesterAuthority,
     destination: readRequiredString(body, 'destination'),
     amount: readAmount(body),
     ...(context.network ? { network: context.network } : {}),
@@ -206,18 +206,18 @@ async function prepareTokenTransfer(
   config: CreateSwigFetchHandlerConfig,
 ) {
   const wallet = requireWallet(context.wallet);
-  const requesterPubkey = await resolveRequesterPubkey(context, config);
-  const feePayer = await resolveFeePayer(context, config, requesterPubkey);
+  const requesterAuthority = await resolveRequesterAuthority(context, config);
+  const feePayer = await resolveFeePayer(context, config);
   const handle = swig.wallets.use(
     {
       ...wallet,
-      requesterPubkey,
+      requesterAuthority,
     },
     { network: context.network },
   );
   const args: TransferTokenArgs = {
     feePayer,
-    requesterPubkey,
+    requesterAuthority,
     mint: readRequiredString(body, 'mint'),
     destinationOwner: readRequiredString(body, 'destinationOwner'),
     amount: readAmount(body),
@@ -237,18 +237,18 @@ async function prepareJupiterSwap(
   config: CreateSwigFetchHandlerConfig,
 ) {
   const wallet = requireWallet(context.wallet);
-  const requesterPubkey = await resolveRequesterPubkey(context, config);
-  const feePayer = await resolveFeePayer(context, config, requesterPubkey);
+  const requesterAuthority = await resolveRequesterAuthority(context, config);
+  const feePayer = await resolveFeePayer(context, config);
   const handle = swig.wallets.use(
     {
       ...wallet,
-      requesterPubkey,
+      requesterAuthority,
     },
     { network: context.network },
   );
   const args: SwapArgs = {
     feePayer,
-    requesterPubkey,
+    requesterAuthority,
     inputMint: readRequiredString(body, 'inputMint'),
     outputMint: readRequiredString(body, 'outputMint'),
     amount: readAmount(body),
@@ -308,27 +308,28 @@ async function prepareJupiterSwap(
   return handle.swap(args);
 }
 
-async function resolveRequesterPubkey(
+async function resolveRequesterAuthority(
   context: SwigRouteContext,
   config: CreateSwigFetchHandlerConfig,
-): Promise<string> {
-  const requesterPubkey =
-    context.wallet?.requesterPubkey ??
-    readOptionalString(context.body, 'requesterPubkey') ??
-    (await config.resolveRequesterPubkey?.(context)) ??
-    readEnv('SWIG_REQUESTER_PUBKEY', 'SWIG_AUTHORITY_PUBLIC_KEY');
+): Promise<WalletAuthority> {
+  const requesterAuthority =
+    context.wallet?.requesterAuthority ??
+    readWalletAuthority(
+      context.body.requesterAuthority,
+      'requesterAuthority',
+    ) ??
+    (await config.resolveRequesterAuthority?.(context));
 
-  if (!requesterPubkey) {
-    throw new SwigRouteError('requesterPubkey is required');
+  if (!requesterAuthority) {
+    throw new SwigRouteError('requesterAuthority is required');
   }
 
-  return requesterPubkey;
+  return requesterAuthority;
 }
 
 async function resolveFeePayer(
   context: SwigRouteContext,
   config: CreateSwigFetchHandlerConfig,
-  requesterPubkey?: string,
 ): Promise<string> {
   const configuredFeePayer =
     typeof config.feePayer === 'function'
@@ -341,8 +342,7 @@ async function resolveFeePayer(
       'SWIG_FEE_PAYER',
       'SWIG_TRANSFER_FEE_PAYER',
       'SWIG_TRANSACTION_FEE_PAYER',
-    ) ??
-    requesterPubkey;
+    );
 
   if (!feePayer) {
     throw new SwigRouteError('feePayer is required');
@@ -407,17 +407,23 @@ function readWallet(value: unknown): WalletReference | undefined {
   return {
     swigConfigAddress: readRequiredString(value, 'swigConfigAddress'),
     walletAddress: readOptionalString(value, 'walletAddress'),
-    requesterPubkey: readOptionalString(value, 'requesterPubkey'),
+    requesterAuthority: readWalletAuthority(
+      value.requesterAuthority,
+      'wallet.requesterAuthority',
+    ),
     network: readNetwork(value.network),
   };
 }
 
-function readWalletAuthority(value: unknown): CreateWalletArgs['initialUser'] {
+function readWalletAuthority(
+  value: unknown,
+  field = 'initialUser',
+): WalletAuthority | undefined {
   if (value === undefined) {
     return undefined;
   }
   if (!isRecord(value)) {
-    throw new SwigRouteError('initialUser must be an object');
+    throw new SwigRouteError(`${field} must be an object`);
   }
   for (const scheme of ['ed25519', 'secp256k1', 'secp256r1'] as const) {
     const authority = value[scheme];
@@ -426,10 +432,10 @@ function readWalletAuthority(value: unknown): CreateWalletArgs['initialUser'] {
     }
     const publicKey = readOptionalString(authority, 'publicKey');
     if (publicKey) {
-      return { [scheme]: { publicKey } } as CreateWalletArgs['initialUser'];
+      return { [scheme]: { publicKey } } as WalletAuthority;
     }
   }
-  throw new SwigRouteError('initialUser must include a supported authority');
+  throw new SwigRouteError(`${field} must include a supported authority`);
 }
 
 function requireWallet(wallet: WalletReference | undefined): WalletReference {

--- a/packages/developer-sdk/src/server/index.ts
+++ b/packages/developer-sdk/src/server/index.ts
@@ -10,6 +10,7 @@ export type {
   Amount,
   CreateWalletArgs,
   CreateWalletResponse,
+  CreateWalletResult,
   ExecuteArgs,
   IdpWalletSession,
   JsonObject,

--- a/packages/developer-sdk/src/server/nest/index.test.ts
+++ b/packages/developer-sdk/src/server/nest/index.test.ts
@@ -78,9 +78,10 @@ describe('createSwigNestHandler', () => {
         body: {
           wallet: {
             swigConfigAddress: 'swig_config_123',
-            requesterPubkey: 'requester_123',
+            requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
           },
           network: 'devnet',
+          feePayer: 'payer_123',
           destination: 'destination_123',
           amount: '42',
         },
@@ -96,7 +97,7 @@ describe('createSwigNestHandler', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/json');
-    expect(JSON.parse(response.body ?? '{}')).toEqual({
+    expect(JSON.parse(response.body ?? '{}')).toMatchObject({
       prepared: {
         transaction: 'base64-transfer-tx',
         transactionEncoding: 'base64',
@@ -109,9 +110,9 @@ describe('createSwigNestHandler', () => {
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',
-        feePayer: 'requester_123',
+        feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         destination: 'destination_123',
         lamports: '42',
       },
@@ -125,7 +126,9 @@ describe('createSwigNestHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       feePayer: 'payer_123',
-      resolveRequesterPubkey: () => 'requester_123',
+      resolveRequesterAuthority: () => ({
+        ed25519: { publicKey: 'requester_123' },
+      }),
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
@@ -162,7 +165,7 @@ describe('createSwigNestHandler', () => {
     );
 
     expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response.body ?? '{}')).toEqual({
+    expect(JSON.parse(response.body ?? '{}')).toMatchObject({
       prepared: {
         transaction: 'base64-swap-tx',
         transactionEncoding: 'base64',
@@ -176,7 +179,7 @@ describe('createSwigNestHandler', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         inputMint: 'So11111111111111111111111111111111111111112',
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         amount: '42',

--- a/packages/developer-sdk/src/server/next/index.test.ts
+++ b/packages/developer-sdk/src/server/next/index.test.ts
@@ -23,9 +23,10 @@ describe('createSwigRouteHandlers', () => {
         body: JSON.stringify({
           wallet: {
             swigConfigAddress: 'swig_config_123',
-            requesterPubkey: 'requester_123',
+            requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
           },
           network: 'devnet',
+          feePayer: 'payer_123',
           destination: 'destination_123',
           amount: '42',
         }),

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -38,6 +38,7 @@ export interface PreparedTransaction {
   network?: Network;
   recentBlockhash?: string;
   kind?: PreparedTransactionKind;
+  signatureRequests: ClientSignatureRequest[];
 }
 
 export interface PreparedTransactionWire {
@@ -53,10 +54,11 @@ export interface PreparedTransactionWire {
   recent_blockhash?: string;
   recentBlockhash?: string;
   kind?: PreparedTransactionKindWire;
+  signature_requests?: ClientSignatureRequestWire[];
+  signatureRequests?: ClientSignatureRequestWire[];
 }
 
-export interface AddAuthorityChallenge {
-  transactionIndex: number;
+export interface ClientSignatureRequest {
   scheme: 'secp256r1' | 'secp256k1';
   signer: string;
   messageHash: string;
@@ -64,9 +66,7 @@ export interface AddAuthorityChallenge {
   counter: number;
 }
 
-export interface AddAuthorityChallengeWire {
-  transaction_index?: number;
-  transactionIndex?: number;
+export interface ClientSignatureRequestWire {
   scheme?:
     | 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1'
     | 'AUTHORITY_SIGNATURE_SCHEME_SECP256K1'
@@ -81,8 +81,6 @@ export interface AddAuthorityChallengeWire {
 export interface CreateWalletResponseWire extends PreparedTransactionWire {
   wallet?: WalletAddressInfo;
   transactions?: PreparedTransactionWire[];
-  add_authority_challenge?: AddAuthorityChallengeWire;
-  addAuthorityChallenge?: AddAuthorityChallengeWire;
 }
 
 export interface CreateWalletResult {
@@ -94,7 +92,6 @@ export interface CreateWalletResult {
   creationTransaction?: PreparedTransaction;
   addAuthorityTransaction?: PreparedTransaction;
   configureRecoveryTransaction?: PreparedTransaction;
-  addAuthorityChallenge?: AddAuthorityChallenge;
   network?: Network;
 }
 

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -86,9 +86,14 @@ export interface CreateWalletResponseWire extends PreparedTransactionWire {
 }
 
 export interface CreateWalletResult {
-  wallet: WalletAddressInfo;
+  wallet: WalletAddressInfo & { network?: Network };
   transactions: PreparedTransaction[];
+  clientAuthorityTransactions: PreparedTransaction[];
+  operatorSignedTransactions: PreparedTransaction[];
+  feePayerOnlyTransactions: PreparedTransaction[];
   creationTransaction?: PreparedTransaction;
+  addAuthorityTransaction?: PreparedTransaction;
+  configureRecoveryTransaction?: PreparedTransaction;
   addAuthorityChallenge?: AddAuthorityChallenge;
   network?: Network;
 }

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -1,11 +1,6 @@
 import type { Amount, Network } from './common.js';
 import type { SolanaInstructionInput } from './instruction.js';
-import type {
-  AddAuthorityChallenge,
-  PreparedTransaction,
-  PreparedTransactionWire,
-} from './transaction.js';
-import type { WalletAddressInfo } from './wallet.js';
+import type { CreateWalletResult } from './transaction.js';
 
 export type WalletAuthority =
   | { ed25519: { publicKey: string } }
@@ -21,15 +16,7 @@ export interface CreateWalletArgs {
   idempotencyKey?: string;
 }
 
-export interface CreateWalletResponse
-  extends WalletAddressInfo, PreparedTransactionWire {
-  network?: Network;
-  label?: string;
-  externalId?: string;
-  transactions?: PreparedTransaction[];
-  creationTransaction?: PreparedTransaction;
-  addAuthorityChallenge?: AddAuthorityChallenge;
-}
+export type CreateWalletResponse = CreateWalletResult;
 
 export interface BaseTransferArgs {
   feePayer: string;

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -20,7 +20,7 @@ export type CreateWalletResponse = CreateWalletResult;
 
 export interface BaseTransferArgs {
   feePayer: string;
-  requesterPubkey?: string;
+  requesterAuthority?: WalletAuthority;
   amount: Amount;
   network?: Network;
   idempotencyKey?: string;
@@ -40,7 +40,7 @@ export type TransferArgs = TransferSolArgs | TransferTokenArgs;
 
 export interface SwapArgs {
   feePayer: string;
-  requesterPubkey?: string;
+  requesterAuthority?: WalletAuthority;
   inputMint: string;
   outputMint: string;
   amount: Amount;

--- a/packages/developer-sdk/src/types/wallet.ts
+++ b/packages/developer-sdk/src/types/wallet.ts
@@ -1,4 +1,5 @@
 import type { Network } from './common.js';
+import type { WalletAuthority } from './wallet-actions.js';
 
 export interface WalletAddressInfo {
   swigConfigAddress: string;
@@ -9,13 +10,13 @@ export interface WalletReference {
   swigConfigAddress: string;
   walletAddress?: string;
   network?: Network;
-  requesterPubkey?: string;
+  requesterAuthority?: WalletAuthority;
 }
 
 export interface IdpWalletSession {
   configAddress: string;
   walletAddress: string;
-  requesterPubkey?: string;
+  requesterAuthority?: WalletAuthority;
   authorityPublicKey?: string;
   /**
    * Deprecated. The transaction API resolves the requester's role on-chain.
@@ -25,5 +26,5 @@ export interface IdpWalletSession {
 
 export interface WalletHandleOptions {
   network?: Network;
-  requesterPubkey?: string;
+  requesterAuthority?: WalletAuthority;
 }

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -50,14 +50,16 @@ describe('WalletsClient', () => {
       {
         configAddress: 'swig_config_123',
         walletAddress: 'wallet_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
       },
       { network: 'devnet' },
     );
 
     expect(wallet.swigConfigAddress).toBe('swig_config_123');
     expect(wallet.walletAddress).toBe('wallet_123');
-    expect(wallet.requesterPubkey).toBe('requester_123');
+    expect(wallet.requesterAuthority).toEqual({
+      ed25519: { publicKey: 'requester_123' },
+    });
     expect(wallet.network).toBe('devnet');
   });
 
@@ -68,11 +70,13 @@ describe('WalletsClient', () => {
     );
 
     const wallet = wallets.use('swig_config_123', {
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     expect(wallet.swigConfigAddress).toBe('swig_config_123');
-    expect(wallet.requesterPubkey).toBe('requester_123');
+    expect(wallet.requesterAuthority).toEqual({
+      ed25519: { publicKey: 'requester_123' },
+    });
     expect(wallet.network).toBe('devnet');
   });
 
@@ -84,7 +88,7 @@ describe('WalletsClient', () => {
     const wallet = wallets.fromIdpSession({
       configAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     expect(
@@ -101,7 +105,7 @@ describe('WalletsClient', () => {
       network: 'NETWORK_MAINNET',
       feePayer: 'payer_123',
       swigAddress: 'swig_config_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
       destination: 'destination_123',
       lamports: '1000000',
     });
@@ -115,7 +119,7 @@ describe('WalletsClient', () => {
     const wallet = wallets.use({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     expect(
@@ -133,7 +137,7 @@ describe('WalletsClient', () => {
       network: 'NETWORK_DEVNET',
       feePayer: 'payer_123',
       swigAddress: 'swig_config_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
       mint: 'mint_123',
       destinationOwner: 'owner_123',
       amount: '2500',
@@ -148,7 +152,7 @@ describe('WalletsClient', () => {
     const wallet = wallets.use({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     expect(
@@ -172,7 +176,7 @@ describe('WalletsClient', () => {
       network: 'NETWORK_DEVNET',
       feePayer: 'payer_123',
       swigAddress: 'swig_config_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
       inputMint: 'input_mint_123',
       outputMint: 'output_mint_123',
       amount: '1000',
@@ -324,7 +328,7 @@ describe('WalletsClient', () => {
     const wallet = swig.wallets.use({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     const prepared = await wallet.transfer.sol({
@@ -341,7 +345,7 @@ describe('WalletsClient', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         destination: 'destination_123',
         lamports: '42',
       },
@@ -371,7 +375,7 @@ describe('WalletsClient', () => {
     });
     const wallet = swig.wallets.use({
       swigConfigAddress: 'swig_config_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     const prepared = await wallet.transfer.token({
@@ -389,7 +393,7 @@ describe('WalletsClient', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         mint: 'mint_123',
         destinationOwner: 'owner_123',
         amount: '42',
@@ -425,7 +429,7 @@ describe('WalletsClient', () => {
     const wallet = swig.wallets.use({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterPubkey: 'requester_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
     });
 
     const prepared = await wallet.swap.jupiter({
@@ -444,7 +448,7 @@ describe('WalletsClient', () => {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',
         swigAddress: 'swig_config_123',
-        requesterPubkey: 'requester_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
         inputMint: 'input_mint_123',
         outputMint: 'output_mint_123',
         amount: '42',

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -216,7 +216,7 @@ describe('WalletsClient', () => {
       }),
     });
 
-    const wallet = await swig.wallets.create({
+    const created = await swig.wallets.create({
       feePayer: 'payer_123',
       policyId: 'policy_123',
     });
@@ -232,14 +232,22 @@ describe('WalletsClient', () => {
       },
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
-    expect(wallet.creationTransactions).toHaveLength(1);
-    expect(wallet.creationTransaction).toMatchObject({
+    expect(created.wallet).toEqual({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      network: 'devnet',
+    });
+    expect(created.transactions).toHaveLength(1);
+    expect(created.creationTransaction).toMatchObject({
       transaction: 'base64-create-tx',
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_123',
       kind: 'create-swig-wallet',
     });
+    expect(created.feePayerOnlyTransactions).toHaveLength(1);
+    expect(created.clientAuthorityTransactions).toEqual([]);
+    expect(created.operatorSignedTransactions).toEqual([]);
   });
 
   test('prepares wallet creation without a policy id when an initial user is provided', async () => {

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -58,7 +58,7 @@ export class WalletsClient {
       return new WalletHandle(this, {
         swigConfigAddress: wallet,
         network: options.network ?? this.defaultNetwork,
-        requesterPubkey: options.requesterPubkey,
+        requesterAuthority: options.requesterAuthority,
       });
     }
 
@@ -66,7 +66,8 @@ export class WalletsClient {
       swigConfigAddress: wallet.swigConfigAddress,
       walletAddress: wallet.walletAddress,
       network: options.network ?? wallet.network ?? this.defaultNetwork,
-      requesterPubkey: options.requesterPubkey ?? wallet.requesterPubkey,
+      requesterAuthority:
+        options.requesterAuthority ?? wallet.requesterAuthority,
     });
   };
 
@@ -78,7 +79,8 @@ export class WalletsClient {
       swigConfigAddress: session.configAddress,
       walletAddress: session.walletAddress,
       network: options.network ?? this.defaultNetwork,
-      requesterPubkey: options.requesterPubkey ?? session.requesterPubkey,
+      requesterAuthority:
+        options.requesterAuthority ?? session.requesterAuthority,
     });
   };
 

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -2,6 +2,7 @@ import type { HttpClient } from '../core/index.js';
 import type {
   CreateWalletArgs,
   CreateWalletResponseWire,
+  CreateWalletResult,
   ExecuteArgs,
   IdpWalletSession,
   Network,
@@ -32,20 +33,21 @@ export class WalletsClient {
     private readonly defaultNetwork?: Network,
   ) {}
 
-  create = async (args: CreateWalletArgs): Promise<WalletHandle> => {
+  create = async (args: CreateWalletArgs): Promise<CreateWalletResult> => {
     const response = await this.http.post<CreateWalletResponseWire>(
       '/transaction/wallet/create',
       createWalletRequest(args, this.defaultNetwork),
     );
     const created = normalizeCreateWalletResponse(response);
 
-    return new WalletHandle(this, {
-      ...created.wallet,
+    return {
+      ...created,
+      wallet: {
+        ...created.wallet,
+        network: created.network ?? args.network ?? this.defaultNetwork,
+      },
       network: created.network ?? args.network ?? this.defaultNetwork,
-      creationTransaction: created.creationTransaction,
-      creationTransactions: created.transactions,
-      addAuthorityChallenge: created.addAuthorityChallenge,
-    });
+    };
   };
 
   use = (

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -1,5 +1,4 @@
 import type {
-  AddAuthorityChallenge,
   ExecuteArgs,
   Network,
   PreparedTransaction,
@@ -11,11 +10,7 @@ import type {
 } from '../types/index.js';
 import type { WalletsClient } from './client.js';
 
-export interface WalletHandleInit extends WalletReference {
-  creationTransaction?: PreparedTransaction;
-  creationTransactions?: PreparedTransaction[];
-  addAuthorityChallenge?: AddAuthorityChallenge;
-}
+export type WalletHandleInit = WalletReference;
 
 export type WalletTransferClient = {
   (args: TransferArgs): Promise<PreparedTransaction>;
@@ -34,9 +29,6 @@ export class WalletHandle {
   readonly walletAddress?: string;
   readonly network?: Network;
   readonly requesterPubkey?: string;
-  readonly creationTransaction?: PreparedTransaction;
-  readonly creationTransactions: PreparedTransaction[];
-  readonly addAuthorityChallenge?: AddAuthorityChallenge;
   readonly transfer: WalletTransferClient;
   readonly swap: WalletSwapClient;
 
@@ -48,11 +40,6 @@ export class WalletHandle {
     this.walletAddress = init.walletAddress;
     this.network = init.network;
     this.requesterPubkey = init.requesterPubkey;
-    this.creationTransaction = init.creationTransaction;
-    this.creationTransactions =
-      init.creationTransactions ??
-      (init.creationTransaction ? [init.creationTransaction] : []);
-    this.addAuthorityChallenge = init.addAuthorityChallenge;
     this.transfer = createWalletTransferClient(wallets, this);
     this.swap = createWalletSwapClient(wallets, this);
   }

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -28,7 +28,7 @@ export class WalletHandle {
   readonly swigConfigAddress: string;
   readonly walletAddress?: string;
   readonly network?: Network;
-  readonly requesterPubkey?: string;
+  readonly requesterAuthority?: WalletReference['requesterAuthority'];
   readonly transfer: WalletTransferClient;
   readonly swap: WalletSwapClient;
 
@@ -39,7 +39,7 @@ export class WalletHandle {
     this.swigConfigAddress = init.swigConfigAddress;
     this.walletAddress = init.walletAddress;
     this.network = init.network;
-    this.requesterPubkey = init.requesterPubkey;
+    this.requesterAuthority = init.requesterAuthority;
     this.transfer = createWalletTransferClient(wallets, this);
     this.swap = createWalletSwapClient(wallets, this);
   }

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -43,6 +43,11 @@ describe('wallet normalizers', () => {
             transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
             kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
           },
+          {
+            transaction: 'base64-configure-recovery-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            kind: 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY',
+          },
         ],
         addAuthorityChallenge: {
           transactionIndex: 1,
@@ -65,6 +70,18 @@ describe('wallet normalizers', () => {
         kind: 'create-swig-wallet',
         network: 'devnet',
       },
+      addAuthorityTransaction: {
+        transaction: 'base64-add-authority-tx',
+        transactionEncoding: 'base64',
+        kind: 'add-authority',
+        network: 'devnet',
+      },
+      configureRecoveryTransaction: {
+        transaction: 'base64-configure-recovery-tx',
+        transactionEncoding: 'base64',
+        kind: 'configure-recovery',
+        network: 'devnet',
+      },
       transactions: [
         {
           transaction: 'base64-create-tx',
@@ -76,6 +93,36 @@ describe('wallet normalizers', () => {
           transaction: 'base64-add-authority-tx',
           transactionEncoding: 'base64',
           kind: 'add-authority',
+          network: 'devnet',
+        },
+        {
+          transaction: 'base64-configure-recovery-tx',
+          transactionEncoding: 'base64',
+          kind: 'configure-recovery',
+          network: 'devnet',
+        },
+      ],
+      clientAuthorityTransactions: [
+        {
+          transaction: 'base64-add-authority-tx',
+          transactionEncoding: 'base64',
+          kind: 'add-authority',
+          network: 'devnet',
+        },
+      ],
+      operatorSignedTransactions: [
+        {
+          transaction: 'base64-configure-recovery-tx',
+          transactionEncoding: 'base64',
+          kind: 'configure-recovery',
+          network: 'devnet',
+        },
+      ],
+      feePayerOnlyTransactions: [
+        {
+          transaction: 'base64-create-tx',
+          transactionEncoding: 'base64',
+          kind: 'create-swig-wallet',
           network: 'devnet',
         },
       ],

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -22,6 +22,7 @@ describe('wallet normalizers', () => {
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_123',
+      signatureRequests: [],
     });
   });
 
@@ -42,6 +43,15 @@ describe('wallet normalizers', () => {
             transaction: 'base64-add-authority-tx',
             transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
             kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
+            signatureRequests: [
+              {
+                scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
+                signer: 'compressed-passkey',
+                messageHash: 'message-hash',
+                slot: '42',
+                counter: 1,
+              },
+            ],
           },
           {
             transaction: 'base64-configure-recovery-tx',
@@ -49,14 +59,6 @@ describe('wallet normalizers', () => {
             kind: 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY',
           },
         ],
-        addAuthorityChallenge: {
-          transactionIndex: 1,
-          scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
-          signer: 'compressed-passkey',
-          messageHash: 'message-hash',
-          slot: '42',
-          counter: 1,
-        },
         network: 'NETWORK_DEVNET',
       }),
     ).toEqual({
@@ -69,18 +71,29 @@ describe('wallet normalizers', () => {
         transactionEncoding: 'base64',
         kind: 'create-swig-wallet',
         network: 'devnet',
+        signatureRequests: [],
       },
       addAuthorityTransaction: {
         transaction: 'base64-add-authority-tx',
         transactionEncoding: 'base64',
         kind: 'add-authority',
         network: 'devnet',
+        signatureRequests: [
+          {
+            scheme: 'secp256r1',
+            signer: 'compressed-passkey',
+            messageHash: 'message-hash',
+            slot: 42,
+            counter: 1,
+          },
+        ],
       },
       configureRecoveryTransaction: {
         transaction: 'base64-configure-recovery-tx',
         transactionEncoding: 'base64',
         kind: 'configure-recovery',
         network: 'devnet',
+        signatureRequests: [],
       },
       transactions: [
         {
@@ -88,18 +101,29 @@ describe('wallet normalizers', () => {
           transactionEncoding: 'base64',
           kind: 'create-swig-wallet',
           network: 'devnet',
+          signatureRequests: [],
         },
         {
           transaction: 'base64-add-authority-tx',
           transactionEncoding: 'base64',
           kind: 'add-authority',
           network: 'devnet',
+          signatureRequests: [
+            {
+              scheme: 'secp256r1',
+              signer: 'compressed-passkey',
+              messageHash: 'message-hash',
+              slot: 42,
+              counter: 1,
+            },
+          ],
         },
         {
           transaction: 'base64-configure-recovery-tx',
           transactionEncoding: 'base64',
           kind: 'configure-recovery',
           network: 'devnet',
+          signatureRequests: [],
         },
       ],
       clientAuthorityTransactions: [
@@ -108,6 +132,15 @@ describe('wallet normalizers', () => {
           transactionEncoding: 'base64',
           kind: 'add-authority',
           network: 'devnet',
+          signatureRequests: [
+            {
+              scheme: 'secp256r1',
+              signer: 'compressed-passkey',
+              messageHash: 'message-hash',
+              slot: 42,
+              counter: 1,
+            },
+          ],
         },
       ],
       operatorSignedTransactions: [
@@ -116,6 +149,7 @@ describe('wallet normalizers', () => {
           transactionEncoding: 'base64',
           kind: 'configure-recovery',
           network: 'devnet',
+          signatureRequests: [],
         },
       ],
       feePayerOnlyTransactions: [
@@ -124,16 +158,9 @@ describe('wallet normalizers', () => {
           transactionEncoding: 'base64',
           kind: 'create-swig-wallet',
           network: 'devnet',
+          signatureRequests: [],
         },
       ],
-      addAuthorityChallenge: {
-        transactionIndex: 1,
-        scheme: 'secp256r1',
-        signer: 'compressed-passkey',
-        messageHash: 'message-hash',
-        slot: 42,
-        counter: 1,
-      },
       network: 'devnet',
     });
   });

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -58,6 +58,12 @@ export function normalizeCreateWalletResponse(
     transactions.find(
       (transaction) => transaction.kind === 'create-swig-wallet',
     ) ?? transactions[0];
+  const addAuthorityTransaction = transactions.find(
+    (transaction) => transaction.kind === 'add-authority',
+  );
+  const configureRecoveryTransaction = transactions.find(
+    (transaction) => transaction.kind === 'configure-recovery',
+  );
   const wallet = response.wallet ?? creationTransaction?.wallet;
 
   if (!wallet) {
@@ -67,7 +73,20 @@ export function normalizeCreateWalletResponse(
   return {
     wallet,
     transactions,
+    clientAuthorityTransactions: transactions.filter(
+      (transaction) => transaction.kind === 'add-authority',
+    ),
+    operatorSignedTransactions: transactions.filter(
+      (transaction) => transaction.kind === 'configure-recovery',
+    ),
+    feePayerOnlyTransactions: transactions.filter(
+      (transaction) =>
+        transaction.kind !== 'add-authority' &&
+        transaction.kind !== 'configure-recovery',
+    ),
     creationTransaction,
+    addAuthorityTransaction,
+    configureRecoveryTransaction,
     addAuthorityChallenge: normalizeAddAuthorityChallenge(
       response.addAuthorityChallenge ?? response.add_authority_challenge,
     ),

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -1,7 +1,7 @@
 import type {
-  AddAuthorityChallenge,
-  AddAuthorityChallengeWire,
   Amount,
+  ClientSignatureRequest,
+  ClientSignatureRequestWire,
   CreateWalletResponseWire,
   CreateWalletResult,
   Network,
@@ -39,6 +39,9 @@ export function normalizePreparedTransaction(
     network: normalizeNetwork(response.network),
     recentBlockhash: response.recentBlockhash ?? response.recent_blockhash,
     kind: normalizePreparedTransactionKind(response.kind),
+    signatureRequests: normalizeSignatureRequests(
+      response.signatureRequests ?? response.signature_requests,
+    ),
   };
 }
 
@@ -74,7 +77,7 @@ export function normalizeCreateWalletResponse(
     wallet,
     transactions,
     clientAuthorityTransactions: transactions.filter(
-      (transaction) => transaction.kind === 'add-authority',
+      (transaction) => transaction.signatureRequests.length > 0,
     ),
     operatorSignedTransactions: transactions.filter(
       (transaction) => transaction.kind === 'configure-recovery',
@@ -87,9 +90,6 @@ export function normalizeCreateWalletResponse(
     creationTransaction,
     addAuthorityTransaction,
     configureRecoveryTransaction,
-    addAuthorityChallenge: normalizeAddAuthorityChallenge(
-      response.addAuthorityChallenge ?? response.add_authority_challenge,
-    ),
     network: topLevelNetwork ?? creationTransaction?.network,
   };
 }
@@ -186,47 +186,43 @@ function normalizePreparedTransactionKind(
   }
 }
 
-function normalizeAddAuthorityChallenge(
-  challenge?: AddAuthorityChallengeWire,
-): AddAuthorityChallenge | undefined {
-  if (!challenge) {
-    return undefined;
+function normalizeSignatureRequests(
+  requests?: ClientSignatureRequestWire[],
+): ClientSignatureRequest[] {
+  if (!requests) {
+    return [];
   }
 
-  const transactionIndex =
-    challenge.transactionIndex ?? challenge.transaction_index;
-  const messageHash = challenge.messageHash ?? challenge.message_hash;
-  const scheme = normalizeAuthoritySignatureScheme(challenge.scheme);
+  return requests.map((request) => {
+    const messageHash = request.messageHash ?? request.message_hash;
+    const scheme = normalizeAuthoritySignatureScheme(request.scheme);
 
-  if (
-    transactionIndex === undefined ||
-    !scheme ||
-    !challenge.signer ||
-    !messageHash ||
-    challenge.slot === undefined ||
-    challenge.counter === undefined
-  ) {
-    throw new Error(
-      'Create wallet response has invalid add_authority_challenge',
-    );
-  }
+    if (
+      !scheme ||
+      !request.signer ||
+      !messageHash ||
+      request.slot === undefined ||
+      request.counter === undefined
+    ) {
+      throw new Error('Prepared transaction has invalid signature request');
+    }
 
-  return {
-    transactionIndex,
-    scheme,
-    signer: challenge.signer,
-    messageHash,
-    slot:
-      typeof challenge.slot === 'string'
-        ? Number.parseInt(challenge.slot, 10)
-        : challenge.slot,
-    counter: challenge.counter,
-  };
+    return {
+      scheme,
+      signer: request.signer,
+      messageHash,
+      slot:
+        typeof request.slot === 'string'
+          ? Number.parseInt(request.slot, 10)
+          : request.slot,
+      counter: request.counter,
+    };
+  });
 }
 
 function normalizeAuthoritySignatureScheme(
-  scheme: AddAuthorityChallengeWire['scheme'],
-): AddAuthorityChallenge['scheme'] | undefined {
+  scheme: ClientSignatureRequestWire['scheme'],
+): ClientSignatureRequest['scheme'] | undefined {
   switch (scheme) {
     case 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1':
     case 1:

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -38,7 +38,7 @@ export function transferSolRequest(
     ),
     feePayer: args.feePayer,
     swigAddress: wallet.swigConfigAddress,
-    requesterPubkey: resolveRequesterPubkey(wallet, args),
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
     destination: args.destination,
     lamports: normalizeAmount(args.amount),
   };
@@ -55,7 +55,7 @@ export function transferTokenRequest(
     ),
     feePayer: args.feePayer,
     swigAddress: wallet.swigConfigAddress,
-    requesterPubkey: resolveRequesterPubkey(wallet, args),
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
     mint: args.mint,
     destinationOwner: args.destinationOwner,
     amount: normalizeAmount(args.amount),
@@ -73,7 +73,7 @@ export function swapRequest(
     ),
     feePayer: args.feePayer,
     swigAddress: wallet.swigConfigAddress,
-    requesterPubkey: resolveRequesterPubkey(wallet, args),
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
     inputMint: args.inputMint,
     outputMint: args.outputMint,
     amount: normalizeAmount(args.amount),
@@ -120,13 +120,16 @@ function resolveNetwork(...networks: Array<Network | undefined>): Network {
   return network;
 }
 
-function resolveRequesterPubkey(
+function resolveRequesterAuthority(
   wallet: WalletHandle,
   args: TransferArgs | SwapArgs,
-): string {
-  const requesterPubkey = args.requesterPubkey ?? wallet.requesterPubkey;
-  if (!requesterPubkey) {
-    throw new Error('requesterPubkey is required');
+): NonNullable<
+  TransferArgs['requesterAuthority'] | SwapArgs['requesterAuthority']
+> {
+  const requesterAuthority =
+    args.requesterAuthority ?? wallet.requesterAuthority;
+  if (!requesterAuthority) {
+    throw new Error('requesterAuthority is required');
   }
-  return requesterPubkey;
+  return requesterAuthority;
 }


### PR DESCRIPTION
## Summary
- make swig.wallets.create return an explicit create result instead of a wallet handle
- preserve ordered transactions and expose client-authority, operator-signed, and fee-payer-only transaction buckets
- document the create order of operations, including backend recovery-operator signing
- add a changeset for publishing

## Tests
- bun --filter "@swig-wallet/developer-sdk" typecheck
- bun --filter "@swig-wallet/developer-sdk" test
- bun --filter "@swig-wallet/developer-sdk" lint
- bun --filter "@swig-wallet/developer-sdk" build
- git diff --check