### PR TITLE
Add prepared passkey signing helpers

### DIFF
--- a/.changeset/prepared-swig-signing.md
+++ b/.changeset/prepared-swig-signing.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Add client helpers for signing prepared secp256r1 Swig transactions and route transaction sponsorship through the deployed paymaster endpoint.

--- a/bun.lock
+++ b/bun.lock
@@ -223,12 +223,13 @@
     },
     "packages/developer-sdk": {
       "name": "@swig-wallet/developer-sdk",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "dependencies": {
+        "@solana/web3.js": "^1.98.0",
         "@swig-wallet/lib": "workspace:*",
+        "bs58": "^6.0.0",
       },
       "devDependencies": {
-        "@solana/web3.js": "^1.98.0",
         "@types/bun": "^1.2.5",
         "@typescript-eslint/eslint-plugin": "^8.26.1",
         "@typescript-eslint/parser": "^8.26.1",

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -209,7 +209,7 @@ declare const prepared: PreparedTransaction;
 const signed = await signPreparedTransaction(prepared, {
   signTransaction: async (transaction) => {
     const versioned = VersionedTransaction.deserialize(
-      Buffer.from(transaction.transaction, 'base64'),
+      Buffer.from(transaction, 'base64'),
     );
     versioned.sign([userKeypair]);
     return Buffer.from(versioned.serialize()).toString('base64');
@@ -221,12 +221,14 @@ const signed = await signPreparedTransaction(prepared, {
 
 Use this for any prepared transaction whose `signatureRequests` contains a
 `secp256r1` request. The same pattern applies to create, transfer, token
-transfer, and swap.
+transfer, and swap. See `examples/passkey/server.ts` and
+`examples/passkey/client.ts` for the split server/client flow.
 
 ```typescript
 import {
   createSecp256r1PasskeySigningFn,
-  signPreparedTransaction,
+  signPreparedSwigTransaction,
+  signPreparedSwigTransactions,
   type PreparedTransaction,
 } from '@swig-wallet/developer-sdk/client';
 
@@ -242,24 +244,21 @@ const passkeySigningFn = createSecp256r1PasskeySigningFn({
 //   response.json(),
 // );
 declare const prepared: PreparedTransaction;
-const [signatureRequest] = prepared.signatureRequests;
 
-const signed = await signPreparedTransaction(prepared, {
-  signTransaction: (transaction) =>
-    signPreparedSwigTransaction(
-      transaction,
-      signatureRequest,
-      passkeySigningFn,
-    ),
+const signed = await signPreparedSwigTransaction(prepared, {
+  secp256r1: passkeySigningFn,
 });
+
+declare const created: { clientAuthorityTransactions: PreparedTransaction[] };
+const signedCreateTransactions = await signPreparedSwigTransactions(
+  created.clientAuthorityTransactions,
+  { secp256r1: passkeySigningFn },
+);
 ```
 
-After signing, pass `signed` to your app-owned send or sponsor flow. The client
-SDK stops at producing the signed prepared transaction payload.
-
-`signPreparedSwigTransaction` is intentionally app-provided for now. It should
-wrap the Swig passkey transaction signing flow for the specific transaction
-format returned by the backend.
+After signing, pass `signed` to your app-owned send or sponsor flow. On your
+server, `swig.transactions.sponsor(signed)` handles the deployed paymaster route
+and base58 payload encoding expected by the backend.
 
 For wallet creation, sign only `created.clientAuthorityTransactions` on the
 client. Do not authority-sign `created.operatorSignedTransactions`; those

--- a/packages/developer-sdk/examples/passkey/client.ts
+++ b/packages/developer-sdk/examples/passkey/client.ts
@@ -1,0 +1,57 @@
+import {
+  createSecp256r1PasskeySigningFn,
+  signPreparedSwigTransaction,
+  signPreparedSwigTransactions,
+  type PasskeySigningFn,
+  type PreparedTransaction,
+  type SignedPreparedTransaction,
+} from '@swig-wallet/developer-sdk/client';
+
+export interface PasskeyClientConfig {
+  credentialId: BufferSource;
+  userVerification?: UserVerificationRequirement;
+}
+
+export function createPasskeySigner(
+  config: PasskeyClientConfig,
+): PasskeySigningFn {
+  return createSecp256r1PasskeySigningFn({
+    allowCredentials: [
+      {
+        id: config.credentialId,
+        type: 'public-key',
+      },
+    ],
+    userVerification: config.userVerification ?? 'preferred',
+  });
+}
+
+export async function signPasskeyPreparedTransaction(
+  prepared: PreparedTransaction,
+  config: PasskeyClientConfig,
+): Promise<SignedPreparedTransaction> {
+  return signPreparedSwigTransaction(prepared, {
+    secp256r1: createPasskeySigner(config),
+  });
+}
+
+export async function signPasskeyPreparedTransactions(
+  preparedTransactions: PreparedTransaction[],
+  config: PasskeyClientConfig,
+): Promise<SignedPreparedTransaction[]> {
+  return signPreparedSwigTransactions(preparedTransactions, {
+    secp256r1: createPasskeySigner(config),
+  });
+}
+
+export async function signPasskeyWalletCreateResult(
+  created: {
+    clientAuthorityTransactions: PreparedTransaction[];
+  },
+  config: PasskeyClientConfig,
+): Promise<SignedPreparedTransaction[]> {
+  return signPasskeyPreparedTransactions(
+    created.clientAuthorityTransactions,
+    config,
+  );
+}

--- a/packages/developer-sdk/examples/passkey/server.ts
+++ b/packages/developer-sdk/examples/passkey/server.ts
@@ -1,0 +1,131 @@
+import type {
+  Amount,
+  CreateWalletResult,
+  Network,
+  PreparedTransaction,
+  PreparedTransactionsResult,
+  SubmittedTransaction,
+  WalletAddressInfo,
+} from '@swig-wallet/developer-sdk';
+import type { SignedPreparedTransaction } from '@swig-wallet/developer-sdk/client';
+import { SwigClient } from '@swig-wallet/developer-sdk/server/typescript';
+
+export interface PasskeyServerConfig {
+  apiKey: string;
+  feePayer: string;
+  baseUrl?: string;
+  network?: Network;
+  fetch?: typeof fetch;
+}
+
+export async function preparePasskeyWalletCreate(
+  config: PasskeyServerConfig,
+  passkeyPublicKey: string,
+): Promise<CreateWalletResult> {
+  const swig = createServerSwigClient(config);
+
+  return swig.wallets.create({
+    feePayer: config.feePayer,
+    initialUser: {
+      secp256r1: {
+        publicKey: passkeyPublicKey,
+      },
+    },
+    ...(config.network ? { network: config.network } : {}),
+  });
+}
+
+export async function preparePasskeySolTransfer(
+  config: PasskeyServerConfig,
+  args: {
+    wallet: WalletAddressInfo;
+    passkeyPublicKey: string;
+    destination: string;
+    amount: Amount;
+  },
+): Promise<PreparedTransaction> {
+  const swig = createServerSwigClient(config);
+  const wallet = swig.wallets.use(
+    {
+      ...args.wallet,
+      requesterAuthority: {
+        secp256r1: {
+          publicKey: args.passkeyPublicKey,
+        },
+      },
+    },
+    { network: config.network },
+  );
+
+  return wallet.transfer.sol({
+    feePayer: config.feePayer,
+    destination: args.destination,
+    amount: args.amount,
+    ...(config.network ? { network: config.network } : {}),
+  });
+}
+
+export async function preparePasskeyGroupedTransfers(
+  config: PasskeyServerConfig,
+  args: {
+    wallet: WalletAddressInfo;
+    passkeyPublicKey: string;
+    transfers: Array<{
+      destination: string;
+      amount: Amount;
+    }>;
+  },
+): Promise<PreparedTransactionsResult> {
+  const swig = createServerSwigClient(config);
+  const wallet = swig.wallets.use(
+    {
+      ...args.wallet,
+      requesterAuthority: {
+        secp256r1: {
+          publicKey: args.passkeyPublicKey,
+        },
+      },
+    },
+    { network: config.network },
+  );
+
+  return wallet.prepare({
+    feePayer: config.feePayer,
+    operations: args.transfers.map((transfer) => ({
+      type: 'transferSol',
+      destination: transfer.destination,
+      amount: transfer.amount,
+    })),
+    ...(config.network ? { network: config.network } : {}),
+  });
+}
+
+export async function sponsorSignedTransaction(
+  config: PasskeyServerConfig,
+  transaction: SignedPreparedTransaction,
+): Promise<SubmittedTransaction> {
+  const swig = createServerSwigClient(config);
+  return swig.transactions.sponsor(transaction);
+}
+
+export async function sponsorSignedTransactionsSequentially(
+  config: PasskeyServerConfig,
+  transactions: SignedPreparedTransaction[],
+): Promise<SubmittedTransaction[]> {
+  const submitted: SubmittedTransaction[] = [];
+
+  for (const transaction of transactions) {
+    submitted.push(await sponsorSignedTransaction(config, transaction));
+  }
+
+  return submitted;
+}
+
+function createServerSwigClient(config: PasskeyServerConfig): SwigClient {
+  return new SwigClient({
+    apiKey: config.apiKey,
+    ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config.network ? { network: config.network } : {}),
+    ...(config.fetch ? { fetch: config.fetch } : {}),
+  });
+}

--- a/packages/developer-sdk/package.json
+++ b/packages/developer-sdk/package.json
@@ -88,10 +88,11 @@
     "next"
   ],
   "dependencies": {
-    "@swig-wallet/lib": "workspace:*"
+    "@solana/web3.js": "^1.98.0",
+    "@swig-wallet/lib": "workspace:*",
+    "bs58": "^6.0.0"
   },
   "devDependencies": {
-    "@solana/web3.js": "^1.98.0",
     "@types/bun": "^1.2.5",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",

--- a/packages/developer-sdk/src/client/index.test.ts
+++ b/packages/developer-sdk/src/client/index.test.ts
@@ -1,7 +1,16 @@
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
 import { describe, expect, test } from 'bun:test';
 
 import type { PreparedTransaction } from '../types/index.js';
-import { signPreparedTransaction } from './index.js';
+import {
+  signPreparedSwigTransaction,
+  signPreparedSwigTransactions,
+  signPreparedTransaction,
+} from './index.js';
 
 const prepared: PreparedTransaction = {
   transaction: 'base64-prepared-tx',
@@ -22,4 +31,272 @@ describe('client signing helpers', () => {
       network: 'devnet',
     });
   });
+
+  test('signPreparedSwigTransaction patches secp256r1 instructions with passkey signing data', async () => {
+    const publicKey = Uint8Array.from({ length: 33 }, (_, index) =>
+      index === 0 ? 2 : index,
+    );
+    const messageHash = Uint8Array.from(
+      { length: 32 },
+      (_, index) => index + 1,
+    );
+    const signature = Uint8Array.from(
+      { length: 64 },
+      (_, index) => 255 - index,
+    );
+    const passkeyMessage = Uint8Array.from([9, 8, 7, 6]);
+    const passkeyPrefix = Uint8Array.from([1, 3, 5, 7]);
+    const prepared = preparedSwigTransaction(publicKey, messageHash);
+
+    const signed = await signPreparedSwigTransaction(prepared, {
+      secp256r1: async (challenge) => {
+        expect(challenge).toEqual(messageHash);
+        return {
+          signature,
+          message: passkeyMessage,
+          prefix: passkeyPrefix,
+        };
+      },
+    });
+
+    const transaction = Transaction.from(base64ToBytes(signed.transaction));
+    const secpData = parseSecp256r1InstructionData(
+      transaction.instructions[0].data,
+    );
+    const swigData = new Uint8Array(transaction.instructions[1].data);
+
+    expect(secpData.publicKey).toEqual(publicKey);
+    expect(secpData.signature).toEqual(signature);
+    expect(secpData.message).toEqual(passkeyMessage);
+    expect(readAuthorityPayload(swigData)).toEqual(
+      concatBytes(baseAuthorityPayload(), passkeyPrefix),
+    );
+    expect(signed.transactionEncoding).toBe('base64');
+    expect(signed.network).toBe('devnet');
+  });
+
+  test('signPreparedSwigTransaction leaves the authority payload unchanged for raw secp256r1 signatures', async () => {
+    const publicKey = Uint8Array.from({ length: 33 }, (_, index) =>
+      index === 0 ? 3 : index + 10,
+    );
+    const messageHash = Uint8Array.from(
+      { length: 32 },
+      (_, index) => index + 33,
+    );
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1);
+    const prepared = preparedSwigTransaction(publicKey, messageHash);
+
+    const signed = await signPreparedSwigTransaction(prepared, {
+      secp256r1: async () => ({ signature }),
+    });
+
+    const transaction = Transaction.from(base64ToBytes(signed.transaction));
+    const secpData = parseSecp256r1InstructionData(
+      transaction.instructions[0].data,
+    );
+    const swigData = new Uint8Array(transaction.instructions[1].data);
+
+    expect(secpData.publicKey).toEqual(publicKey);
+    expect(secpData.signature).toEqual(signature);
+    expect(secpData.message).toEqual(messageHash);
+    expect(readAuthorityPayload(swigData)).toEqual(baseAuthorityPayload());
+  });
+
+  test('signPreparedSwigTransactions signs prepared transactions sequentially', async () => {
+    const firstPublicKey = Uint8Array.from({ length: 33 }, (_, index) =>
+      index === 0 ? 2 : index + 1,
+    );
+    const secondPublicKey = Uint8Array.from({ length: 33 }, (_, index) =>
+      index === 0 ? 3 : index + 2,
+    );
+    const firstMessageHash = Uint8Array.from(
+      { length: 32 },
+      (_, index) => index + 1,
+    );
+    const secondMessageHash = Uint8Array.from(
+      { length: 32 },
+      (_, index) => index + 40,
+    );
+    const challenges: Uint8Array[] = [];
+
+    const signed = await signPreparedSwigTransactions(
+      [
+        preparedSwigTransaction(firstPublicKey, firstMessageHash),
+        preparedSwigTransaction(secondPublicKey, secondMessageHash),
+      ],
+      {
+        secp256r1: async (challenge) => {
+          challenges.push(challenge);
+          return {
+            signature: Uint8Array.from({ length: 64 }, (_, index) => index),
+          };
+        },
+      },
+    );
+
+    expect(signed).toHaveLength(2);
+    expect(challenges).toEqual([firstMessageHash, secondMessageHash]);
+  });
 });
+
+const SECP256R1_PROGRAM_ID = new PublicKey(
+  'Secp256r1SigVerify1111111111111111111111111',
+);
+const SWIG_PROGRAM_ID = new PublicKey(
+  'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB',
+);
+const FEE_PAYER = new PublicKey('2bDoQTvcRuAL8bA7igx6cjSZHH3wJqVg1vsYrUjeTWyP');
+
+function preparedSwigTransaction(
+  publicKey: Uint8Array,
+  messageHash: Uint8Array,
+): PreparedTransaction {
+  const transaction = new Transaction({
+    feePayer: FEE_PAYER,
+    recentBlockhash: '11111111111111111111111111111111',
+  }).add(
+    new TransactionInstruction({
+      programId: SECP256R1_PROGRAM_ID,
+      keys: [],
+      data: Buffer.from(
+        encodeSecp256r1InstructionData({
+          publicKey,
+          signature: new Uint8Array(64),
+          message: messageHash,
+        }),
+      ),
+    }),
+    new TransactionInstruction({
+      programId: SWIG_PROGRAM_ID,
+      keys: [],
+      data: Buffer.from(signV2InstructionData()),
+    }),
+  );
+
+  return {
+    transaction: bytesToBase64(
+      transaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      }),
+    ),
+    transactionEncoding: 'base64',
+    network: 'devnet',
+    signatureRequests: [
+      {
+        scheme: 'secp256r1',
+        signer: bytesToHex(publicKey),
+        messageHash: bytesToHex(messageHash),
+        slot: 1,
+        counter: 1,
+      },
+    ],
+  };
+}
+
+function encodeSecp256r1InstructionData(args: {
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+  message: Uint8Array;
+}): Uint8Array {
+  const headerSize = 16;
+  const messageOffset =
+    headerSize + args.publicKey.length + args.signature.length;
+  const data = new Uint8Array(messageOffset + args.message.length);
+  const view = new DataView(data.buffer);
+
+  data[0] = 1;
+  view.setUint16(2, headerSize + args.publicKey.length, true);
+  view.setUint16(4, 65535, true);
+  view.setUint16(6, headerSize, true);
+  view.setUint16(8, 65535, true);
+  view.setUint16(10, messageOffset, true);
+  view.setUint16(12, args.message.length, true);
+  view.setUint16(14, 65535, true);
+  data.set(args.publicKey, headerSize);
+  data.set(args.signature, headerSize + args.publicKey.length);
+  data.set(args.message, messageOffset);
+
+  return data;
+}
+
+function parseSecp256r1InstructionData(data: Uint8Array): {
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+  message: Uint8Array;
+} {
+  const signatureOffset = readU16(data, 2);
+  const publicKeyOffset = readU16(data, 6);
+  const messageOffset = readU16(data, 10);
+  const messageSize = readU16(data, 12);
+
+  return {
+    publicKey: data.slice(publicKeyOffset, publicKeyOffset + 33),
+    signature: data.slice(signatureOffset, signatureOffset + 64),
+    message: data.slice(messageOffset, messageOffset + messageSize),
+  };
+}
+
+function signV2InstructionData(): Uint8Array {
+  const compactInstructionPayload = Uint8Array.from([11, 22, 33]);
+  const authorityPayload = baseAuthorityPayload();
+  const data = new Uint8Array(8 + compactInstructionPayload.length + 17);
+  const view = new DataView(data.buffer);
+
+  view.setUint16(0, 11, true);
+  view.setUint16(2, compactInstructionPayload.length, true);
+  view.setUint32(4, 0, true);
+  data.set(compactInstructionPayload, 8);
+  data.set(authorityPayload, 8 + compactInstructionPayload.length);
+
+  return data;
+}
+
+function baseAuthorityPayload(): Uint8Array {
+  return Uint8Array.from({ length: 17 }, (_, index) => index + 1);
+}
+
+function readAuthorityPayload(data: Uint8Array): Uint8Array {
+  const instructionPayloadLength = readU16(data, 2);
+  return data.slice(8 + instructionPayloadLength);
+}
+
+function readU16(data: Uint8Array, offset: number): number {
+  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint16(
+    offset,
+    true,
+  );
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const bytes = new Uint8Array(left.length + right.length);
+  bytes.set(left);
+  bytes.set(right, left.length);
+  return bytes;
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+
+  return btoa(binary);
+}

--- a/packages/developer-sdk/src/client/index.ts
+++ b/packages/developer-sdk/src/client/index.ts
@@ -7,6 +7,14 @@ export type {
   PreparedTransaction,
   TransactionEncoding,
 } from '../types/index.js';
+export {
+  signPreparedSwigTransaction,
+  signPreparedSwigTransactions,
+} from './swig-signing.js';
+export type {
+  Secp256r1SigningFns,
+  SignPreparedSwigTransactionOptions,
+} from './swig-signing.js';
 
 export interface SignedPreparedTransaction {
   transaction: string;

--- a/packages/developer-sdk/src/client/swig-signing.ts
+++ b/packages/developer-sdk/src/client/swig-signing.ts
@@ -1,0 +1,420 @@
+import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
+
+import type {
+  ClientSignatureRequest,
+  PasskeySigningFn,
+  PreparedTransaction,
+} from '../types/index.js';
+import type { SignedPreparedTransaction } from './index.js';
+
+const SECP256R1_PROGRAM_ID = new PublicKey(
+  'Secp256r1SigVerify1111111111111111111111111',
+);
+const SWIG_PROGRAM_ID = new PublicKey(
+  'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB',
+);
+const SIGN_V2_DISCRIMINATOR = 11;
+const SECP256R1_AUTHORITY_PAYLOAD_SIZE = 17;
+const SECP256R1_PUBLIC_KEY_SIZE = 33;
+const SECP256R1_SIGNATURE_SIZE = 64;
+const SECP256R1_HEADER_SIZE = 16;
+const U16_MAX = 65535;
+
+export type Secp256r1SigningFns =
+  | PasskeySigningFn
+  | Record<string, PasskeySigningFn>;
+
+export interface SignPreparedSwigTransactionOptions {
+  secp256r1: Secp256r1SigningFns;
+}
+
+type SwigTransaction = Transaction | VersionedTransaction;
+
+export async function signPreparedSwigTransaction(
+  prepared: PreparedTransaction,
+  options: SignPreparedSwigTransactionOptions,
+): Promise<SignedPreparedTransaction> {
+  if (
+    prepared.transactionEncoding !== undefined &&
+    prepared.transactionEncoding !== 'base64'
+  ) {
+    throw new Error('Only base64 prepared transactions can be signed');
+  }
+
+  const transaction = deserializeTransaction(
+    base64ToBytes(prepared.transaction),
+  );
+
+  for (const request of prepared.signatureRequests) {
+    await applySignatureRequest(transaction, request, options);
+  }
+
+  return {
+    transaction: bytesToBase64(serializeTransaction(transaction)),
+    transactionEncoding: prepared.transactionEncoding ?? 'base64',
+    network: prepared.network,
+  };
+}
+
+export async function signPreparedSwigTransactions(
+  preparedTransactions: PreparedTransaction[],
+  options: SignPreparedSwigTransactionOptions,
+): Promise<SignedPreparedTransaction[]> {
+  const signedTransactions: SignedPreparedTransaction[] = [];
+
+  for (const prepared of preparedTransactions) {
+    signedTransactions.push(
+      await signPreparedSwigTransaction(prepared, options),
+    );
+  }
+
+  return signedTransactions;
+}
+
+async function applySignatureRequest(
+  transaction: SwigTransaction,
+  request: ClientSignatureRequest,
+  options: SignPreparedSwigTransactionOptions,
+) {
+  if (request.scheme !== 'secp256r1') {
+    throw new Error(
+      `Client signing for ${request.scheme} prepared transactions is not supported yet`,
+    );
+  }
+
+  const publicKey = hexToBytes(request.signer);
+  if (publicKey.length !== SECP256R1_PUBLIC_KEY_SIZE) {
+    throw new Error('Secp256r1 signature request signer must be 33 bytes');
+  }
+
+  const messageHash = hexToBytes(request.messageHash);
+  const signingFn = resolveSecp256r1SigningFn(request, options.secp256r1);
+  const signingResult = await signingFn(messageHash);
+
+  if (signingResult.signature.length !== SECP256R1_SIGNATURE_SIZE) {
+    throw new Error('Secp256r1 signature must be 64 bytes');
+  }
+
+  const signedMessage = signingResult.message ?? messageHash;
+  const secpInstructionIndex = findSecp256r1InstructionIndex(
+    transaction,
+    publicKey,
+    messageHash,
+  );
+
+  setInstructionData(
+    transaction,
+    secpInstructionIndex,
+    encodeSecp256r1SignatureInstruction({
+      publicKey,
+      signature: signingResult.signature,
+      message: signedMessage,
+    }),
+  );
+
+  if (signingResult.prefix !== undefined) {
+    const signV2InstructionIndex = findFollowingSignV2InstructionIndex(
+      transaction,
+      secpInstructionIndex,
+    );
+    setInstructionData(
+      transaction,
+      signV2InstructionIndex,
+      patchSignV2AuthorityPayload(
+        getInstructionData(transaction, signV2InstructionIndex),
+        signingResult.prefix,
+      ),
+    );
+  }
+}
+
+function resolveSecp256r1SigningFn(
+  request: ClientSignatureRequest,
+  signingFns: Secp256r1SigningFns,
+): PasskeySigningFn {
+  if (typeof signingFns === 'function') {
+    return signingFns;
+  }
+
+  const normalizedSigner = normalizeHex(request.signer);
+  const signingFn =
+    signingFns[normalizedSigner] ??
+    signingFns[`0x${normalizedSigner}`] ??
+    signingFns[request.signer];
+
+  if (!signingFn) {
+    throw new Error(
+      `No secp256r1 signing function registered for signer ${request.signer}`,
+    );
+  }
+
+  return signingFn;
+}
+
+function deserializeTransaction(bytes: Uint8Array): SwigTransaction {
+  try {
+    return Transaction.from(bytes);
+  } catch {
+    return VersionedTransaction.deserialize(bytes);
+  }
+}
+
+function serializeTransaction(transaction: SwigTransaction): Uint8Array {
+  if (transaction instanceof VersionedTransaction) {
+    return transaction.serialize();
+  }
+
+  return transaction.serialize({
+    requireAllSignatures: false,
+    verifySignatures: false,
+  });
+}
+
+function findSecp256r1InstructionIndex(
+  transaction: SwigTransaction,
+  publicKey: Uint8Array,
+  messageHash: Uint8Array,
+): number {
+  for (let index = 0; index < instructionCount(transaction); index++) {
+    if (
+      !getInstructionProgramId(transaction, index).equals(SECP256R1_PROGRAM_ID)
+    ) {
+      continue;
+    }
+
+    const parsed = parseSecp256r1SignatureInstruction(
+      getInstructionData(transaction, index),
+    );
+
+    if (
+      parsed &&
+      bytesEqual(parsed.publicKey, publicKey) &&
+      bytesEqual(parsed.message, messageHash)
+    ) {
+      return index;
+    }
+  }
+
+  throw new Error('Matching secp256r1 signature instruction not found');
+}
+
+function findFollowingSignV2InstructionIndex(
+  transaction: SwigTransaction,
+  secpInstructionIndex: number,
+): number {
+  for (
+    let index = secpInstructionIndex + 1;
+    index < instructionCount(transaction);
+    index++
+  ) {
+    if (!getInstructionProgramId(transaction, index).equals(SWIG_PROGRAM_ID)) {
+      continue;
+    }
+
+    if (
+      readU16(getInstructionData(transaction, index), 0) ===
+      SIGN_V2_DISCRIMINATOR
+    ) {
+      return index;
+    }
+  }
+
+  throw new Error(
+    'Swig SignV2 instruction following secp256r1 precompile not found',
+  );
+}
+
+function encodeSecp256r1SignatureInstruction(args: {
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+  message: Uint8Array;
+}): Uint8Array {
+  const messageOffset =
+    SECP256R1_HEADER_SIZE +
+    SECP256R1_PUBLIC_KEY_SIZE +
+    SECP256R1_SIGNATURE_SIZE;
+  const data = new Uint8Array(messageOffset + args.message.length);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  data[0] = 1;
+  data[1] = 0;
+  view.setUint16(2, SECP256R1_HEADER_SIZE + SECP256R1_PUBLIC_KEY_SIZE, true);
+  view.setUint16(4, U16_MAX, true);
+  view.setUint16(6, SECP256R1_HEADER_SIZE, true);
+  view.setUint16(8, U16_MAX, true);
+  view.setUint16(10, messageOffset, true);
+  view.setUint16(12, args.message.length, true);
+  view.setUint16(14, U16_MAX, true);
+  data.set(args.publicKey, SECP256R1_HEADER_SIZE);
+  data.set(args.signature, SECP256R1_HEADER_SIZE + SECP256R1_PUBLIC_KEY_SIZE);
+  data.set(args.message, messageOffset);
+
+  return data;
+}
+
+function parseSecp256r1SignatureInstruction(data: Uint8Array):
+  | {
+      publicKey: Uint8Array;
+      message: Uint8Array;
+    }
+  | undefined {
+  if (data.length < SECP256R1_HEADER_SIZE || data[0] !== 1) {
+    return undefined;
+  }
+
+  const publicKeyOffset = readU16(data, 6);
+  const messageOffset = readU16(data, 10);
+  const messageSize = readU16(data, 12);
+
+  if (
+    data.length < publicKeyOffset + SECP256R1_PUBLIC_KEY_SIZE ||
+    data.length < messageOffset + messageSize
+  ) {
+    return undefined;
+  }
+
+  return {
+    publicKey: data.slice(
+      publicKeyOffset,
+      publicKeyOffset + SECP256R1_PUBLIC_KEY_SIZE,
+    ),
+    message: data.slice(messageOffset, messageOffset + messageSize),
+  };
+}
+
+function patchSignV2AuthorityPayload(
+  instructionData: Uint8Array,
+  prefix: Uint8Array,
+): Uint8Array {
+  const instructionPayloadLength = readU16(instructionData, 2);
+  const authorityPayloadOffset = 8 + instructionPayloadLength;
+
+  if (
+    instructionData.length <
+    authorityPayloadOffset + SECP256R1_AUTHORITY_PAYLOAD_SIZE
+  ) {
+    throw new Error(
+      'Swig SignV2 instruction is missing secp256r1 authority payload',
+    );
+  }
+
+  const fixedPayloadEnd =
+    authorityPayloadOffset + SECP256R1_AUTHORITY_PAYLOAD_SIZE;
+  const patched = new Uint8Array(fixedPayloadEnd + prefix.length);
+  patched.set(instructionData.slice(0, fixedPayloadEnd));
+  patched.set(prefix, fixedPayloadEnd);
+
+  return patched;
+}
+
+function instructionCount(transaction: SwigTransaction): number {
+  if (transaction instanceof VersionedTransaction) {
+    return transaction.message.compiledInstructions.length;
+  }
+
+  return transaction.instructions.length;
+}
+
+function getInstructionProgramId(
+  transaction: SwigTransaction,
+  index: number,
+): PublicKey {
+  if (transaction instanceof VersionedTransaction) {
+    const instruction = transaction.message.compiledInstructions[index];
+    const programId =
+      transaction.message.staticAccountKeys[instruction.programIdIndex];
+    if (!programId) {
+      throw new Error(
+        'Versioned transaction program id is not statically available',
+      );
+    }
+    return programId;
+  }
+
+  return transaction.instructions[index].programId;
+}
+
+function getInstructionData(
+  transaction: SwigTransaction,
+  index: number,
+): Uint8Array {
+  if (transaction instanceof VersionedTransaction) {
+    return transaction.message.compiledInstructions[index].data;
+  }
+
+  return new Uint8Array(transaction.instructions[index].data);
+}
+
+function setInstructionData(
+  transaction: SwigTransaction,
+  index: number,
+  data: Uint8Array,
+) {
+  if (transaction instanceof VersionedTransaction) {
+    transaction.message.compiledInstructions[index].data = data;
+    return;
+  }
+
+  transaction.instructions[index].data = data as Buffer;
+}
+
+function hexToBytes(value: string): Uint8Array {
+  const normalized = normalizeHex(value);
+  if (normalized.length % 2 !== 0) {
+    throw new Error('Hex strings must contain an even number of characters');
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < normalized.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(normalized.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function normalizeHex(value: string): string {
+  const normalized = value.startsWith('0x') ? value.slice(2) : value;
+  if (!/^[\da-fA-F]+$/.test(normalized)) {
+    throw new Error('Invalid hex string');
+  }
+  return normalized.toLowerCase();
+}
+
+function readU16(data: Uint8Array, offset: number): number {
+  if (data.length < offset + 2) {
+    throw new Error('Instruction data is too short');
+  }
+  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint16(
+    offset,
+    true,
+  );
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+
+  return btoa(binary);
+}

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -15,6 +15,7 @@ export type {
   Network,
   PreparedTransaction,
   PreparedTransactionWire,
+  PreparedTransactionsResult,
   RetryOptions,
   SolanaAccountMeta,
   SolanaInstruction,

--- a/packages/developer-sdk/src/transactions/client.test.ts
+++ b/packages/developer-sdk/src/transactions/client.test.ts
@@ -1,0 +1,50 @@
+import bs58 from 'bs58';
+import { describe, expect, test } from 'bun:test';
+
+import { TransactionsClient } from './client.js';
+
+describe('TransactionsClient', () => {
+  test('sponsors base64 transactions through the deployed paymaster endpoint', async () => {
+    const transactionBytes = Uint8Array.from([1, 2, 3, 4, 5]);
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const transactions = new TransactionsClient(
+      {
+        post: async (path: string, body: unknown) => {
+          calls.push({ path, body });
+          return { signature: 'sponsored_signature_123' };
+        },
+      } as never,
+      'devnet',
+    );
+
+    await expect(
+      transactions.sponsor({
+        transaction: bytesToBase64(transactionBytes),
+      }),
+    ).resolves.toEqual({
+      signature: 'sponsored_signature_123',
+    });
+
+    expect(calls).toEqual([
+      {
+        path: '/paymaster/sponsor',
+        body: {
+          base58_encoded_transaction: bs58.encode(transactionBytes),
+          network: 'devnet',
+          metadata: undefined,
+          idempotencyKey: undefined,
+        },
+      },
+    ]);
+  });
+});
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary);
+}

--- a/packages/developer-sdk/src/transactions/client.ts
+++ b/packages/developer-sdk/src/transactions/client.ts
@@ -1,3 +1,4 @@
+import bs58 from 'bs58';
 import type { HttpClient } from '../core/index.js';
 import type {
   Network,
@@ -17,10 +18,11 @@ export class TransactionsClient {
     args: SponsorSignedTransactionArgs,
   ): Promise<SubmittedTransaction> => {
     const response = await this.http.post<SubmittedTransactionWire>(
-      '/v1/transactions/sponsor',
+      '/paymaster/sponsor',
       {
-        transaction: args.transaction,
-        transactionEncoding: args.transactionEncoding,
+        base58_encoded_transaction: bs58.encode(
+          base64ToBytes(args.transaction),
+        ),
         network: args.network ?? this.defaultNetwork,
         metadata: args.metadata,
         idempotencyKey: args.idempotencyKey,
@@ -29,4 +31,15 @@ export class TransactionsClient {
 
     return normalizeSubmittedTransaction(response);
   };
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
 }

--- a/packages/developer-sdk/tsconfig.json
+++ b/packages/developer-sdk/tsconfig.json
@@ -10,7 +10,11 @@
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {
-      "@swig-wallet/developer-sdk": ["src/index.ts"]
+      "@swig-wallet/developer-sdk": ["src/index.ts"],
+      "@swig-wallet/developer-sdk/client": ["src/client/index.ts"],
+      "@swig-wallet/developer-sdk/server/typescript": [
+        "src/server/typescript/index.ts"
+      ]
     },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
## Summary
- add first-class client helpers for signing prepared secp256r1 Swig transactions
- fix developer SDK sponsorship to call the deployed paymaster route with base58 payloads
- add passkey server/client examples under packages/developer-sdk/examples/passkey
- add tests for secp256r1 patching, sequential signing, and sponsor payload shape

## Verification
- bun --filter "@swig-wallet/developer-sdk" test
- bun --filter "@swig-wallet/developer-sdk" lint
- bun --filter "@swig-wallet/developer-sdk" typecheck
- bun --filter "@swig-wallet/developer-sdk" build