### PR TITLE
Update SDK recovery setup plan flow

### DIFF
--- a/.changeset/recovery-setup-plan-shape.md
+++ b/.changeset/recovery-setup-plan-shape.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Update the documented recovery setup flow to feed the create-time `recoverySetup` plan directly into `wallet.recovery.prepareSetup`, and avoid defaulting `targetRoleId` into that plan unless explicitly provided.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -267,10 +267,9 @@ fee-payer or sponsor signature before submission.
 
 ## Recovery Flow
 
-Recovery-enabled wallets can be created by passing a guardian public key. The
-backend installs the recovery authority and returns the operator-signed
-configure-recovery transaction in `operatorSignedTransactions`. The current
-backend requires `policyId` when `guardianPubkey` is provided.
+Recovery-enabled wallets should be created from a recovery-enabled policy. Pass
+the guardian once at wallet creation; the SDK returns a `recoverySetup` plan that
+can be fed directly into the setup helper.
 
 ```typescript
 const created = await swig.wallets.create({
@@ -281,12 +280,41 @@ const created = await swig.wallets.create({
       publicKey: passkeyPublicKey,
     },
   },
-  guardianPubkey: guardianPublicKey,
+  recovery: {
+    guardianPubkey: guardianPublicKey,
+    delaySeconds: 86_400,
+  },
 });
 ```
 
-After wallet creation, use the wallet recovery helper to prepare start, cancel,
-and execute transactions:
+Submit the creation transaction, then prepare the recovery setup from the plan
+returned by create. The add-authority transaction is signed by the current
+passkey authority; the configure-recovery transaction is already signed by
+Swig's recovery operator and only needs the fee payer or sponsor path.
+
+```typescript
+import { signPreparedSwigTransaction } from '@swig-wallet/developer-sdk/client';
+
+await submitPrepared(created.creationTransaction!);
+
+const wallet = swig.wallets.use(created.wallet);
+
+const setup = await wallet.recovery.prepareSetup({
+  feePayer,
+  ...created.recoverySetup!,
+});
+
+const signedAddAuthority = await signPreparedSwigTransaction(
+  setup.addAuthorityTransaction!,
+  { secp256r1: passkeySigningFn },
+);
+
+await submitPrepared(signedAddAuthority);
+await submitPrepared(setup.configureRecoveryTransaction!);
+```
+
+After setup, the guardian can start recovery and execute after the configured
+delay. The current wallet authority can cancel a pending recovery.
 
 ```typescript
 import { signPreparedTransaction } from '@swig-wallet/developer-sdk/client';
@@ -294,14 +322,6 @@ import { signPreparedTransaction } from '@swig-wallet/developer-sdk/client';
 declare const signWithGuardian: Parameters<
   typeof signPreparedTransaction
 >[1]['signTransaction'];
-
-const wallet = swig.wallets.use(created.wallet, {
-  requesterAuthority: {
-    secp256r1: {
-      publicKey: passkeyPublicKey,
-    },
-  },
-});
 
 const start = await wallet.recovery.start({
   feePayer,

--- a/packages/developer-sdk/scripts/local-transaction-smoke.ts
+++ b/packages/developer-sdk/scripts/local-transaction-smoke.ts
@@ -422,9 +422,7 @@ async function runRecoverySmoke(connection: Connection) {
   }
   const recoverySetup = await wallet.recovery.prepareSetup({
     feePayer: recoveryFeePayer.publicKey.toBase58(),
-    guardianPubkey: created.recoverySetup.guardianPubkey,
-    delaySeconds: created.recoverySetup.delaySeconds,
-    targetRoleId: created.recoverySetup.targetRoleId,
+    ...created.recoverySetup,
   });
 
   const addRecoverySignature = await signSwigAndSendPreparedTransaction(

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -261,7 +261,6 @@ describe('createSwigFetchHandler', () => {
           },
           guardianPubkey: 'guardian_123',
           delaySeconds: 1,
-          targetRoleId: 0,
         },
       },
     });

--- a/packages/developer-sdk/src/wallets/client.test.ts
+++ b/packages/developer-sdk/src/wallets/client.test.ts
@@ -432,7 +432,6 @@ describe('WalletsClient', () => {
       },
       guardianPubkey: 'guardian_123',
       delaySeconds: 86_400,
-      targetRoleId: 0,
     });
   });
 
@@ -497,7 +496,6 @@ describe('WalletsClient', () => {
       },
       guardianPubkey: 'guardian_123',
       delaySeconds: 1,
-      targetRoleId: 0,
     });
   });
 
@@ -801,7 +799,7 @@ describe('WalletsClient', () => {
     });
   });
 
-  test('prepares recovery setup through the explicit setup endpoints', async () => {
+  test('prepares recovery setup from a create-time setup plan', async () => {
     const calls: CapturedRequest[] = [];
     const swig = new SwigClient({
       apiKey: 'sk_test',
@@ -846,13 +844,16 @@ describe('WalletsClient', () => {
     const wallet = swig.wallets.use({
       swigConfigAddress: 'swig_config_123',
       walletAddress: 'wallet_123',
-      requesterAuthority: { secp256r1: { publicKey: 'passkey_123' } },
     });
+    const recoverySetup = {
+      requesterAuthority: { secp256r1: { publicKey: 'passkey_123' } },
+      guardianPubkey: 'guardian_123',
+      delaySeconds: 86_400,
+    } as const;
 
     const prepared = await wallet.recovery.prepareSetup({
       feePayer: 'payer_123',
-      guardianPubkey: 'guardian_123',
-      delaySeconds: 86_400,
+      ...recoverySetup,
     });
 
     expect(calls).toHaveLength(2);

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -285,7 +285,9 @@ function recoverySetupPlanFromPolicy(
     delaySeconds:
       args.recovery?.delaySeconds ??
       normalizePolicyDelaySeconds(policy.guardianDelaySeconds),
-    targetRoleId: args.recovery?.targetRoleId ?? 0,
+    ...(args.recovery?.targetRoleId === undefined
+      ? {}
+      : { targetRoleId: args.recovery.targetRoleId }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Feed create-time `created.recoverySetup` directly into `wallet.recovery.prepareSetup` in README and smoke coverage
- Stop defaulting `targetRoleId` into the recovery setup plan unless the caller explicitly provides it
- Update SDK tests and add a patch changeset

## Validation
- `bun --filter @swig-wallet/developer-sdk test`
- `bun --filter @swig-wallet/developer-sdk typecheck`
- `bun --filter @swig-wallet/developer-sdk lint`
- `bunx prettier --check packages/developer-sdk/README.md packages/developer-sdk/scripts/local-transaction-smoke.ts packages/developer-sdk/src/wallets/client.ts packages/developer-sdk/src/wallets/client.test.ts packages/developer-sdk/src/server/fetch/index.test.ts .changeset/recovery-setup-plan-shape.md`