### PR TITLE
Add recovery flow helpers to developer SDK

### DIFF
--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -265,6 +265,70 @@ client. Do not authority-sign `created.operatorSignedTransactions`; those
 already include the backend recovery operator signature and only need the final
 fee-payer or sponsor signature before submission.
 
+## Recovery Flow
+
+Recovery-enabled wallets can be created by passing a guardian public key. The
+backend installs the recovery authority and returns the operator-signed
+configure-recovery transaction in `operatorSignedTransactions`. The current
+backend requires `policyId` when `guardianPubkey` is provided.
+
+```typescript
+const created = await swig.wallets.create({
+  feePayer,
+  policyId,
+  initialUser: {
+    secp256r1: {
+      publicKey: passkeyPublicKey,
+    },
+  },
+  guardianPubkey: guardianPublicKey,
+});
+```
+
+After wallet creation, use the wallet recovery helper to prepare start, cancel,
+and execute transactions:
+
+```typescript
+import { signPreparedTransaction } from '@swig-wallet/developer-sdk/client';
+
+declare const signWithGuardian: Parameters<
+  typeof signPreparedTransaction
+>[1]['signTransaction'];
+
+const wallet = swig.wallets.use(created.wallet, {
+  requesterAuthority: {
+    secp256r1: {
+      publicKey: passkeyPublicKey,
+    },
+  },
+});
+
+const start = await wallet.recovery.start({
+  feePayer,
+  guardianPubkey: guardianPublicKey,
+  newAuthority: newAuthorityPublicKey,
+});
+const signedStart = await signPreparedTransaction(start, {
+  signTransaction: signWithGuardian,
+});
+
+const cancel = await wallet.recovery.cancel({
+  feePayer,
+});
+
+const execute = await wallet.recovery.execute({
+  feePayer,
+  newAuthority: newAuthorityPublicKey,
+});
+const signedExecute = await signPreparedTransaction(execute, {
+  signTransaction: signWithGuardian,
+});
+```
+
+The guardian signs both start and execute. The current wallet authority signs
+cancel. Execute is prepared after the recovery delay has elapsed and applies the
+recovered authority change.
+
 ## Public Entrypoints
 
 - `@swig-wallet/developer-sdk/server/typescript`: API-key server SDK for manual

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 
+import { p256 } from '@noble/curves/p256';
+import {
+  createAssociatedTokenAccountInstruction,
+  createMint,
+  createMintToInstruction,
+  getAccount,
+  getAssociatedTokenAddress,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
 import {
   Connection,
   Keypair,
@@ -14,6 +23,10 @@ import {
   type PreparedTransaction,
 } from '@swig-wallet/developer-sdk';
 import {
+  signPreparedSwigTransaction,
+  type PasskeySigningFn,
+} from '../src/client/index.js';
+import {
   createSwigNestHandler,
   type SwigNestHandler,
   type SwigNestResponseLike,
@@ -24,11 +37,18 @@ const databaseUrl = 'postgres://swig:swig@localhost:55432/swig';
 const rpcUrl = 'http://localhost:8899';
 const swapAmountLamports = 10_000_000;
 const swapSlippageBps = 1_000;
+const tokenTransferAmount = 25;
+const localRecoveryPolicyId = 'clocalrecoverypolicy001';
+const recoverySmokeOnly = process.env.RECOVERY_SMOKE_ONLY === '1';
+const runRecoverySmokeEnabled =
+  recoverySmokeOnly || process.env.RUN_RECOVERY_SMOKE === '1';
 const runId = randomUUID();
 const apiKey = `sk_local_transaction_smoke_${runId}`;
+const recoveryApiKey = `sk_local_recovery_smoke_${runId}`;
 const userId = `local-smoke-user-${runId}`;
 const organizationId = `local-smoke-org-${runId}`;
 const apiKeyId = `local-smoke-api-key-${runId}`;
+const recoveryApiKeyId = `local-recovery-api-key-${runId}`;
 const feePayer = Keypair.generate();
 const requester = Keypair.generate();
 const destination = Keypair.generate();
@@ -41,6 +61,15 @@ async function main() {
   const connection = new Connection(rpcUrl, 'confirmed');
 
   seedLocalFixture();
+
+  if (recoverySmokeOnly) {
+    console.log(`local recovery smoke: ${runId}`);
+    console.log(`api: ${apiBaseUrl}`);
+    console.log(`rpc: ${rpcUrl}`);
+    await runRecoverySmoke(connection);
+    return;
+  }
+
   await airdropIfNeeded(connection, feePayer.publicKey, LAMPORTS_PER_SOL);
 
   const swig = new SwigClient({
@@ -71,6 +100,9 @@ async function main() {
   const createTransaction = requirePrepared(created.creationTransaction);
   console.log(`swig config: ${created.wallet.swigConfigAddress}`);
   console.log(`wallet: ${requireWalletAddress(created.wallet.walletAddress)}`);
+  const walletAddress = new PublicKey(
+    requireWalletAddress(created.wallet.walletAddress),
+  );
 
   const createSignature = await signAndSendPreparedTransaction(
     connection,
@@ -82,10 +114,11 @@ async function main() {
     connection,
     new PublicKey(created.wallet.swigConfigAddress),
   );
+  await airdropIfNeeded(connection, walletAddress, LAMPORTS_PER_SOL / 10);
   await airdropIfNeeded(
     connection,
-    new PublicKey(requireWalletAddress(created.wallet.walletAddress)),
-    LAMPORTS_PER_SOL / 10,
+    destination.publicKey,
+    await connection.getMinimumBalanceForRentExemption(0),
   );
 
   const transferTransaction = await wallet.transfer.sol({
@@ -106,6 +139,79 @@ async function main() {
   const after = await connection.getBalance(destination.publicKey);
   console.log(`transfer signature: ${transferSignature}`);
   console.log(`destination balance delta: ${after - before} lamports`);
+
+  const tokenMint = await createMint(
+    connection,
+    feePayer,
+    feePayer.publicKey,
+    null,
+    0,
+  );
+  const walletTokenAccount = await getAssociatedTokenAddress(
+    tokenMint,
+    walletAddress,
+    true,
+    TOKEN_PROGRAM_ID,
+  );
+  const destinationTokenAccount = await getAssociatedTokenAddress(
+    tokenMint,
+    destination.publicKey,
+    false,
+    TOKEN_PROGRAM_ID,
+  );
+  const tokenSetupTransaction = new Transaction().add(
+    createAssociatedTokenAccountInstruction(
+      feePayer.publicKey,
+      walletTokenAccount,
+      walletAddress,
+      tokenMint,
+      TOKEN_PROGRAM_ID,
+    ),
+    createAssociatedTokenAccountInstruction(
+      feePayer.publicKey,
+      destinationTokenAccount,
+      destination.publicKey,
+      tokenMint,
+      TOKEN_PROGRAM_ID,
+    ),
+    createMintToInstruction(
+      tokenMint,
+      walletTokenAccount,
+      feePayer.publicKey,
+      tokenTransferAmount,
+      [],
+      TOKEN_PROGRAM_ID,
+    ),
+  );
+  const tokenSetupSignature = await signAndSendLocalTransaction(
+    connection,
+    tokenSetupTransaction,
+    [feePayer],
+  );
+  console.log(`token setup signature: ${tokenSetupSignature}`);
+
+  const tokenTransferTransaction = await wallet.transfer.token({
+    feePayer: feePayer.publicKey.toBase58(),
+    requesterAuthority: {
+      ed25519: { publicKey: requester.publicKey.toBase58() },
+    },
+    mint: tokenMint.toBase58(),
+    destinationOwner: destination.publicKey.toBase58(),
+    amount: tokenTransferAmount,
+  });
+  const tokenBefore = await getAccount(connection, destinationTokenAccount);
+  const tokenTransferSignature = await signAndSendPreparedTransaction(
+    connection,
+    tokenTransferTransaction,
+    [feePayer, requester],
+  );
+  const tokenAfter = await getAccount(connection, destinationTokenAccount);
+  console.log(`token transfer signature: ${tokenTransferSignature}`);
+  console.log(
+    `destination token balance delta: ${
+      tokenAfter.amount - tokenBefore.amount
+    } units`,
+  );
 
   const swapTransaction = await wallet.swap.jupiter({
     feePayer: feePayer.publicKey.toBase58(),
@@ -139,6 +245,12 @@ async function main() {
       ed25519: { publicKey: requester.publicKey.toBase58() },
     }),
   });
+  const nestTransferDestination = Keypair.generate();
+  await airdropIfNeeded(
+    connection,
+    nestTransferDestination.publicKey,
+    await connection.getMinimumBalanceForRentExemption(0),
+  );
   const nestTransferTransaction = await prepareWithNest(nestHandler, {
     route: '/swig/transfer/sol',
     body: {
@@ -147,7 +259,7 @@ async function main() {
         walletAddress: wallet.walletAddress,
       },
       network: 'devnet',
-      destination: Keypair.generate().publicKey.toBase58(),
+      destination: nestTransferDestination.publicKey.toBase58(),
       amount: '1000',
     },
   });
@@ -181,6 +293,10 @@ async function main() {
     [feePayer, requester],
   );
   console.log(`nest swap signature: ${nestSwapSignature}`);
+
+  if (runRecoverySmokeEnabled) {
+    await runRecoverySmoke(connection);
+  }
 }
 
 function seedLocalFixture() {
@@ -209,6 +325,20 @@ ON CONFLICT (key) DO UPDATE SET
   "organizationId" = EXCLUDED."organizationId",
   "userId" = EXCLUDED."userId";
 
+INSERT INTO "api_keys" (id, key, name, "organizationId", "userId", "updatedAt")
+VALUES (
+  ${sqlLiteral(recoveryApiKeyId)},
+  ${sqlLiteral(sha256Hex(recoveryApiKey))},
+  'Local Recovery Smoke',
+  'clocaldashboarddemoorg001',
+  'clocaldashboarduser001',
+  NOW()
+)
+ON CONFLICT (key) DO UPDATE SET
+  "updatedAt" = NOW(),
+  "organizationId" = EXCLUDED."organizationId",
+  "userId" = EXCLUDED."userId";
+
 COMMIT;
 `;
 
@@ -222,6 +352,162 @@ COMMIT;
       `Failed to seed local transaction API fixture. Make sure psql is installed and Postgres is reachable at ${databaseUrl}.\n${String(error)}`,
     );
   }
+}
+
+async function runRecoverySmoke(connection: Connection) {
+  const recoveryFeePayer = Keypair.generate();
+  const guardian = Keypair.generate();
+  const initialAuthority = createP256Authority();
+  const newAuthority = createP256Authority();
+  const recoveryDestination = Keypair.generate();
+
+  await airdropIfNeeded(
+    connection,
+    recoveryFeePayer.publicKey,
+    LAMPORTS_PER_SOL,
+  );
+  await airdropIfNeeded(
+    connection,
+    recoveryDestination.publicKey,
+    await connection.getMinimumBalanceForRentExemption(0),
+  );
+
+  const recoverySwig = new SwigClient({
+    apiKey: recoveryApiKey,
+    baseUrl: apiBaseUrl,
+    network: 'devnet',
+  });
+
+  const created = await recoverySwig.wallets.create({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    policyId: localRecoveryPolicyId,
+    initialUser: {
+      secp256r1: {
+        publicKey: initialAuthority.publicKeyHex,
+      },
+    },
+    guardianPubkey: guardian.publicKey.toBase58(),
+  });
+  const recoveryWalletAddress = new PublicKey(
+    requireWalletAddress(created.wallet.walletAddress),
+  );
+  const wallet = recoverySwig.wallets.use(created.wallet, {
+    requesterAuthority: {
+      secp256r1: {
+        publicKey: initialAuthority.publicKeyHex,
+      },
+    },
+  });
+
+  console.log(`recovery swig config: ${created.wallet.swigConfigAddress}`);
+  console.log(`recovery wallet: ${recoveryWalletAddress.toBase58()}`);
+  console.log(`recovery guardian: ${guardian.publicKey.toBase58()}`);
+
+  const recoveryCreateSignature = await signAndSendPreparedTransaction(
+    connection,
+    requirePrepared(created.creationTransaction),
+    [recoveryFeePayer],
+  );
+  console.log(`recovery create signature: ${recoveryCreateSignature}`);
+  await waitForAccount(
+    connection,
+    new PublicKey(created.wallet.swigConfigAddress),
+  );
+
+  const addRecoverySignature = await signSwigAndSendPreparedTransaction(
+    connection,
+    requirePrepared(created.addAuthorityTransaction),
+    initialAuthority.signingFn,
+    [recoveryFeePayer],
+  );
+  console.log(`recovery add authority signature: ${addRecoverySignature}`);
+
+  const configureRecoverySignature = await signAndSendPreparedTransaction(
+    connection,
+    requirePrepared(created.configureRecoveryTransaction),
+    [recoveryFeePayer],
+  );
+  console.log(`recovery configure signature: ${configureRecoverySignature}`);
+
+  await airdropIfNeeded(
+    connection,
+    recoveryWalletAddress,
+    LAMPORTS_PER_SOL / 10,
+  );
+
+  const startForCancel = await wallet.recovery.start({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    guardianPubkey: guardian.publicKey.toBase58(),
+    newAuthority: newAuthority.publicKeyHex,
+  });
+  const startForCancelSignature = await signAndSendPreparedTransaction(
+    connection,
+    startForCancel,
+    [recoveryFeePayer, guardian],
+  );
+  console.log(
+    `recovery start/cancel start signature: ${startForCancelSignature}`,
+  );
+
+  const cancel = await wallet.recovery.cancel({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+  });
+  const cancelSignature = await signSwigAndSendPreparedTransaction(
+    connection,
+    cancel,
+    initialAuthority.signingFn,
+    [recoveryFeePayer],
+  );
+  console.log(`recovery cancel signature: ${cancelSignature}`);
+
+  const start = await wallet.recovery.start({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    guardianPubkey: guardian.publicKey.toBase58(),
+    newAuthority: newAuthority.publicKeyHex,
+  });
+  const startSignature = await signAndSendPreparedTransaction(
+    connection,
+    start,
+    [recoveryFeePayer, guardian],
+  );
+  console.log(`recovery start signature: ${startSignature}`);
+
+  await Bun.sleep(5_000);
+
+  const execute = await wallet.recovery.execute({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    newAuthority: newAuthority.publicKeyHex,
+  });
+  const executeSignature = await signAndSendPreparedTransaction(
+    connection,
+    execute,
+    [recoveryFeePayer, guardian],
+  );
+  console.log(`recovery execute signature: ${executeSignature}`);
+
+  const postRecoveryTransfer = await wallet.transfer.sol({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    requesterAuthority: {
+      secp256r1: {
+        publicKey: newAuthority.publicKeyHex,
+      },
+    },
+    destination: recoveryDestination.publicKey.toBase58(),
+    amount: 1_000,
+  });
+  const before = await connection.getBalance(recoveryDestination.publicKey);
+  const postRecoveryTransferSignature =
+    await signSwigAndSendPreparedTransaction(
+      connection,
+      postRecoveryTransfer,
+      newAuthority.signingFn,
+      [recoveryFeePayer],
+    );
+  const after = await connection.getBalance(recoveryDestination.publicKey);
+  console.log(
+    `recovery post-execute transfer signature: ${postRecoveryTransferSignature}`,
+  );
+  console.log(`recovery destination balance delta: ${after - before} lamports`);
 }
 
 async function signAndSendPreparedTransaction(
@@ -239,7 +525,7 @@ async function signAndSendPreparedTransaction(
   }
 
   const transaction = deserializePreparedTransaction(prepared);
-  const requiredSigners = getRequiredSigners(transaction);
+  const requiredSigners = getUnsignedRequiredSigners(transaction);
   const availableSigners = signers.filter((signer) =>
     requiredSigners.includes(signer.publicKey.toBase58()),
   );
@@ -272,18 +558,62 @@ async function signAndSendPreparedTransaction(
   return signature;
 }
 
-function getRequiredSigners(
+async function signSwigAndSendPreparedTransaction(
+  connection: Connection,
+  prepared: PreparedTransaction,
+  signingFn: PasskeySigningFn,
+  signers: Keypair[],
+): Promise<string> {
+  const signed = await signPreparedSwigTransaction(prepared, {
+    secp256r1: signingFn,
+  });
+  return signAndSendPreparedTransaction(
+    connection,
+    { ...prepared, ...signed, signatureRequests: [] },
+    signers,
+  );
+}
+
+async function signAndSendLocalTransaction(
+  connection: Connection,
+  transaction: Transaction,
+  signers: Keypair[],
+): Promise<string> {
+  transaction.feePayer = signers[0]?.publicKey;
+  transaction.recentBlockhash = (
+    await connection.getLatestBlockhash('confirmed')
+  ).blockhash;
+  transaction.sign(...signers);
+
+  const signature = await connection.sendRawTransaction(
+    transaction.serialize(),
+    {
+      skipPreflight: false,
+    },
+  );
+  await confirmSignature(connection, signature);
+  return signature;
+}
+
+function getUnsignedRequiredSigners(
   transaction: Transaction | VersionedTransaction,
 ): string[] {
   if (transaction instanceof VersionedTransaction) {
     return transaction.message.staticAccountKeys
       .slice(0, transaction.message.header.numRequiredSignatures)
+      .filter((_, index) => isEmptySignature(transaction.signatures[index]))
       .map((key) => key.toBase58());
   }
 
   const message = transaction.compileMessage();
   return message.accountKeys
     .slice(0, message.header.numRequiredSignatures)
+    .filter((key) => {
+      const signature = transaction.signatures.find((entry) =>
+        entry.publicKey.equals(key),
+      )?.signature;
+      return isEmptySignature(signature);
+    })
     .map((key) => key.toBase58());
 }
 
@@ -400,6 +730,30 @@ function requireWalletAddress(walletAddress: string | undefined): string {
     throw new Error('Create wallet response did not include a wallet address');
   }
   return walletAddress;
+}
+
+function createP256Authority(): {
+  publicKeyHex: string;
+  signingFn: PasskeySigningFn;
+} {
+  const privateKey = p256.utils.randomPrivateKey();
+  const publicKey = p256.getPublicKey(privateKey, true);
+  return {
+    publicKeyHex: bytesToHex(publicKey),
+    signingFn: async (message) => ({
+      signature: p256.sign(message, privateKey).toCompactRawBytes(),
+    }),
+  };
+}
+
+function isEmptySignature(
+  signature: Uint8Array | Buffer | null | undefined,
+): boolean {
+  return !signature || signature.every((byte) => byte === 0);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function sha256Hex(value: string): string {

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -5,10 +5,12 @@ export { WalletHandle, WalletsClient } from './wallets/index.js';
 
 export type {
   Amount,
+  CancelRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
   ExecuteArgs,
+  ExecuteRecoveryArgs,
   IdpWalletSession,
   JsonObject,
   JsonValue,
@@ -21,6 +23,7 @@ export type {
   SolanaInstruction,
   SolanaInstructionInput,
   SponsorSignedTransactionArgs,
+  StartRecoveryArgs,
   SubmittedTransaction,
   SubmittedTransactionWire,
   SwapArgs,

--- a/packages/developer-sdk/src/server/index.ts
+++ b/packages/developer-sdk/src/server/index.ts
@@ -8,10 +8,12 @@ export {
 
 export type {
   Amount,
+  CancelRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
   ExecuteArgs,
+  ExecuteRecoveryArgs,
   IdpWalletSession,
   JsonObject,
   JsonValue,
@@ -20,6 +22,7 @@ export type {
   PreparedTransactionWire,
   RetryOptions,
   SponsorSignedTransactionArgs,
+  StartRecoveryArgs,
   SubmittedTransaction,
   SubmittedTransactionWire,
   SwapArgs,

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -77,6 +77,25 @@ export interface SwapArgs {
   idempotencyKey?: string;
 }
 
+export interface BaseRecoveryArgs {
+  feePayer: string;
+  network?: Network;
+  idempotencyKey?: string;
+}
+
+export interface StartRecoveryArgs extends BaseRecoveryArgs {
+  guardianPubkey: string;
+  newAuthority: string;
+}
+
+export interface CancelRecoveryArgs extends BaseRecoveryArgs {
+  requesterAuthority?: WalletAuthority;
+}
+
+export interface ExecuteRecoveryArgs extends BaseRecoveryArgs {
+  newAuthority: string;
+}
+
 export interface ExecuteArgs {
   instructions: SolanaInstructionInput[];
   addressLookupTableAccounts?: string[];

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, test } from 'bun:test';
 import { SwigClient } from '../server/typescript/index.js';
 import { WalletsClient } from './client.js';
 import {
+  cancelRecoveryRequest,
+  executeRecoveryRequest,
+  startRecoveryRequest,
   swapRequest,
   transferSolRequest,
   transferTokenRequest,
@@ -189,6 +192,65 @@ describe('WalletsClient', () => {
       maxAccounts: 32,
       mode: 'fast',
       blockhashSlotsToExpiry: 10,
+    });
+  });
+
+  test('builds recovery requests for the transaction API', () => {
+    const wallets = new WalletsClient(
+      { post: async () => ({}) } as never,
+      'devnet',
+    );
+    const wallet = wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    expect(
+      startRecoveryRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+          guardianPubkey: 'guardian_123',
+          newAuthority: 'new_authority_123',
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigAddress: 'swig_config_123',
+      guardianPubkey: 'guardian_123',
+      newAuthority: 'new_authority_123',
+    });
+    expect(
+      cancelRecoveryRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+    expect(
+      executeRecoveryRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+          newAuthority: 'new_authority_123',
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigAddress: 'swig_config_123',
+      newAuthority: 'new_authority_123',
     });
   });
 
@@ -552,5 +614,85 @@ describe('WalletsClient', () => {
       network: 'devnet',
       recentBlockhash: 'blockhash_789',
     });
+  });
+
+  test('prepares recovery flow through the transaction API', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transaction: `base64-${calls.length}-tx`,
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+          recentBlockhash: 'blockhash_recovery',
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const started = await wallet.recovery.start({
+      feePayer: 'payer_123',
+      guardianPubkey: 'guardian_123',
+      newAuthority: 'new_authority_123',
+    });
+    const cancelled = await wallet.recovery.cancel({
+      feePayer: 'payer_123',
+    });
+    const executed = await wallet.recovery.execute({
+      feePayer: 'payer_123',
+      newAuthority: 'new_authority_123',
+    });
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/recovery/start',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        guardianPubkey: 'guardian_123',
+        newAuthority: 'new_authority_123',
+      },
+    });
+    expect(calls[1]).toMatchObject({
+      url: 'http://localhost:8080/transaction/recovery/cancel',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+      },
+    });
+    expect(calls[2]).toMatchObject({
+      url: 'http://localhost:8080/transaction/recovery/execute',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        newAuthority: 'new_authority_123',
+      },
+    });
+    expect(started).toMatchObject({
+      transaction: 'base64-1-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+    });
+    expect(cancelled.transaction).toBe('base64-2-tx');
+    expect(executed.transaction).toBe('base64-3-tx');
   });
 });

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -1,9 +1,11 @@
 import type { HttpClient } from '../core/index.js';
 import type {
+  CancelRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponseWire,
   CreateWalletResult,
   ExecuteArgs,
+  ExecuteRecoveryArgs,
   IdpWalletSession,
   Network,
   PrepareArgs,
@@ -11,6 +13,7 @@ import type {
   PreparedTransactionsResult,
   PreparedTransactionWire,
   PrepareTransactionsResponseWire,
+  StartRecoveryArgs,
   SwapArgs,
   TransferArgs,
   WalletHandleOptions,
@@ -23,10 +26,13 @@ import {
   normalizePrepareTransactionsResponse,
 } from './normalizers.js';
 import {
+  cancelRecoveryRequest,
   createWalletRequest,
+  executeRecoveryRequest,
   executeRequest,
   isTokenTransfer,
   prepareRequest,
+  startRecoveryRequest,
   swapRequest,
   transferSolRequest,
   transferTokenRequest,
@@ -145,6 +151,39 @@ export class WalletsClient {
     const response = await this.http.post<PreparedTransactionWire>(
       '/transaction/swap/jupiter',
       swapRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  startRecovery = async (
+    wallet: WalletHandle,
+    args: StartRecoveryArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      '/transaction/recovery/start',
+      startRecoveryRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  cancelRecovery = async (
+    wallet: WalletHandle,
+    args: CancelRecoveryArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      '/transaction/recovery/cancel',
+      cancelRecoveryRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  executeRecovery = async (
+    wallet: WalletHandle,
+    args: ExecuteRecoveryArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      '/transaction/recovery/execute',
+      executeRecoveryRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePreparedTransaction(response);
   };

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -1,9 +1,12 @@
 import type {
+  CancelRecoveryArgs,
   ExecuteArgs,
+  ExecuteRecoveryArgs,
   Network,
   PrepareArgs,
   PreparedTransaction,
   PreparedTransactionsResult,
+  StartRecoveryArgs,
   SwapArgs,
   TransferArgs,
   TransferSolArgs,
@@ -26,6 +29,12 @@ export type WalletSwapClient = {
   jupiter(args: SwapArgs): Promise<PreparedTransaction>;
 };
 
+export type WalletRecoveryClient = {
+  start(args: StartRecoveryArgs): Promise<PreparedTransaction>;
+  cancel(args: CancelRecoveryArgs): Promise<PreparedTransaction>;
+  execute(args: ExecuteRecoveryArgs): Promise<PreparedTransaction>;
+};
+
 export class WalletHandle {
   readonly swigConfigAddress: string;
   readonly walletAddress?: string;
@@ -33,6 +42,7 @@ export class WalletHandle {
   readonly requesterAuthority?: WalletReference['requesterAuthority'];
   readonly transfer: WalletTransferClient;
   readonly swap: WalletSwapClient;
+  readonly recovery: WalletRecoveryClient;
 
   constructor(
     private readonly wallets: WalletsClient,
@@ -44,6 +54,7 @@ export class WalletHandle {
     this.requesterAuthority = init.requesterAuthority;
     this.transfer = createWalletTransferClient(wallets, this);
     this.swap = createWalletSwapClient(wallets, this);
+    this.recovery = createWalletRecoveryClient(wallets, this);
   }
 
   prepare = (args: PrepareArgs): Promise<PreparedTransactionsResult> =>
@@ -76,4 +87,16 @@ function createWalletSwapClient(
   swap.jupiter = (args: SwapArgs) => wallets.jupiterSwap(wallet, args);
 
   return swap;
+}
+
+function createWalletRecoveryClient(
+  wallets: WalletsClient,
+  wallet: WalletHandle,
+): WalletRecoveryClient {
+  return {
+    start: (args: StartRecoveryArgs) => wallets.startRecovery(wallet, args),
+    cancel: (args: CancelRecoveryArgs) => wallets.cancelRecovery(wallet, args),
+    execute: (args: ExecuteRecoveryArgs) =>
+      wallets.executeRecovery(wallet, args),
+  };
 }

--- a/packages/developer-sdk/src/wallets/index.ts
+++ b/packages/developer-sdk/src/wallets/index.ts
@@ -2,6 +2,7 @@ export { WalletsClient } from './client.js';
 export { WalletHandle } from './handle.js';
 export type {
   WalletHandleInit,
+  WalletRecoveryClient,
   WalletSwapClient,
   WalletTransferClient,
 } from './handle.js';

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -1,9 +1,12 @@
 import type {
+  CancelRecoveryArgs,
   CreateWalletArgs,
   ExecuteArgs,
+  ExecuteRecoveryArgs,
   Network,
   PrepareArgs,
   PrepareOperation,
+  StartRecoveryArgs,
   SwapArgs,
   TransferArgs,
   TransferSolArgs,
@@ -109,6 +112,52 @@ export function swapRequest(
   };
 }
 
+export function startRecoveryRequest(
+  wallet: WalletHandle,
+  args: StartRecoveryArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    guardianPubkey: args.guardianPubkey,
+    newAuthority: args.newAuthority,
+  };
+}
+
+export function cancelRecoveryRequest(
+  wallet: WalletHandle,
+  args: CancelRecoveryArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
+  };
+}
+
+export function executeRecoveryRequest(
+  wallet: WalletHandle,
+  args: ExecuteRecoveryArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    newAuthority: args.newAuthority,
+  };
+}
+
 export function executeRequest(
   wallet: WalletHandle,
   args: ExecuteArgs,
@@ -159,11 +208,12 @@ function resolveNetwork(...networks: Array<Network | undefined>): Network {
 
 function resolveRequesterAuthority(
   wallet: WalletHandle,
-  args: TransferArgs | SwapArgs | PrepareArgs,
+  args: TransferArgs | SwapArgs | PrepareArgs | CancelRecoveryArgs,
 ): NonNullable<
   | TransferArgs['requesterAuthority']
   | SwapArgs['requesterAuthority']
   | PrepareArgs['requesterAuthority']
+  | CancelRecoveryArgs['requesterAuthority']
 > {
   const requesterAuthority =
     args.requesterAuthority ?? wallet.requesterAuthority;


### PR DESCRIPTION
## Summary
- add wallet recovery start/cancel/execute helpers and request types
- document the recovery create/lifecycle SDK shape
- expand local smoke coverage for SPL token transfer and optional recovery smoke

## Verification
- bun --filter @swig-wallet/developer-sdk typecheck
- bun --filter @swig-wallet/developer-sdk test
- bun --filter @swig-wallet/developer-sdk lint
- bun test packages/developer-sdk/src/wallets/client.test.ts
- bunx prettier --write packages/developer-sdk/scripts/local-transaction-smoke.ts
- local Surfpool smoke: bun --filter @swig-wallet/developer-sdk smoke:local passed before the optional recovery leg was added

## Notes
- RECOVERY_SMOKE_ONLY=1 currently reaches the local backend and fails with HTTP 400 because the local transaction-service has no enclave_operator_signer_url configured.