### PR TITLE
SWI-473: Add browser proxy client

### DIFF
--- a/packages/developer-sdk/next/README.md
+++ b/packages/developer-sdk/next/README.md
@@ -57,28 +57,41 @@ export const { POST } = createSwigRouteHandlers({
 
 ## Client Usage
 
-Once the route is installed, browser code can call it directly:
+Once the route is installed, browser code can use the browser client. It calls
+your local app route only; the Swig developer API key stays on the server.
 
 ```typescript
 import { signPreparedTransaction } from '@swig-wallet/developer-sdk/client';
+import { SwigBrowserClient } from '@swig-wallet/developer-sdk/browser';
 
-const { prepared } = await fetch('/api/swig/transfer/sol', {
-  method: 'POST',
-  headers: { 'content-type': 'application/json' },
-  body: JSON.stringify({
-    network: 'devnet',
-    wallet: {
-      swigConfigAddress,
-      walletAddress,
-      requesterAuthority: { ed25519: { publicKey: userPublicKey } },
-    },
-    destination,
-    amount: '1000000',
-  }),
-}).then((response) => response.json());
+const swig = new SwigBrowserClient({ network: 'devnet' });
+const wallet = swig.wallets.fromIdpSession(session);
+
+const prepared = await wallet.transfer.sol({
+  destination,
+  amount: 1_000_000n,
+});
 
 const signed = await signPreparedTransaction(prepared, {
   signTransaction: (transaction) => signPreparedSwigTransaction(transaction),
+});
+```
+
+The same wallet handle also supports SPL transfers and Jupiter swap
+preparation:
+
+```typescript
+await wallet.transfer.token({
+  mint,
+  destinationOwner,
+  amount: '2500',
+});
+
+await wallet.swap.jupiter({
+  inputMint,
+  outputMint,
+  amount: '1000000',
+  slippageBps: 75,
 });
 ```
 
@@ -89,8 +102,8 @@ resolve it server-side:
 
 ```typescript
 export const { POST } = createSwigRouteHandlers({
-  resolveRequesterAuthority: async ({ wallet, body }) => {
-    return wallet?.requesterAuthority ?? lookupRequesterForUser(body);
+  resolveRequesterAuthority: async ({ wallet }) => {
+    return wallet?.requesterAuthority ?? lookupRequesterForRole(wallet?.roleId);
   },
 });
 ```

--- a/packages/developer-sdk/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/src/browser-proxy.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test } from 'bun:test';
+
+import { SwigBrowserClient, SwigBrowserProxyError } from './browser.js';
+
+type CapturedRequest = {
+  url: string;
+  method?: string;
+  headers: Headers;
+  body: unknown;
+};
+
+type JsonFetchResult =
+  | unknown
+  | {
+      status: number;
+      body: unknown;
+    };
+
+function jsonFetch(
+  handler: (request: CapturedRequest) => JsonFetchResult,
+): typeof fetch {
+  return (async (input, init) => {
+    const request = new Request(absoluteUrl(input), init);
+    const text = await request.text();
+    const result = handler({
+      url: request.url,
+      method: request.method,
+      headers: request.headers,
+      body: text ? JSON.parse(text) : undefined,
+    });
+    const response = isJsonFetchResponse(result)
+      ? result
+      : { status: 200, body: result };
+
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+describe('SwigBrowserClient', () => {
+  test('prepares SOL transfers through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          prepared: {
+            transaction: 'base64-transfer-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            recentBlockhash: 'blockhash_123',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.fromIdpSession({
+      configAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      roleId: 2,
+      authFlow: 'role',
+      updatedAt: 1_748_000_000,
+    });
+
+    const prepared = await wallet.transfer.sol({
+      destination: 'destination_123',
+      amount: 42n,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/transfer/sol',
+      method: 'POST',
+      body: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          roleId: 2,
+          network: 'devnet',
+        },
+        network: 'devnet',
+        destination: 'destination_123',
+        amount: '42',
+      },
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(prepared).toMatchObject({
+      transaction: 'base64-transfer-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+      recentBlockhash: 'blockhash_123',
+    });
+  });
+
+  test('prepares SPL token transfers through a custom local proxy path', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      basePath: '/wallet/api/swig/',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          prepared: {
+            transaction: 'base64-token-transfer-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use(
+      {
+        swigConfigAddress: 'swig_config_123',
+        walletAddress: 'wallet_123',
+      },
+      {
+        network: 'devnet',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+      },
+    );
+
+    const prepared = await wallet.transfer.token({
+      feePayer: 'payer_123',
+      mint: 'mint_123',
+      destinationOwner: 'owner_123',
+      amount: '2500',
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/wallet/api/swig/transfer/spl-token',
+      body: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          network: 'devnet',
+          requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        },
+        network: 'devnet',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        feePayer: 'payer_123',
+        mint: 'mint_123',
+        destinationOwner: 'owner_123',
+        amount: '2500',
+      },
+    });
+    expect(prepared.transaction).toBe('base64-token-transfer-tx');
+  });
+
+  test('prepares grouped wallet operations through the proxy route', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          prepared: {
+            wallet: {
+              swigConfigAddress: 'swig_config_123',
+              walletAddress: 'wallet_123',
+            },
+            transactions: [
+              {
+                transaction: 'base64-prepare-tx',
+                transactionEncoding: 'base64',
+                network: 'devnet',
+              },
+            ],
+            network: 'devnet',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use('swig_config_123');
+
+    const prepared = await wallet.prepare({
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+      operations: [
+        {
+          type: 'transferSol',
+          destination: 'destination_123',
+          amount: 1_000n,
+        },
+        {
+          type: 'transferToken',
+          mint: 'mint_123',
+          destinationOwner: 'owner_123',
+          amount: '2500',
+        },
+      ],
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/prepare',
+      body: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          network: 'devnet',
+          requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        },
+        network: 'devnet',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        operations: [
+          {
+            type: 'transferSol',
+            destination: 'destination_123',
+            amount: '1000',
+          },
+          {
+            type: 'transferToken',
+            mint: 'mint_123',
+            destinationOwner: 'owner_123',
+            amount: '2500',
+          },
+        ],
+      },
+    });
+    expect(prepared.transactions).toHaveLength(1);
+    expect(prepared.wallet).toEqual({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      network: 'devnet',
+    });
+  });
+
+  test('prepares Jupiter swaps through the proxy route', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          prepared: {
+            transaction: 'base64-swap-tx',
+            transactionEncoding: 'base64',
+            network: 'devnet',
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      authorityPublicKey: 'authority_123',
+    });
+
+    const prepared = await wallet.swap.jupiter({
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+      inputMint: 'So11111111111111111111111111111111111111112',
+      outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      amount: 42n,
+      slippageBps: 75,
+      tipAmountLamports: 5_000n,
+      maxAccounts: 32,
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/swap/jupiter',
+      body: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          authorityPublicKey: 'authority_123',
+          network: 'devnet',
+          requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        },
+        network: 'devnet',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '42',
+        slippageBps: 75,
+        tipAmountLamports: '5000',
+        maxAccounts: 32,
+      },
+    });
+    expect(prepared.transaction).toBe('base64-swap-tx');
+  });
+
+  test('throws proxy errors with the route response status and message', async () => {
+    const swig = new SwigBrowserClient({
+      fetch: jsonFetch(() => ({
+        status: 401,
+        body: { error: 'requesterAuthority is required' },
+      })),
+    });
+    const wallet = swig.wallets.use('swig_config_123', { network: 'devnet' });
+
+    try {
+      await wallet.transfer.sol({
+        destination: 'destination_123',
+        amount: 1n,
+      });
+      throw new Error('Expected transfer to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SwigBrowserProxyError);
+      expect(error).toMatchObject({
+        message: 'requesterAuthority is required',
+        status: 401,
+        body: { error: 'requesterAuthority is required' },
+      });
+    }
+  });
+});
+
+function absoluteUrl(input: RequestInfo | URL): RequestInfo | URL {
+  if (typeof input === 'string' && input.startsWith('/')) {
+    return `https://app.example${input}`;
+  }
+  return input;
+}
+
+function isJsonFetchResponse(
+  value: JsonFetchResult,
+): value is { status: number; body: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'status' in value &&
+    typeof value.status === 'number' &&
+    'body' in value
+  );
+}

--- a/packages/developer-sdk/src/browser-proxy.ts
+++ b/packages/developer-sdk/src/browser-proxy.ts
@@ -1,0 +1,415 @@
+import type {
+  IdpWalletSession,
+  Network,
+  PrepareArgs,
+  PreparedTransaction,
+  PreparedTransactionsResult,
+  PreparedTransactionWire,
+  PrepareOperation,
+  PrepareTransactionsResponseWire,
+  SwapArgs,
+  TransferSolArgs,
+  TransferTokenArgs,
+  WalletAuthority,
+  WalletHandleOptions,
+  WalletReference,
+} from './types/index.js';
+import {
+  normalizeAmount,
+  normalizePreparedTransaction,
+  normalizePrepareTransactionsResponse,
+} from './wallets/normalizers.js';
+
+export interface SwigBrowserClientConfig {
+  /**
+   * Local app proxy base path. Defaults to the route created by the Next.js
+   * adapter: /api/swig.
+   */
+  basePath?: string;
+  network?: Network;
+  fetch?: typeof fetch;
+}
+
+export interface BrowserWalletReference extends WalletReference {
+  roleId?: number;
+  authorityPublicKey?: string;
+}
+
+export type BrowserTransferSolArgs = WithoutFeePayer<TransferSolArgs>;
+export type BrowserTransferTokenArgs = WithoutFeePayer<TransferTokenArgs>;
+export type BrowserTransferArgs =
+  | BrowserTransferSolArgs
+  | BrowserTransferTokenArgs;
+export type BrowserPrepareArgs = WithoutFeePayer<PrepareArgs>;
+export type BrowserSwapArgs = WithoutFeePayer<SwapArgs>;
+
+export type BrowserWalletTransferClient = {
+  (args: BrowserTransferArgs): Promise<PreparedTransaction>;
+  sol(args: BrowserTransferSolArgs): Promise<PreparedTransaction>;
+  token(args: BrowserTransferTokenArgs): Promise<PreparedTransaction>;
+  splToken(args: BrowserTransferTokenArgs): Promise<PreparedTransaction>;
+};
+
+export type BrowserWalletSwapClient = {
+  (args: BrowserSwapArgs): Promise<PreparedTransaction>;
+  jupiter(args: BrowserSwapArgs): Promise<PreparedTransaction>;
+};
+
+type WithoutFeePayer<TArgs extends { feePayer: string }> = Omit<
+  TArgs,
+  'feePayer'
+> & {
+  feePayer?: string;
+};
+
+type SwigBrowserProxyRoute =
+  | 'prepare'
+  | 'transfer/sol'
+  | 'transfer/spl-token'
+  | 'swap/jupiter';
+
+type BrowserProxyRequestArgs = {
+  feePayer?: string;
+  requesterAuthority?: WalletAuthority;
+  network?: Network;
+  idempotencyKey?: string;
+};
+
+export class SwigBrowserProxyError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+    this.name = 'SwigBrowserProxyError';
+  }
+}
+
+export class SwigBrowserClient {
+  readonly wallets: BrowserWalletsClient;
+
+  constructor(config: SwigBrowserClientConfig = {}) {
+    this.wallets = new BrowserWalletsClient(config);
+  }
+}
+
+export class BrowserWalletsClient {
+  private readonly http: BrowserProxyHttpClient;
+  private readonly defaultNetwork?: Network;
+
+  constructor(config: SwigBrowserClientConfig = {}) {
+    this.http = new BrowserProxyHttpClient({
+      basePath: config.basePath ?? '/api/swig',
+      fetch: resolveFetch(config.fetch),
+    });
+    this.defaultNetwork = config.network;
+  }
+
+  use = (
+    wallet: string | BrowserWalletReference,
+    options: WalletHandleOptions = {},
+  ): BrowserWalletHandle => {
+    if (typeof wallet === 'string') {
+      return new BrowserWalletHandle(this, {
+        swigConfigAddress: wallet,
+        network: options.network ?? this.defaultNetwork,
+        requesterAuthority: options.requesterAuthority,
+      });
+    }
+
+    return new BrowserWalletHandle(this, {
+      swigConfigAddress: wallet.swigConfigAddress,
+      walletAddress: wallet.walletAddress,
+      roleId: wallet.roleId,
+      authorityPublicKey: wallet.authorityPublicKey,
+      network: options.network ?? wallet.network ?? this.defaultNetwork,
+      requesterAuthority:
+        options.requesterAuthority ?? wallet.requesterAuthority,
+    });
+  };
+
+  fromIdpSession = (
+    session: IdpWalletSession,
+    options: WalletHandleOptions = {},
+  ): BrowserWalletHandle => {
+    return new BrowserWalletHandle(this, {
+      swigConfigAddress: session.configAddress,
+      walletAddress: session.walletAddress,
+      roleId: session.roleId,
+      authorityPublicKey: session.authorityPublicKey,
+      network: options.network ?? this.defaultNetwork,
+      requesterAuthority:
+        options.requesterAuthority ?? session.requesterAuthority,
+    });
+  };
+
+  transfer = (
+    wallet: BrowserWalletHandle,
+    args: BrowserTransferArgs,
+  ): Promise<PreparedTransaction> => {
+    return isBrowserTokenTransfer(args)
+      ? this.transferToken(wallet, args)
+      : this.transferSol(wallet, args);
+  };
+
+  prepare = async (
+    wallet: BrowserWalletHandle,
+    args: BrowserPrepareArgs,
+  ): Promise<PreparedTransactionsResult> => {
+    const response = await this.http.post<PrepareTransactionsResponseWire>(
+      'prepare',
+      {
+        ...baseRequest(wallet, args, this.defaultNetwork),
+        operations: args.operations.map(prepareOperationRequest),
+      },
+    );
+    return normalizePrepareTransactionsResponse(response);
+  };
+
+  transferSol = async (
+    wallet: BrowserWalletHandle,
+    args: BrowserTransferSolArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      'transfer/sol',
+      {
+        ...baseRequest(wallet, args, this.defaultNetwork),
+        destination: args.destination,
+        amount: normalizeAmount(args.amount),
+      },
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  transferToken = async (
+    wallet: BrowserWalletHandle,
+    args: BrowserTransferTokenArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      'transfer/spl-token',
+      {
+        ...baseRequest(wallet, args, this.defaultNetwork),
+        mint: args.mint,
+        destinationOwner: args.destinationOwner,
+        amount: normalizeAmount(args.amount),
+      },
+    );
+    return normalizePreparedTransaction(response);
+  };
+
+  swap = (
+    wallet: BrowserWalletHandle,
+    args: BrowserSwapArgs,
+  ): Promise<PreparedTransaction> => {
+    return this.jupiterSwap(wallet, args);
+  };
+
+  jupiterSwap = async (
+    wallet: BrowserWalletHandle,
+    args: BrowserSwapArgs,
+  ): Promise<PreparedTransaction> => {
+    const response = await this.http.post<PreparedTransactionWire>(
+      'swap/jupiter',
+      {
+        ...baseRequest(wallet, args, this.defaultNetwork),
+        inputMint: args.inputMint,
+        outputMint: args.outputMint,
+        amount: normalizeAmount(args.amount),
+        slippageBps: args.slippageBps,
+        destinationAccount: args.destinationAccount,
+        wrapAndUnwrapSol: args.wrapAndUnwrapSol,
+        tipAmountLamports:
+          args.tipAmountLamports === undefined
+            ? undefined
+            : normalizeAmount(args.tipAmountLamports),
+        computeUnitPricePercentile: args.computeUnitPricePercentile,
+        maxAccounts: args.maxAccounts,
+        mode: args.mode,
+        blockhashSlotsToExpiry: args.blockhashSlotsToExpiry,
+      },
+    );
+    return normalizePreparedTransaction(response);
+  };
+}
+
+export class BrowserWalletHandle {
+  readonly swigConfigAddress: string;
+  readonly walletAddress?: string;
+  readonly roleId?: number;
+  readonly authorityPublicKey?: string;
+  readonly network?: Network;
+  readonly requesterAuthority?: WalletAuthority;
+  readonly transfer: BrowserWalletTransferClient;
+  readonly swap: BrowserWalletSwapClient;
+
+  constructor(
+    private readonly wallets: BrowserWalletsClient,
+    init: BrowserWalletReference,
+  ) {
+    this.swigConfigAddress = init.swigConfigAddress;
+    this.walletAddress = init.walletAddress;
+    this.roleId = init.roleId;
+    this.authorityPublicKey = init.authorityPublicKey;
+    this.network = init.network;
+    this.requesterAuthority = init.requesterAuthority;
+    this.transfer = createBrowserWalletTransferClient(wallets, this);
+    this.swap = createBrowserWalletSwapClient(wallets, this);
+  }
+
+  prepare = (args: BrowserPrepareArgs): Promise<PreparedTransactionsResult> =>
+    this.wallets.prepare(this, args);
+}
+
+class BrowserProxyHttpClient {
+  readonly #basePath: string;
+  readonly #fetch: typeof fetch;
+
+  constructor(config: { basePath: string; fetch: typeof fetch }) {
+    this.#basePath = config.basePath.replace(/\/$/, '');
+    this.#fetch = config.fetch;
+  }
+
+  post = async <TResponse>(
+    route: SwigBrowserProxyRoute,
+    body: unknown,
+  ): Promise<TResponse> => {
+    const response = await this.#fetch(`${this.#basePath}/${route}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const responseBody = await parseResponseBody(response);
+
+    if (!response.ok) {
+      throw new SwigBrowserProxyError(
+        errorMessageFromBody(responseBody),
+        response.status,
+        responseBody,
+      );
+    }
+
+    return readPrepared<TResponse>(responseBody);
+  };
+}
+
+function createBrowserWalletTransferClient(
+  wallets: BrowserWalletsClient,
+  wallet: BrowserWalletHandle,
+): BrowserWalletTransferClient {
+  const transfer = ((args: BrowserTransferArgs) =>
+    wallets.transfer(wallet, args)) as BrowserWalletTransferClient;
+
+  transfer.sol = (args: BrowserTransferSolArgs) =>
+    wallets.transferSol(wallet, args);
+  transfer.token = (args: BrowserTransferTokenArgs) =>
+    wallets.transferToken(wallet, args);
+  transfer.splToken = transfer.token;
+
+  return transfer;
+}
+
+function createBrowserWalletSwapClient(
+  wallets: BrowserWalletsClient,
+  wallet: BrowserWalletHandle,
+): BrowserWalletSwapClient {
+  const swap = ((args: BrowserSwapArgs) =>
+    wallets.swap(wallet, args)) as BrowserWalletSwapClient;
+  swap.jupiter = (args: BrowserSwapArgs) => wallets.jupiterSwap(wallet, args);
+
+  return swap;
+}
+
+function baseRequest(
+  wallet: BrowserWalletHandle,
+  args: BrowserProxyRequestArgs,
+  defaultNetwork?: Network,
+) {
+  const network = args.network ?? wallet.network ?? defaultNetwork;
+  const requesterAuthority =
+    args.requesterAuthority ?? wallet.requesterAuthority;
+
+  return {
+    wallet: {
+      swigConfigAddress: wallet.swigConfigAddress,
+      walletAddress: wallet.walletAddress,
+      roleId: wallet.roleId,
+      authorityPublicKey: wallet.authorityPublicKey,
+      network,
+      requesterAuthority,
+    },
+    network,
+    requesterAuthority,
+    feePayer: args.feePayer,
+    idempotencyKey: args.idempotencyKey,
+  };
+}
+
+function prepareOperationRequest(
+  operation: PrepareOperation,
+): PrepareOperation {
+  switch (operation.type) {
+    case 'transferSol':
+      return {
+        type: 'transferSol',
+        destination: operation.destination,
+        amount: normalizeAmount(operation.amount),
+      };
+    case 'transferToken':
+      return {
+        type: 'transferToken',
+        mint: operation.mint,
+        destinationOwner: operation.destinationOwner,
+        amount: normalizeAmount(operation.amount),
+      };
+  }
+}
+
+function isBrowserTokenTransfer(
+  args: BrowserTransferArgs,
+): args is BrowserTransferTokenArgs {
+  return (
+    'mint' in args && typeof args.mint === 'string' && args.mint.length > 0
+  );
+}
+
+function resolveFetch(fetchImpl?: typeof fetch): typeof fetch {
+  const resolvedFetch = fetchImpl ?? globalThis.fetch;
+  if (!resolvedFetch) {
+    throw new Error('fetch is required to use SwigBrowserClient');
+  }
+  return resolvedFetch;
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function readPrepared<TResponse>(body: unknown): TResponse {
+  if (isRecord(body) && 'prepared' in body) {
+    return body.prepared as TResponse;
+  }
+  throw new Error('Swig proxy response is missing prepared');
+}
+
+function errorMessageFromBody(body: unknown): string {
+  if (isRecord(body) && typeof body.error === 'string' && body.error.trim()) {
+    return body.error;
+  }
+  return 'Swig proxy request failed';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/developer-sdk/src/browser.ts
+++ b/packages/developer-sdk/src/browser.ts
@@ -1,1 +1,2 @@
+export * from './browser-proxy.js';
 export * from './client/index.js';

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -341,9 +341,13 @@ describe('createSwigFetchHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       feePayer: 'payer_123',
-      resolveRequesterAuthority: () => ({
-        ed25519: { publicKey: 'requester_123' },
-      }),
+      resolveRequesterAuthority: ({ wallet }) => {
+        expect(wallet?.roleId).toBe(2);
+        expect(wallet?.authorityPublicKey).toBe('authority_123');
+        return {
+          ed25519: { publicKey: 'requester_123' },
+        };
+      },
       fetch: jsonFetch((request) => {
         calls.push(request);
         return {
@@ -359,6 +363,8 @@ describe('createSwigFetchHandler', () => {
         body: JSON.stringify({
           wallet: {
             swigConfigAddress: 'swig_config_123',
+            roleId: 2,
+            authorityPublicKey: 'authority_123',
           },
           network: 'devnet',
           destination: 'destination_123',

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -18,11 +18,16 @@ export type SwigProxyRoute =
   | 'transfer/spl-token'
   | 'swap/jupiter';
 
+export interface SwigProxyWalletReference extends WalletReference {
+  roleId?: number;
+  authorityPublicKey?: string;
+}
+
 export interface SwigRouteContext {
   request: Request;
   route: SwigProxyRoute;
   body: Record<string, unknown>;
-  wallet?: WalletReference;
+  wallet?: SwigProxyWalletReference;
   network?: Network;
 }
 
@@ -422,7 +427,7 @@ async function readJsonObject(
   return body;
 }
 
-function readWallet(value: unknown): WalletReference | undefined {
+function readWallet(value: unknown): SwigProxyWalletReference | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -433,6 +438,8 @@ function readWallet(value: unknown): WalletReference | undefined {
   return {
     swigConfigAddress: readRequiredString(value, 'swigConfigAddress'),
     walletAddress: readOptionalString(value, 'walletAddress'),
+    roleId: readOptionalNumber(value, 'roleId'),
+    authorityPublicKey: readOptionalString(value, 'authorityPublicKey'),
     requesterAuthority: readWalletAuthority(
       value.requesterAuthority,
       'wallet.requesterAuthority',

--- a/packages/developer-sdk/src/types/wallet.ts
+++ b/packages/developer-sdk/src/types/wallet.ts
@@ -16,10 +16,13 @@ export interface WalletReference {
 export interface IdpWalletSession {
   configAddress: string;
   walletAddress: string;
+  authFlow?: 'session' | 'role';
+  updatedAt?: number;
   requesterAuthority?: WalletAuthority;
   authorityPublicKey?: string;
   /**
-   * Deprecated. The transaction API resolves the requester's role on-chain.
+   * Present on persisted IdP sessions. Local proxy handlers can use it to
+   * resolve requester authority server-side.
    */
   roleId?: number;
 }


### PR DESCRIPTION
## Summary
- Add @swig-wallet/developer-sdk/browser SwigBrowserClient for local proxy-backed prepare flows
- Support IdP session wallet handles, SOL/SPL transfers, grouped prepare, and Jupiter swaps without browser API keys
- Preserve IdP role metadata on server proxy context for requester authority resolution
- Update Next adapter docs to use the browser client

## Verification
- bun --filter @swig-wallet/developer-sdk lint
- bun --filter @swig-wallet/developer-sdk typecheck
- bun --filter @swig-wallet/developer-sdk test
- bun --filter @swig-wallet/developer-sdk build