### PR TITLE
Add grouped prepare operations to developer SDK

### DIFF
--- a/.changeset/grouped-prepare-operations.md
+++ b/.changeset/grouped-prepare-operations.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/developer-sdk": patch
+---
+
+Add grouped wallet operation preparation through `wallet.prepare` and the framework proxy, plus a `destinationAccount` swap override.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -100,6 +100,38 @@ it is returned. Submit each transaction in order after applying any required
 client authority signature. A prepared transaction needs a client authority
 signature when `signatureRequests.length > 0`.
 
+### Prepare Grouped Operations
+
+Use `wallet.prepare` when multiple operations should be built into one backend
+shaped transaction. The backend decides the final instruction layout and derives
+token accounts for token transfers.
+
+```typescript
+const prepared = await wallet.prepare({
+  feePayer,
+  operations: [
+    {
+      type: 'transferSol',
+      destination,
+      amount: 1_000_000n,
+    },
+    {
+      type: 'transferToken',
+      mint,
+      destinationOwner,
+      amount: 10_000n,
+    },
+  ],
+});
+
+return {
+  wallet: prepared.wallet,
+  transactions: prepared.transactions,
+  clientAuthorityTransactions: prepared.clientAuthorityTransactions,
+  feePayerOnlyTransactions: prepared.feePayerOnlyTransactions,
+};
+```
+
 ### Prepare SOL Transfer
 
 ```typescript
@@ -147,6 +179,7 @@ const preparedSwap = await wallet.swap.jupiter({
   outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
   amount: 10_000n,
   slippageBps: 100,
+  destinationAccount,
   wrapAndUnwrapSol: true,
 });
 

--- a/packages/developer-sdk/nest/README.md
+++ b/packages/developer-sdk/nest/README.md
@@ -32,6 +32,7 @@ The handler expects routes like:
 
 ```text
 POST /swig/wallet/create
+POST /swig/prepare
 POST /swig/transfer/sol
 POST /swig/transfer/spl-token
 POST /swig/swap/jupiter
@@ -75,7 +76,11 @@ const { prepared } = await fetch('https://api.example.com/swig/transfer/sol', {
   headers: { 'content-type': 'application/json' },
   body: JSON.stringify({
     network: 'devnet',
-    wallet: { swigConfigAddress, walletAddress, requesterPubkey },
+    wallet: {
+      swigConfigAddress,
+      walletAddress,
+      requesterAuthority: { ed25519: { publicKey: userPublicKey } },
+    },
     destination,
     amount: '1000000',
   }),
@@ -92,8 +97,8 @@ If your app resolves the requester from auth context, do it server-side:
 
 ```typescript
 const swigHandler = createSwigNestHandler({
-  resolveRequesterPubkey: async ({ request, wallet }) => {
-    return wallet?.requesterPubkey ?? lookupRequesterFromRequest(request);
+  resolveRequesterAuthority: async ({ request, wallet }) => {
+    return wallet?.requesterAuthority ?? lookupRequesterFromRequest(request);
   },
 });
 ```

--- a/packages/developer-sdk/next/README.md
+++ b/packages/developer-sdk/next/README.md
@@ -23,6 +23,7 @@ The helper handles:
 
 ```text
 POST /api/swig/wallet/create
+POST /api/swig/prepare
 POST /api/swig/transfer/sol
 POST /api/swig/transfer/spl-token
 POST /api/swig/swap/jupiter
@@ -66,7 +67,11 @@ const { prepared } = await fetch('/api/swig/transfer/sol', {
   headers: { 'content-type': 'application/json' },
   body: JSON.stringify({
     network: 'devnet',
-    wallet: { swigConfigAddress, walletAddress, requesterPubkey },
+    wallet: {
+      swigConfigAddress,
+      walletAddress,
+      requesterAuthority: { ed25519: { publicKey: userPublicKey } },
+    },
     destination,
     amount: '1000000',
   }),
@@ -79,13 +84,13 @@ const signed = await signPreparedTransaction(prepared, {
 
 ## Custom Requester Resolution
 
-If your app does not include `requesterPubkey` in the wallet reference, resolve
-it server-side:
+If your app does not include `requesterAuthority` in the wallet reference,
+resolve it server-side:
 
 ```typescript
 export const { POST } = createSwigRouteHandlers({
-  resolveRequesterPubkey: async ({ wallet, body }) => {
-    return wallet?.requesterPubkey ?? lookupRequesterForUser(body);
+  resolveRequesterAuthority: async ({ wallet, body }) => {
+    return wallet?.requesterAuthority ?? lookupRequesterForUser(body);
   },
 });
 ```

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -269,6 +269,110 @@ describe('createSwigFetchHandler', () => {
     });
   });
 
+  test('prepares grouped operations through the API-key server client', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      resolveRequesterAuthority: () => ({
+        ed25519: { publicKey: 'requester_123' },
+      }),
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              transaction: 'base64-prepare-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+            },
+          ],
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/prepare', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          network: 'devnet',
+          operations: [
+            {
+              type: 'transferSol',
+              destination: 'destination_123',
+              amount: '42',
+            },
+            {
+              type: 'transferToken',
+              mint: 'mint_123',
+              destinationOwner: 'owner_123',
+              amount: '2500',
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      prepared: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          network: 'devnet',
+        },
+        transactions: [
+          {
+            transaction: 'base64-prepare-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+          },
+        ],
+        feePayerOnlyTransactions: [
+          {
+            transaction: 'base64-prepare-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+          },
+        ],
+      },
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/prepare',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        operations: [
+          {
+            transferSol: {
+              destination: 'destination_123',
+              lamports: '42',
+            },
+          },
+          {
+            transferToken: {
+              mint: 'mint_123',
+              destinationOwner: 'owner_123',
+              amount: '2500',
+            },
+          },
+        ],
+      },
+    });
+  });
+
   test('prepares token transfers through the API-key server client', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({
@@ -358,6 +462,7 @@ describe('createSwigFetchHandler', () => {
           outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
           amount: '42',
           slippageBps: 100,
+          destinationAccount: 'destination_account_123',
           wrapAndUnwrapSol: true,
           maxAccounts: 20,
           mode: 'fast',
@@ -384,6 +489,7 @@ describe('createSwigFetchHandler', () => {
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         amount: '42',
         slippageBps: 100,
+        destinationAccount: 'destination_account_123',
         wrapAndUnwrapSol: true,
         maxAccounts: 20,
         mode: 'fast',

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -2,6 +2,8 @@ import type {
   Amount,
   CreateWalletArgs,
   Network,
+  PrepareArgs,
+  PrepareOperation,
   SwapArgs,
   TransferTokenArgs,
   WalletAuthority,
@@ -11,6 +13,7 @@ import { SwigClient } from '../typescript/index.js';
 
 export type SwigProxyRoute =
   | 'wallet/create'
+  | 'prepare'
   | 'transfer/sol'
   | 'transfer/spl-token'
   | 'swap/jupiter';
@@ -53,6 +56,7 @@ class SwigRouteError extends Error {
 
 const swigProxyRoutes: SwigProxyRoute[] = [
   'wallet/create',
+  'prepare',
   'transfer/sol',
   'transfer/spl-token',
   'swap/jupiter',
@@ -95,6 +99,10 @@ async function handlePost(
       case 'wallet/create':
         return json({
           prepared: await prepareWalletCreation(swig, body, context, config),
+        });
+      case 'prepare':
+        return json({
+          prepared: await prepareGroupedOperations(swig, body, context, config),
         });
       case 'transfer/sol':
         return json({
@@ -152,6 +160,35 @@ async function prepareWalletCreation(
   }
 
   return createWalletResult(created);
+}
+
+async function prepareGroupedOperations(
+  swig: SwigClient,
+  body: Record<string, unknown>,
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+) {
+  const wallet = requireWallet(context.wallet);
+  const requesterAuthority = await resolveRequesterAuthority(context, config);
+  const feePayer = await resolveFeePayer(context, config);
+  const handle = swig.wallets.use(
+    {
+      ...wallet,
+      requesterAuthority,
+    },
+    { network: context.network },
+  );
+  const args: PrepareArgs = {
+    feePayer,
+    requesterAuthority,
+    operations: readPrepareOperations(body.operations),
+    ...(context.network ? { network: context.network } : {}),
+    ...(readOptionalString(body, 'idempotencyKey')
+      ? { idempotencyKey: readOptionalString(body, 'idempotencyKey') }
+      : {}),
+  };
+
+  return handle.prepare(args);
 }
 
 function createWalletResult(
@@ -254,6 +291,11 @@ async function prepareJupiterSwap(
     amount: readAmount(body),
     ...(readOptionalNumber(body, 'slippageBps') !== undefined
       ? { slippageBps: readOptionalNumber(body, 'slippageBps') }
+      : {}),
+    ...(readOptionalString(body, 'destinationAccount')
+      ? {
+          destinationAccount: readOptionalString(body, 'destinationAccount'),
+        }
       : {}),
     ...(readOptionalString(body, 'destinationTokenAccount')
       ? {
@@ -443,6 +485,38 @@ function requireWallet(wallet: WalletReference | undefined): WalletReference {
     throw new SwigRouteError('wallet is required');
   }
   return wallet;
+}
+
+function readPrepareOperations(value: unknown): PrepareOperation[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new SwigRouteError('operations must be a non-empty array');
+  }
+
+  return value.map((operation, index) => {
+    if (!isRecord(operation)) {
+      throw new SwigRouteError(`operations[${index}] must be an object`);
+    }
+
+    switch (operation.type) {
+      case 'transferSol':
+        return {
+          type: 'transferSol',
+          destination: readRequiredString(operation, 'destination'),
+          amount: readAmount(operation),
+        };
+      case 'transferToken':
+        return {
+          type: 'transferToken',
+          mint: readRequiredString(operation, 'mint'),
+          destinationOwner: readRequiredString(operation, 'destinationOwner'),
+          amount: readAmount(operation),
+        };
+      default:
+        throw new SwigRouteError(
+          `operations[${index}].type must be transferSol or transferToken`,
+        );
+    }
+  });
 }
 
 function readAmount(body: Record<string, unknown>): Amount {

--- a/packages/developer-sdk/src/server/nest/index.test.ts
+++ b/packages/developer-sdk/src/server/nest/index.test.ts
@@ -152,6 +152,7 @@ describe('createSwigNestHandler', () => {
           outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
           amount: '42',
           slippageBps: 100,
+          destinationAccount: 'destination_account_123',
           wrapAndUnwrapSol: true,
         },
         headers: {
@@ -184,6 +185,7 @@ describe('createSwigNestHandler', () => {
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         amount: '42',
         slippageBps: 100,
+        destinationAccount: 'destination_account_123',
         wrapAndUnwrapSol: true,
       },
     });

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -83,6 +83,20 @@ export interface CreateWalletResponseWire extends PreparedTransactionWire {
   transactions?: PreparedTransactionWire[];
 }
 
+export interface PrepareTransactionsResponseWire {
+  wallet?: WalletAddressInfo;
+  transactions?: PreparedTransactionWire[];
+  network?: NetworkWire;
+}
+
+export interface PreparedTransactionsResult {
+  wallet?: WalletAddressInfo & { network?: Network };
+  transactions: PreparedTransaction[];
+  clientAuthorityTransactions: PreparedTransaction[];
+  feePayerOnlyTransactions: PreparedTransaction[];
+  network?: Network;
+}
+
 export interface CreateWalletResult {
   wallet: WalletAddressInfo & { network?: Network };
   transactions: PreparedTransaction[];

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -38,6 +38,27 @@ export interface TransferTokenArgs extends BaseTransferArgs {
 
 export type TransferArgs = TransferSolArgs | TransferTokenArgs;
 
+export type PrepareOperation =
+  | {
+      type: 'transferSol';
+      destination: string;
+      amount: Amount;
+    }
+  | {
+      type: 'transferToken';
+      mint: string;
+      destinationOwner: string;
+      amount: Amount;
+    };
+
+export interface PrepareArgs {
+  feePayer: string;
+  requesterAuthority?: WalletAuthority;
+  operations: PrepareOperation[];
+  network?: Network;
+  idempotencyKey?: string;
+}
+
 export interface SwapArgs {
   feePayer: string;
   requesterAuthority?: WalletAuthority;
@@ -45,6 +66,7 @@ export interface SwapArgs {
   outputMint: string;
   amount: Amount;
   slippageBps?: number;
+  destinationAccount?: string;
   destinationTokenAccount?: string;
   nativeDestinationAccount?: string;
   wrapAndUnwrapSol?: boolean;

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -164,6 +164,7 @@ describe('WalletsClient', () => {
           outputMint: 'output_mint_123',
           amount: 1_000n,
           slippageBps: 75,
+          destinationAccount: 'destination_account_123',
           tipAmountLamports: '5000',
           computeUnitPricePercentile: 'high',
           maxAccounts: 32,
@@ -181,6 +182,7 @@ describe('WalletsClient', () => {
       outputMint: 'output_mint_123',
       amount: '1000',
       slippageBps: 75,
+      destinationAccount: 'destination_account_123',
       destinationTokenAccount: undefined,
       nativeDestinationAccount: undefined,
       wrapAndUnwrapSol: undefined,
@@ -406,6 +408,95 @@ describe('WalletsClient', () => {
     });
   });
 
+  test('prepares grouped wallet operations through the transaction API', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              transaction: 'base64-grouped-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              recentBlockhash: 'blockhash_grouped',
+            },
+          ],
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.prepare({
+      feePayer: 'payer_123',
+      operations: [
+        {
+          type: 'transferSol',
+          destination: 'destination_123',
+          amount: 42n,
+        },
+        {
+          type: 'transferToken',
+          mint: 'mint_123',
+          destinationOwner: 'owner_123',
+          amount: '2500',
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/prepare',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        operations: [
+          {
+            transferSol: {
+              destination: 'destination_123',
+              lamports: '42',
+            },
+          },
+          {
+            transferToken: {
+              mint: 'mint_123',
+              destinationOwner: 'owner_123',
+              amount: '2500',
+            },
+          },
+        ],
+      },
+    });
+    expect(prepared.transactions).toHaveLength(1);
+    expect(prepared.transactions[0]).toMatchObject({
+      transaction: 'base64-grouped-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+      recentBlockhash: 'blockhash_grouped',
+    });
+    expect(prepared.wallet).toEqual({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      network: 'devnet',
+    });
+    expect(prepared.feePayerOnlyTransactions).toHaveLength(1);
+    expect(prepared.clientAuthorityTransactions).toEqual([]);
+  });
+
   test('prepares Jupiter swaps through the local transaction endpoint', async () => {
     const calls: CapturedRequest[] = [];
     const swig = new SwigClient({
@@ -438,6 +529,7 @@ describe('WalletsClient', () => {
       outputMint: 'output_mint_123',
       amount: 42n,
       slippageBps: 100,
+      destinationAccount: 'destination_account_123',
     });
 
     expect(calls).toHaveLength(1);
@@ -453,6 +545,7 @@ describe('WalletsClient', () => {
         outputMint: 'output_mint_123',
         amount: '42',
         slippageBps: 100,
+        destinationAccount: 'destination_account_123',
       },
     });
     expect(prepared).toMatchObject({

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -6,8 +6,11 @@ import type {
   ExecuteArgs,
   IdpWalletSession,
   Network,
+  PrepareArgs,
   PreparedTransaction,
+  PreparedTransactionsResult,
   PreparedTransactionWire,
+  PrepareTransactionsResponseWire,
   SwapArgs,
   TransferArgs,
   WalletHandleOptions,
@@ -17,11 +20,13 @@ import { WalletHandle } from './handle.js';
 import {
   normalizeCreateWalletResponse,
   normalizePreparedTransaction,
+  normalizePrepareTransactionsResponse,
 } from './normalizers.js';
 import {
   createWalletRequest,
   executeRequest,
   isTokenTransfer,
+  prepareRequest,
   swapRequest,
   transferSolRequest,
   transferTokenRequest,
@@ -91,6 +96,17 @@ export class WalletsClient {
     return isTokenTransfer(args)
       ? this.transferToken(wallet, args)
       : this.transferSol(wallet, args);
+  };
+
+  prepare = async (
+    wallet: WalletHandle,
+    args: PrepareArgs,
+  ): Promise<PreparedTransactionsResult> => {
+    const response = await this.http.post<PrepareTransactionsResponseWire>(
+      '/transaction/prepare',
+      prepareRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePrepareTransactionsResponse(response);
   };
 
   transferSol = async (

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -1,7 +1,9 @@
 import type {
   ExecuteArgs,
   Network,
+  PrepareArgs,
   PreparedTransaction,
+  PreparedTransactionsResult,
   SwapArgs,
   TransferArgs,
   TransferSolArgs,
@@ -43,6 +45,9 @@ export class WalletHandle {
     this.transfer = createWalletTransferClient(wallets, this);
     this.swap = createWalletSwapClient(wallets, this);
   }
+
+  prepare = (args: PrepareArgs): Promise<PreparedTransactionsResult> =>
+    this.wallets.prepare(this, args);
 
   execute = (args: ExecuteArgs) => this.wallets.execute(this, args);
 }

--- a/packages/developer-sdk/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeCreateWalletResponse,
   normalizeInstruction,
   normalizePreparedTransaction,
+  normalizePrepareTransactionsResponse,
   normalizeSubmittedTransaction,
 } from './normalizers.js';
 
@@ -161,6 +162,74 @@ describe('wallet normalizers', () => {
           signatureRequests: [],
         },
       ],
+      network: 'devnet',
+    });
+  });
+
+  test('normalizes grouped prepare responses', () => {
+    expect(
+      normalizePrepareTransactionsResponse({
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+        },
+        transactions: [
+          {
+            transaction: 'base64-grouped-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            signatureRequests: [
+              {
+                scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
+                signer: 'compressed-passkey',
+                messageHash: 'message-hash',
+                slot: '42',
+                counter: 1,
+              },
+            ],
+          },
+        ],
+        network: 'NETWORK_DEVNET',
+      }),
+    ).toEqual({
+      wallet: {
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+        network: 'devnet',
+      },
+      transactions: [
+        {
+          transaction: 'base64-grouped-tx',
+          transactionEncoding: 'base64',
+          network: 'devnet',
+          signatureRequests: [
+            {
+              scheme: 'secp256r1',
+              signer: 'compressed-passkey',
+              messageHash: 'message-hash',
+              slot: 42,
+              counter: 1,
+            },
+          ],
+        },
+      ],
+      clientAuthorityTransactions: [
+        {
+          transaction: 'base64-grouped-tx',
+          transactionEncoding: 'base64',
+          network: 'devnet',
+          signatureRequests: [
+            {
+              scheme: 'secp256r1',
+              signer: 'compressed-passkey',
+              messageHash: 'message-hash',
+              slot: 42,
+              counter: 1,
+            },
+          ],
+        },
+      ],
+      feePayerOnlyTransactions: [],
       network: 'devnet',
     });
   });

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -9,7 +9,9 @@ import type {
   PreparedTransaction,
   PreparedTransactionKind,
   PreparedTransactionKindWire,
+  PreparedTransactionsResult,
   PreparedTransactionWire,
+  PrepareTransactionsResponseWire,
   SolanaInstruction,
   SolanaInstructionInput,
   SubmittedTransaction,
@@ -91,6 +93,38 @@ export function normalizeCreateWalletResponse(
     addAuthorityTransaction,
     configureRecoveryTransaction,
     network: topLevelNetwork ?? creationTransaction?.network,
+  };
+}
+
+export function normalizePrepareTransactionsResponse(
+  response: PrepareTransactionsResponseWire,
+): PreparedTransactionsResult {
+  const network = normalizeNetwork(response.network);
+  const transactions = Array.isArray(response.transactions)
+    ? response.transactions.map((transaction) =>
+        normalizePreparedTransaction({
+          ...transaction,
+          network: transaction.network ?? response.network,
+        }),
+      )
+    : [];
+  const wallet = response.wallet
+    ? {
+        ...response.wallet,
+        ...(network ? { network } : {}),
+      }
+    : undefined;
+
+  return {
+    ...(wallet ? { wallet } : {}),
+    transactions,
+    clientAuthorityTransactions: transactions.filter(
+      (transaction) => transaction.signatureRequests.length > 0,
+    ),
+    feePayerOnlyTransactions: transactions.filter(
+      (transaction) => transaction.signatureRequests.length === 0,
+    ),
+    network,
   };
 }
 

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -2,6 +2,8 @@ import type {
   CreateWalletArgs,
   ExecuteArgs,
   Network,
+  PrepareArgs,
+  PrepareOperation,
   SwapArgs,
   TransferArgs,
   TransferSolArgs,
@@ -62,6 +64,22 @@ export function transferTokenRequest(
   };
 }
 
+export function prepareRequest(
+  wallet: WalletHandle,
+  args: PrepareArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
+    operations: args.operations.map(prepareOperationRequest),
+  };
+}
+
 export function swapRequest(
   wallet: WalletHandle,
   args: SwapArgs,
@@ -78,6 +96,7 @@ export function swapRequest(
     outputMint: args.outputMint,
     amount: normalizeAmount(args.amount),
     slippageBps: args.slippageBps,
+    destinationAccount: args.destinationAccount,
     destinationTokenAccount: args.destinationTokenAccount,
     nativeDestinationAccount: args.nativeDestinationAccount,
     wrapAndUnwrapSol: args.wrapAndUnwrapSol,
@@ -112,6 +131,26 @@ export function isTokenTransfer(args: TransferArgs): args is TransferTokenArgs {
   );
 }
 
+function prepareOperationRequest(operation: PrepareOperation) {
+  switch (operation.type) {
+    case 'transferSol':
+      return {
+        transferSol: {
+          destination: operation.destination,
+          lamports: normalizeAmount(operation.amount),
+        },
+      };
+    case 'transferToken':
+      return {
+        transferToken: {
+          mint: operation.mint,
+          destinationOwner: operation.destinationOwner,
+          amount: normalizeAmount(operation.amount),
+        },
+      };
+  }
+}
+
 function resolveNetwork(...networks: Array<Network | undefined>): Network {
   const network = networks.find((candidate) => candidate !== undefined);
   if (!network) {
@@ -122,9 +161,11 @@ function resolveNetwork(...networks: Array<Network | undefined>): Network {
 
 function resolveRequesterAuthority(
   wallet: WalletHandle,
-  args: TransferArgs | SwapArgs,
+  args: TransferArgs | SwapArgs | PrepareArgs,
 ): NonNullable<
-  TransferArgs['requesterAuthority'] | SwapArgs['requesterAuthority']
+  | TransferArgs['requesterAuthority']
+  | SwapArgs['requesterAuthority']
+  | PrepareArgs['requesterAuthority']
 > {
   const requesterAuthority =
     args.requesterAuthority ?? wallet.requesterAuthority;


### PR DESCRIPTION
## Summary
- add `wallet.prepare(...)` for grouped wallet operations
- add `/prepare` support to the fetch, Next, and Nest proxy helpers
- expose swap `destinationAccount` and document the grouped prepare flow

## Tests
- `bun --filter "@swig-wallet/developer-sdk" typecheck`
- `bun --filter "@swig-wallet/developer-sdk" test`
- `bun --filter "@swig-wallet/developer-sdk" lint`
- `bun --filter "@swig-wallet/developer-sdk" build`
- `bunx prettier --check packages/developer-sdk`
