### PR TITLE
Simplify developer SDK swap destination

### DIFF
--- a/.changeset/simplify-swap-destination.md
+++ b/.changeset/simplify-swap-destination.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Simplify Jupiter swap destination arguments to a single recipient owner account.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -183,6 +183,8 @@ const preparedSwap = await wallet.swap.jupiter({
   wrapAndUnwrapSol: true,
 });
 
+// destinationAccount is the recipient owner. The backend derives the output
+// token ATA for SPL outputs or the native destination for unwrapped SOL.
 return preparedSwap;
 ```
 

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -297,22 +297,6 @@ async function prepareJupiterSwap(
           destinationAccount: readOptionalString(body, 'destinationAccount'),
         }
       : {}),
-    ...(readOptionalString(body, 'destinationTokenAccount')
-      ? {
-          destinationTokenAccount: readOptionalString(
-            body,
-            'destinationTokenAccount',
-          ),
-        }
-      : {}),
-    ...(readOptionalString(body, 'nativeDestinationAccount')
-      ? {
-          nativeDestinationAccount: readOptionalString(
-            body,
-            'nativeDestinationAccount',
-          ),
-        }
-      : {}),
     ...(readOptionalBoolean(body, 'wrapAndUnwrapSol') !== undefined
       ? { wrapAndUnwrapSol: readOptionalBoolean(body, 'wrapAndUnwrapSol') }
       : {}),

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -67,8 +67,6 @@ export interface SwapArgs {
   amount: Amount;
   slippageBps?: number;
   destinationAccount?: string;
-  destinationTokenAccount?: string;
-  nativeDestinationAccount?: string;
   wrapAndUnwrapSol?: boolean;
   tipAmountLamports?: Amount;
   computeUnitPricePercentile?: string;

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -183,8 +183,6 @@ describe('WalletsClient', () => {
       amount: '1000',
       slippageBps: 75,
       destinationAccount: 'destination_account_123',
-      destinationTokenAccount: undefined,
-      nativeDestinationAccount: undefined,
       wrapAndUnwrapSol: undefined,
       tipAmountLamports: '5000',
       computeUnitPricePercentile: 'high',

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -97,8 +97,6 @@ export function swapRequest(
     amount: normalizeAmount(args.amount),
     slippageBps: args.slippageBps,
     destinationAccount: args.destinationAccount,
-    destinationTokenAccount: args.destinationTokenAccount,
-    nativeDestinationAccount: args.nativeDestinationAccount,
     wrapAndUnwrapSol: args.wrapAndUnwrapSol,
     tipAmountLamports:
       args.tipAmountLamports === undefined


### PR DESCRIPTION
## Summary\n- remove low-level destinationTokenAccount/nativeDestinationAccount fields from the developer SDK swap surface\n- keep a single destinationAccount owner field and document that the backend derives ATA/native destination details\n- add a changeset for @swig-wallet/developer-sdk\n\n## Testing\n- bun --filter '@swig-wallet/developer-sdk' test\n- bun --filter '@swig-wallet/developer-sdk' typecheck\n- bun --filter '@swig-wallet/developer-sdk' lint\n- pnpm format:fix