### PR TITLE
Add passkey signing fix changeset

### DIFF
--- a/.changeset/raw-passkey-client-data.md
+++ b/.changeset/raw-passkey-client-data.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/developer-sdk": patch
+---
+
+Fix passkey signing to preserve raw WebAuthn `clientDataJSON` in the secp256r1 authority payload.


### PR DESCRIPTION
## Summary
- add a patch changeset for the developer SDK passkey signing fix

## Verification
- changeset-only change; no runtime tests needed