### PR TITLE
Update SDK recovery setup flow

### DIFF
--- a/packages/api/src/portal/policies.ts
+++ b/packages/api/src/portal/policies.ts
@@ -19,7 +19,7 @@ export class PoliciesApi {
 
   async get(policyId: string): Promise<ApiResponse<Policy>> {
     const baseUrl = this.#requirePortalUrl();
-    const url = `${baseUrl}/api/v1/policies/${encodeURIComponent(policyId)}`;
+    const url = `${baseUrl}/wallet/policies/${encodeURIComponent(policyId)}`;
     return request<Policy>(
       url,
       {

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 
 import { p256 } from '@noble/curves/p256';
+import { sha256 } from '@noble/hashes/sha2';
 import {
   createAssociatedTokenAccountInstruction,
   createMint,
@@ -386,7 +387,9 @@ async function runRecoverySmoke(connection: Connection) {
         publicKey: initialAuthority.publicKeyHex,
       },
     },
-    guardianPubkey: guardian.publicKey.toBase58(),
+    recovery: {
+      guardianPubkey: guardian.publicKey.toBase58(),
+    },
   });
   const recoveryWalletAddress = new PublicKey(
     requireWalletAddress(created.wallet.walletAddress),
@@ -414,9 +417,19 @@ async function runRecoverySmoke(connection: Connection) {
     new PublicKey(created.wallet.swigConfigAddress),
   );
 
+  if (!created.recoverySetup) {
+    throw new Error('Recovery-enabled policy did not return a setup plan');
+  }
+  const recoverySetup = await wallet.recovery.prepareSetup({
+    feePayer: recoveryFeePayer.publicKey.toBase58(),
+    guardianPubkey: created.recoverySetup.guardianPubkey,
+    delaySeconds: created.recoverySetup.delaySeconds,
+    targetRoleId: created.recoverySetup.targetRoleId,
+  });
+
   const addRecoverySignature = await signSwigAndSendPreparedTransaction(
     connection,
-    requirePrepared(created.addAuthorityTransaction),
+    requirePrepared(recoverySetup.addAuthorityTransaction),
     initialAuthority.signingFn,
     [recoveryFeePayer],
   );
@@ -424,7 +437,7 @@ async function runRecoverySmoke(connection: Connection) {
 
   const configureRecoverySignature = await signAndSendPreparedTransaction(
     connection,
-    requirePrepared(created.configureRecoveryTransaction),
+    requirePrepared(recoverySetup.configureRecoveryTransaction),
     [recoveryFeePayer],
   );
   console.log(`recovery configure signature: ${configureRecoverySignature}`);
@@ -741,7 +754,9 @@ function createP256Authority(): {
   return {
     publicKeyHex: bytesToHex(publicKey),
     signingFn: async (message) => ({
-      signature: p256.sign(message, privateKey).toCompactRawBytes(),
+      signature: p256
+        .sign(sha256(message), privateKey, { lowS: true })
+        .toCompactRawBytes(),
     }),
   };
 }

--- a/packages/developer-sdk/src/core/http.ts
+++ b/packages/developer-sdk/src/core/http.ts
@@ -21,6 +21,12 @@ export class HttpClient {
     this.#fetch = config.fetch;
   }
 
+  get = async <TResponse>(path: string): Promise<TResponse> => {
+    return this.#request<TResponse>(path, {
+      method: 'GET',
+    });
+  };
+
   post = async <TResponse>(path: string, body: unknown): Promise<TResponse> => {
     return this.#request<TResponse>(path, {
       method: 'POST',

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -4,8 +4,10 @@ export { TransactionsClient } from './transactions/index.js';
 export { WalletHandle, WalletsClient } from './wallets/index.js';
 
 export type {
+  AddRecoveryAuthorityArgs,
   Amount,
   CancelRecoveryArgs,
+  ConfigureRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
@@ -15,9 +17,14 @@ export type {
   JsonObject,
   JsonValue,
   Network,
+  Policy,
+  PolicyAuthority,
+  PrepareRecoverySetupArgs,
+  PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionWire,
   PreparedTransactionsResult,
+  RecoverySetupPlan,
   RetryOptions,
   SolanaAccountMeta,
   SolanaInstruction,

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -42,6 +42,22 @@ describe('createSwigFetchHandler', () => {
       feePayer: 'payer_123',
       fetch: jsonFetch((request) => {
         calls.push(request);
+        if (request.method === 'GET') {
+          return {
+            id: 'policy_123',
+            name: 'Default policy',
+            description: null,
+            authority: {
+              type: 'Ed25519',
+              publicKey: 'initial_user_123',
+            },
+            actions: [{ type: 'All' }],
+            guardianEnabled: false,
+            guardianAuthority: null,
+            guardianDelaySeconds: 86_400,
+          };
+        }
+
         return {
           wallet: {
             swigConfigAddress: 'swig_config_123',
@@ -106,6 +122,10 @@ describe('createSwigFetchHandler', () => {
       },
     });
     expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/policies/policy_123',
+      method: 'GET',
+    });
+    expect(calls[1]).toMatchObject({
       url: 'http://localhost:8080/transaction/wallet/create',
       body: {
         network: 'NETWORK_DEVNET',
@@ -171,6 +191,90 @@ describe('createSwigFetchHandler', () => {
     expect(
       (calls[0]?.body as Record<string, unknown>).policyId,
     ).toBeUndefined();
+  });
+
+  test('passes recovery options through wallet creation', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        if (request.method === 'GET') {
+          return {
+            id: 'policy_123',
+            name: 'Recovery policy',
+            description: null,
+            authority: null,
+            actions: [{ type: 'All' }],
+            guardianEnabled: true,
+            guardianAuthority: null,
+            guardianDelaySeconds: '1',
+          };
+        }
+
+        return {
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              transaction: 'base64-create-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+            },
+          ],
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/wallet/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          network: 'devnet',
+          policyId: 'policy_123',
+          initialUser: {
+            secp256r1: {
+              publicKey: 'passkey_public_key_123',
+            },
+          },
+          recovery: {
+            guardianPubkey: 'guardian_123',
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      prepared: {
+        recoverySetup: {
+          requesterAuthority: {
+            secp256r1: {
+              publicKey: 'passkey_public_key_123',
+            },
+          },
+          guardianPubkey: 'guardian_123',
+          delaySeconds: 1,
+          targetRoleId: 0,
+        },
+      },
+    });
+    expect(calls[1]?.body).toMatchObject({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      policyId: 'policy_123',
+      initialUser: {
+        secp256r1: {
+          publicKey: 'passkey_public_key_123',
+        },
+      },
+    });
   });
 
   test('prepares SOL transfers through the API-key server client', async () => {

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -134,6 +134,7 @@ async function prepareWalletCreation(
   const feePayer = await resolveFeePayer(context, config);
   const policyId = readOptionalString(body, 'policyId');
   const initialUser = readWalletAuthority(body.initialUser);
+  const recovery = readRecoveryOptions(body.recovery);
   if (!policyId && !initialUser) {
     throw new SwigRouteError('policyId or initialUser is required');
   }
@@ -142,9 +143,7 @@ async function prepareWalletCreation(
     feePayer,
     ...(policyId ? { policyId } : {}),
     ...(initialUser ? { initialUser } : {}),
-    ...(readOptionalString(body, 'guardianPubkey')
-      ? { guardianPubkey: readOptionalString(body, 'guardianPubkey') }
-      : {}),
+    ...(recovery ? { recovery } : {}),
     ...(context.network ? { network: context.network } : {}),
     ...(readOptionalString(body, 'idempotencyKey')
       ? { idempotencyKey: readOptionalString(body, 'idempotencyKey') }
@@ -203,6 +202,7 @@ function createWalletResult(
     creationTransaction: wallet.creationTransaction,
     addAuthorityTransaction: wallet.addAuthorityTransaction,
     configureRecoveryTransaction: wallet.configureRecoveryTransaction,
+    recoverySetup: wallet.recoverySetup,
     network: wallet.network,
   };
 }
@@ -462,6 +462,27 @@ function readWalletAuthority(
     }
   }
   throw new SwigRouteError(`${field} must include a supported authority`);
+}
+
+function readRecoveryOptions(
+  value: unknown,
+): CreateWalletArgs['recovery'] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new SwigRouteError('recovery must be an object');
+  }
+
+  const guardianPubkey = readOptionalString(value, 'guardianPubkey');
+  const delaySeconds = readOptionalNumber(value, 'delaySeconds');
+  const targetRoleId = readOptionalNumber(value, 'targetRoleId');
+
+  return {
+    ...(guardianPubkey ? { guardianPubkey } : {}),
+    ...(delaySeconds !== undefined ? { delaySeconds } : {}),
+    ...(targetRoleId !== undefined ? { targetRoleId } : {}),
+  };
 }
 
 function requireWallet(wallet: WalletReference | undefined): WalletReference {

--- a/packages/developer-sdk/src/server/index.ts
+++ b/packages/developer-sdk/src/server/index.ts
@@ -7,8 +7,10 @@ export {
 } from './typescript/index.js';
 
 export type {
+  AddRecoveryAuthorityArgs,
   Amount,
   CancelRecoveryArgs,
+  ConfigureRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
@@ -18,8 +20,14 @@ export type {
   JsonObject,
   JsonValue,
   Network,
+  Policy,
+  PolicyAuthority,
+  PrepareRecoverySetupArgs,
+  PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionWire,
+  PreparedTransactionsResult,
+  RecoverySetupPlan,
   RetryOptions,
   SponsorSignedTransactionArgs,
   StartRecoveryArgs,

--- a/packages/developer-sdk/src/types/index.ts
+++ b/packages/developer-sdk/src/types/index.ts
@@ -2,6 +2,7 @@ export type * from './common.js';
 export type * from './config.js';
 export type * from './instruction.js';
 export type * from './passkeys.js';
+export type * from './policy.js';
 export type * from './transaction.js';
 export type * from './wallet-actions.js';
 export type * from './wallet.js';

--- a/packages/developer-sdk/src/types/policy.ts
+++ b/packages/developer-sdk/src/types/policy.ts
@@ -1,0 +1,22 @@
+import type { WalletAuthority } from './wallet-actions.js';
+
+export type PolicyAuthority =
+  | { type: 'Ed25519'; publicKey: string }
+  | { type: 'Secp256k1'; publicKey: string }
+  | { type: 'Secp256r1'; publicKey: string }
+  | { type: 'Ed25519Session'; publicKey: string; maxDurationSlots: string }
+  | { type: 'Secp256k1Session'; publicKey: string; maxDurationSlots: string }
+  | { type: 'Secp256r1Session'; publicKey: string; maxDurationSlots: string };
+
+export interface Policy {
+  id: string;
+  name: string;
+  description: string | null;
+  authority?: PolicyAuthority | WalletAuthority | null;
+  actions?: unknown[];
+  guardianEnabled?: boolean;
+  initialKeySource?: string;
+  guardianAuthority?: PolicyAuthority | WalletAuthority | null;
+  guardianKeySource?: string;
+  guardianDelaySeconds?: number | string;
+}

--- a/packages/developer-sdk/src/types/transaction.ts
+++ b/packages/developer-sdk/src/types/transaction.ts
@@ -1,4 +1,5 @@
 import type { JsonObject, Network } from './common.js';
+import type { WalletAuthority } from './wallet-actions.js';
 import type { WalletAddressInfo } from './wallet.js';
 
 export type TransactionEncoding = 'base64';
@@ -97,6 +98,13 @@ export interface PreparedTransactionsResult {
   network?: Network;
 }
 
+export interface RecoverySetupPlan {
+  requesterAuthority: WalletAuthority;
+  guardianPubkey: string;
+  delaySeconds: number;
+  targetRoleId?: number;
+}
+
 export interface CreateWalletResult {
   wallet: WalletAddressInfo & { network?: Network };
   transactions: PreparedTransaction[];
@@ -104,6 +112,18 @@ export interface CreateWalletResult {
   operatorSignedTransactions: PreparedTransaction[];
   feePayerOnlyTransactions: PreparedTransaction[];
   creationTransaction?: PreparedTransaction;
+  addAuthorityTransaction?: PreparedTransaction;
+  configureRecoveryTransaction?: PreparedTransaction;
+  recoverySetup?: RecoverySetupPlan;
+  network?: Network;
+}
+
+export interface PreparedRecoverySetupResult {
+  wallet?: WalletAddressInfo & { network?: Network };
+  transactions: PreparedTransaction[];
+  clientAuthorityTransactions: PreparedTransaction[];
+  operatorSignedTransactions: PreparedTransaction[];
+  feePayerOnlyTransactions: PreparedTransaction[];
   addAuthorityTransaction?: PreparedTransaction;
   configureRecoveryTransaction?: PreparedTransaction;
   network?: Network;

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -11,7 +11,11 @@ export interface CreateWalletArgs {
   policyId?: string;
   feePayer: string;
   initialUser?: WalletAuthority;
-  guardianPubkey?: string;
+  recovery?: {
+    guardianPubkey?: string;
+    delaySeconds?: number;
+    targetRoleId?: number;
+  };
   network?: Network;
   idempotencyKey?: string;
 }
@@ -82,6 +86,19 @@ export interface BaseRecoveryArgs {
   network?: Network;
   idempotencyKey?: string;
 }
+
+export interface AddRecoveryAuthorityArgs extends BaseRecoveryArgs {
+  requesterAuthority?: WalletAuthority;
+}
+
+export interface ConfigureRecoveryArgs extends BaseRecoveryArgs {
+  guardianPubkey: string;
+  delaySeconds?: number;
+  targetRoleId?: number;
+}
+
+export interface PrepareRecoverySetupArgs
+  extends AddRecoveryAuthorityArgs, ConfigureRecoveryArgs {}
 
 export interface StartRecoveryArgs extends BaseRecoveryArgs {
   guardianPubkey: string;

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from 'bun:test';
 import { SwigClient } from '../server/typescript/index.js';
 import { WalletsClient } from './client.js';
 import {
+  addRecoveryAuthorityRequest,
   cancelRecoveryRequest,
+  configureRecoveryRequest,
   executeRecoveryRequest,
   startRecoveryRequest,
   swapRequest,
@@ -224,6 +226,39 @@ describe('WalletsClient', () => {
       newAuthority: 'new_authority_123',
     });
     expect(
+      addRecoveryAuthorityRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+    expect(
+      configureRecoveryRequest(
+        wallet,
+        {
+          feePayer: 'payer_123',
+          guardianPubkey: 'guardian_123',
+          delaySeconds: 86_400,
+          targetRoleId: 0,
+        },
+        'devnet',
+      ),
+    ).toEqual({
+      network: 'NETWORK_DEVNET',
+      feePayer: 'payer_123',
+      swigAddress: 'swig_config_123',
+      guardianPubkey: 'guardian_123',
+      delaySeconds: 86_400,
+      targetRoleId: 0,
+    });
+    expect(
       cancelRecoveryRequest(
         wallet,
         {
@@ -262,6 +297,22 @@ describe('WalletsClient', () => {
       network: 'devnet',
       fetch: jsonFetch((request) => {
         calls.push(request);
+        if (request.method === 'GET') {
+          return {
+            id: 'policy_123',
+            name: 'Default policy',
+            description: null,
+            authority: {
+              type: 'Ed25519',
+              publicKey: 'initial_user_123',
+            },
+            actions: [{ type: 'All' }],
+            guardianEnabled: false,
+            guardianAuthority: null,
+            guardianDelaySeconds: 86_400,
+          };
+        }
+
         return {
           network: 'NETWORK_DEVNET',
           wallet: {
@@ -287,8 +338,12 @@ describe('WalletsClient', () => {
       policyId: 'policy_123',
     });
 
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/policies/policy_123',
+      method: 'GET',
+    });
+    expect(calls[1]).toMatchObject({
       url: 'http://localhost:8080/transaction/wallet/create',
       method: 'POST',
       body: {
@@ -298,6 +353,7 @@ describe('WalletsClient', () => {
       },
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+    expect(calls[1]?.headers.get('authorization')).toBe('Bearer sk_test');
     expect(created.wallet).toEqual({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
@@ -314,6 +370,135 @@ describe('WalletsClient', () => {
     expect(created.feePayerOnlyTransactions).toHaveLength(1);
     expect(created.clientAuthorityTransactions).toEqual([]);
     expect(created.operatorSignedTransactions).toEqual([]);
+  });
+
+  test('returns a recovery setup plan from a recovery-enabled policy', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        if (request.method === 'GET') {
+          return {
+            id: 'policy_recovery_123',
+            name: 'Recovery policy',
+            description: null,
+            authority: {
+              type: 'Secp256r1',
+              publicKey: 'passkey_public_key_123',
+            },
+            actions: [{ type: 'All' }],
+            guardianEnabled: true,
+            guardianAuthority: {
+              type: 'Ed25519',
+              publicKey: 'guardian_123',
+            },
+            guardianDelaySeconds: 86_400,
+          };
+        }
+
+        return {
+          network: 'NETWORK_DEVNET',
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              transaction: 'base64-create-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+            },
+          ],
+        };
+      }),
+    });
+
+    const created = await swig.wallets.create({
+      feePayer: 'payer_123',
+      policyId: 'policy_recovery_123',
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(created.transactions).toHaveLength(1);
+    expect(created.recoverySetup).toEqual({
+      requesterAuthority: {
+        secp256r1: {
+          publicKey: 'passkey_public_key_123',
+        },
+      },
+      guardianPubkey: 'guardian_123',
+      delaySeconds: 86_400,
+      targetRoleId: 0,
+    });
+  });
+
+  test('uses create recovery options when the policy guardian is provided at creation', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        if (request.method === 'GET') {
+          return {
+            id: 'policy_recovery_at_creation_123',
+            name: 'Recovery policy',
+            description: null,
+            authority: null,
+            actions: [{ type: 'All' }],
+            guardianEnabled: true,
+            guardianAuthority: null,
+            guardianDelaySeconds: '1',
+          };
+        }
+
+        return {
+          network: 'NETWORK_DEVNET',
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transactions: [
+            {
+              transaction: 'base64-create-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              kind: 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET',
+            },
+          ],
+        };
+      }),
+    });
+
+    const created = await swig.wallets.create({
+      feePayer: 'payer_123',
+      policyId: 'policy_recovery_at_creation_123',
+      initialUser: {
+        secp256r1: {
+          publicKey: 'passkey_public_key_123',
+        },
+      },
+      recovery: {
+        guardianPubkey: 'guardian_123',
+      },
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(created.recoverySetup).toEqual({
+      requesterAuthority: {
+        secp256r1: {
+          publicKey: 'passkey_public_key_123',
+        },
+      },
+      guardianPubkey: 'guardian_123',
+      delaySeconds: 1,
+      targetRoleId: 0,
+    });
   });
 
   test('prepares wallet creation without a policy id when an initial user is provided', async () => {
@@ -613,6 +798,95 @@ describe('WalletsClient', () => {
       transactionEncoding: 'base64',
       network: 'devnet',
       recentBlockhash: 'blockhash_789',
+    });
+  });
+
+  test('prepares recovery setup through the explicit setup endpoints', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        if (request.url.endsWith('/transaction/recovery/configure')) {
+          return {
+            transaction: 'base64-configure-recovery-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            kind: 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY',
+            wallet: {
+              swigConfigAddress: 'swig_config_123',
+              walletAddress: 'wallet_123',
+            },
+          };
+        }
+
+        return {
+          transaction: 'base64-add-authority-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+          kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
+          signatureRequests: [
+            {
+              scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
+              signer: 'passkey_public_key_123',
+              messageHash: 'hash_123',
+              slot: 123,
+              counter: 1,
+            },
+          ],
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterAuthority: { secp256r1: { publicKey: 'passkey_123' } },
+    });
+
+    const prepared = await wallet.recovery.prepareSetup({
+      feePayer: 'payer_123',
+      guardianPubkey: 'guardian_123',
+      delaySeconds: 86_400,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/wallet/recovery-authority/add',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { secp256r1: { publicKey: 'passkey_123' } },
+      },
+    });
+    expect(calls[1]).toMatchObject({
+      url: 'http://localhost:8080/transaction/recovery/configure',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        guardianPubkey: 'guardian_123',
+        delaySeconds: 86_400,
+      },
+    });
+    expect(prepared.transactions).toHaveLength(2);
+    expect(prepared.clientAuthorityTransactions).toHaveLength(1);
+    expect(prepared.operatorSignedTransactions).toHaveLength(1);
+    expect(prepared.addAuthorityTransaction).toMatchObject({
+      transaction: 'base64-add-authority-tx',
+      kind: 'add-authority',
+    });
+    expect(prepared.configureRecoveryTransaction).toMatchObject({
+      transaction: 'base64-configure-recovery-tx',
+      kind: 'configure-recovery',
     });
   });
 

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -1,6 +1,8 @@
 import type { HttpClient } from '../core/index.js';
 import type {
+  AddRecoveryAuthorityArgs,
   CancelRecoveryArgs,
+  ConfigureRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponseWire,
   CreateWalletResult,
@@ -8,14 +10,19 @@ import type {
   ExecuteRecoveryArgs,
   IdpWalletSession,
   Network,
+  Policy,
   PrepareArgs,
+  PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionsResult,
   PreparedTransactionWire,
+  PrepareRecoverySetupArgs,
   PrepareTransactionsResponseWire,
+  RecoverySetupPlan,
   StartRecoveryArgs,
   SwapArgs,
   TransferArgs,
+  WalletAuthority,
   WalletHandleOptions,
   WalletReference,
 } from '../types/index.js';
@@ -26,7 +33,9 @@ import {
   normalizePrepareTransactionsResponse,
 } from './normalizers.js';
 import {
+  addRecoveryAuthorityRequest,
   cancelRecoveryRequest,
+  configureRecoveryRequest,
   createWalletRequest,
   executeRecoveryRequest,
   executeRequest,
@@ -45,20 +54,35 @@ export class WalletsClient {
   ) {}
 
   create = async (args: CreateWalletArgs): Promise<CreateWalletResult> => {
+    const policy = args.policyId
+      ? await this.getPolicy(args.policyId)
+      : undefined;
     const response = await this.http.post<CreateWalletResponseWire>(
       '/transaction/wallet/create',
       createWalletRequest(args, this.defaultNetwork),
     );
     const created = normalizeCreateWalletResponse(response);
+    const network = created.network ?? args.network ?? this.defaultNetwork;
 
     return {
       ...created,
       wallet: {
         ...created.wallet,
-        network: created.network ?? args.network ?? this.defaultNetwork,
+        network,
       },
-      network: created.network ?? args.network ?? this.defaultNetwork,
+      ...(policy
+        ? {
+            recoverySetup: recoverySetupPlanFromPolicy(policy, args),
+          }
+        : {}),
+      network,
     };
+  };
+
+  getPolicy = async (policyId: string): Promise<Policy> => {
+    return this.http.get<Policy>(
+      `/wallet/policies/${encodeURIComponent(policyId)}`,
+    );
   };
 
   use = (
@@ -166,6 +190,47 @@ export class WalletsClient {
     return normalizePreparedTransaction(response);
   };
 
+  addRecoveryAuthority = async (
+    wallet: WalletHandle,
+    args: AddRecoveryAuthorityArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      '/transaction/wallet/recovery-authority/add',
+      addRecoveryAuthorityRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  configureRecovery = async (
+    wallet: WalletHandle,
+    args: ConfigureRecoveryArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      '/transaction/recovery/configure',
+      configureRecoveryRequest(wallet, args, this.defaultNetwork),
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  prepareRecoverySetup = async (
+    wallet: WalletHandle,
+    args: PrepareRecoverySetupArgs,
+  ): Promise<PreparedRecoverySetupResult> => {
+    const addAuthorityTransaction = await this.addRecoveryAuthority(
+      wallet,
+      args,
+    );
+    const configureRecoveryTransaction = await this.configureRecovery(
+      wallet,
+      args,
+    );
+    return recoverySetupResult(
+      [addAuthorityTransaction, configureRecoveryTransaction],
+      wallet,
+      args.network ?? wallet.network ?? this.defaultNetwork,
+    );
+  };
+
   cancelRecovery = async (
     wallet: WalletHandle,
     args: CancelRecoveryArgs,
@@ -197,5 +262,119 @@ export class WalletsClient {
       executeRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePreparedTransaction(response);
+  };
+}
+
+function recoverySetupPlanFromPolicy(
+  policy: Policy,
+  args: CreateWalletArgs,
+): RecoverySetupPlan | undefined {
+  const requesterAuthority =
+    args.initialUser ?? walletAuthorityFromPolicy(policy.authority);
+  const guardianPubkey =
+    args.recovery?.guardianPubkey ??
+    publicKeyFromPolicyAuthority(policy.guardianAuthority);
+
+  if (!policy.guardianEnabled || !requesterAuthority || !guardianPubkey) {
+    return undefined;
+  }
+
+  return {
+    requesterAuthority,
+    guardianPubkey,
+    delaySeconds:
+      args.recovery?.delaySeconds ??
+      normalizePolicyDelaySeconds(policy.guardianDelaySeconds),
+    targetRoleId: args.recovery?.targetRoleId ?? 0,
+  };
+}
+
+function normalizePolicyDelaySeconds(delaySeconds: unknown): number {
+  if (typeof delaySeconds === 'number' && Number.isFinite(delaySeconds)) {
+    return delaySeconds;
+  }
+  if (typeof delaySeconds === 'string' && /^[0-9]+$/.test(delaySeconds)) {
+    const parsed = Number(delaySeconds);
+    if (Number.isSafeInteger(parsed)) {
+      return parsed;
+    }
+  }
+  return 86_400;
+}
+
+function walletAuthorityFromPolicy(
+  authority: Policy['authority'],
+): WalletAuthority | undefined {
+  if (!authority) {
+    return undefined;
+  }
+
+  if (
+    'ed25519' in authority ||
+    'secp256k1' in authority ||
+    'secp256r1' in authority
+  ) {
+    return authority;
+  }
+
+  switch (authority.type) {
+    case 'Ed25519':
+      return { ed25519: { publicKey: authority.publicKey } };
+    case 'Secp256k1':
+      return { secp256k1: { publicKey: authority.publicKey } };
+    case 'Secp256r1':
+      return { secp256r1: { publicKey: authority.publicKey } };
+  }
+}
+
+function publicKeyFromPolicyAuthority(
+  authority: Policy['guardianAuthority'],
+): string | undefined {
+  if (!authority) {
+    return undefined;
+  }
+  if ('publicKey' in authority) {
+    return authority.publicKey;
+  }
+  if ('ed25519' in authority) {
+    return authority.ed25519.publicKey;
+  }
+  if ('secp256k1' in authority) {
+    return authority.secp256k1.publicKey;
+  }
+  return authority.secp256r1.publicKey;
+}
+
+function recoverySetupResult(
+  transactions: PreparedTransaction[],
+  wallet: WalletHandle,
+  network?: Network,
+): PreparedRecoverySetupResult {
+  const addAuthorityTransaction = transactions.find(
+    (transaction) => transaction.kind === 'add-authority',
+  );
+  const configureRecoveryTransaction = transactions.find(
+    (transaction) => transaction.kind === 'configure-recovery',
+  );
+  const walletInfo =
+    addAuthorityTransaction?.wallet ?? configureRecoveryTransaction?.wallet;
+
+  return {
+    ...(walletInfo ? { wallet: { ...walletInfo, network } } : {}),
+    transactions,
+    clientAuthorityTransactions: transactions.filter(
+      (transaction) => transaction.signatureRequests.length > 0,
+    ),
+    operatorSignedTransactions: transactions.filter(
+      (transaction) => transaction.kind === 'configure-recovery',
+    ),
+    feePayerOnlyTransactions: transactions.filter(
+      (transaction) =>
+        transaction.signatureRequests.length === 0 &&
+        transaction.kind !== 'configure-recovery',
+    ),
+    ...(addAuthorityTransaction ? { addAuthorityTransaction } : {}),
+    ...(configureRecoveryTransaction ? { configureRecoveryTransaction } : {}),
+    network: network ?? wallet.network,
   };
 }

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -4,8 +4,10 @@ import type {
   ExecuteRecoveryArgs,
   Network,
   PrepareArgs,
+  PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionsResult,
+  PrepareRecoverySetupArgs,
   StartRecoveryArgs,
   SwapArgs,
   TransferArgs,
@@ -30,6 +32,9 @@ export type WalletSwapClient = {
 };
 
 export type WalletRecoveryClient = {
+  prepareSetup(
+    args: PrepareRecoverySetupArgs,
+  ): Promise<PreparedRecoverySetupResult>;
   start(args: StartRecoveryArgs): Promise<PreparedTransaction>;
   cancel(args: CancelRecoveryArgs): Promise<PreparedTransaction>;
   execute(args: ExecuteRecoveryArgs): Promise<PreparedTransaction>;
@@ -94,6 +99,8 @@ function createWalletRecoveryClient(
   wallet: WalletHandle,
 ): WalletRecoveryClient {
   return {
+    prepareSetup: (args: PrepareRecoverySetupArgs) =>
+      wallets.prepareRecoverySetup(wallet, args),
     start: (args: StartRecoveryArgs) => wallets.startRecovery(wallet, args),
     cancel: (args: CancelRecoveryArgs) => wallets.cancelRecovery(wallet, args),
     execute: (args: ExecuteRecoveryArgs) =>

--- a/packages/developer-sdk/src/wallets/requests.ts
+++ b/packages/developer-sdk/src/wallets/requests.ts
@@ -1,5 +1,7 @@
 import type {
+  AddRecoveryAuthorityArgs,
   CancelRecoveryArgs,
+  ConfigureRecoveryArgs,
   CreateWalletArgs,
   ExecuteArgs,
   ExecuteRecoveryArgs,
@@ -28,7 +30,6 @@ export function createWalletRequest(
     feePayer: args.feePayer,
     ...(args.policyId ? { policyId: args.policyId } : {}),
     initialUser: args.initialUser,
-    guardianPubkey: args.guardianPubkey,
   };
 }
 
@@ -128,6 +129,38 @@ export function startRecoveryRequest(
   };
 }
 
+export function addRecoveryAuthorityRequest(
+  wallet: WalletHandle,
+  args: AddRecoveryAuthorityArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
+  };
+}
+
+export function configureRecoveryRequest(
+  wallet: WalletHandle,
+  args: ConfigureRecoveryArgs,
+  defaultNetwork?: Network,
+) {
+  return {
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    guardianPubkey: args.guardianPubkey,
+    delaySeconds: args.delaySeconds,
+    targetRoleId: args.targetRoleId,
+  };
+}
+
 export function cancelRecoveryRequest(
   wallet: WalletHandle,
   args: CancelRecoveryArgs,
@@ -208,12 +241,18 @@ function resolveNetwork(...networks: Array<Network | undefined>): Network {
 
 function resolveRequesterAuthority(
   wallet: WalletHandle,
-  args: TransferArgs | SwapArgs | PrepareArgs | CancelRecoveryArgs,
+  args:
+    | TransferArgs
+    | SwapArgs
+    | PrepareArgs
+    | CancelRecoveryArgs
+    | AddRecoveryAuthorityArgs,
 ): NonNullable<
   | TransferArgs['requesterAuthority']
   | SwapArgs['requesterAuthority']
   | PrepareArgs['requesterAuthority']
   | CancelRecoveryArgs['requesterAuthority']
+  | AddRecoveryAuthorityArgs['requesterAuthority']
 > {
   const requesterAuthority =
     args.requesterAuthority ?? wallet.requesterAuthority;


### PR DESCRIPTION
## Summary
- fetch policies from `/wallet/policies/{policyId}` instead of `/api/v1/policies/{policyId}`
- keep `wallets.create({ policyId })` as the single high-level SDK surface while returning an explicit recovery setup plan
- add explicit SDK recovery setup helpers for add-recovery-authority and configure-recovery backend calls
- update local transaction smoke coverage for recovery setup/start/execute

## Verification
- `bun test packages/developer-sdk/src/wallets/client.test.ts packages/developer-sdk/src/server/fetch/index.test.ts packages/developer-sdk/src/client/index.test.ts`
- `bun --filter @swig-wallet/developer-sdk typecheck`
- `bun --filter @swig-wallet/api typecheck`
- `bun --filter @swig-wallet/developer-sdk lint`
- `bun --filter @swig-wallet/api lint`
- `git diff --check`
- local SDK recovery smoke against Surfpool devnet fork passed create, add recovery authority, configure recovery, start/cancel, start/execute, and post-execute transfer
