### PR TITLE
Add developer SDK EVM signing helper

### DIFF
--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -256,6 +256,32 @@ const signedCreateTransactions = await signPreparedSwigTransactions(
 );
 ```
 
+### EVM Transaction Signing
+
+Use this when the prepared transaction contains a `secp256k1` signature request.
+The helper wraps an EIP-1193 provider with `personal_sign` and adds the Ethereum
+message prefix expected by Swig's secp256k1 authority payload.
+
+```typescript
+import {
+  createSecp256k1EvmSigningFn,
+  signPreparedSwigTransaction,
+  type PreparedTransaction,
+} from '@swig-wallet/developer-sdk/client';
+
+declare const prepared: PreparedTransaction;
+declare const evmAddress: string;
+
+const evmSigningFn = createSecp256k1EvmSigningFn({
+  provider: window.ethereum,
+  address: evmAddress,
+});
+
+const signed = await signPreparedSwigTransaction(prepared, {
+  secp256k1: evmSigningFn,
+});
+```
+
 After signing, pass `signed` to your app-owned send or sponsor flow. On your
 server, `swig.transactions.sponsor(signed)` handles the deployed paymaster route
 and base58 payload encoding expected by the backend.

--- a/packages/developer-sdk/src/client/index.test.ts
+++ b/packages/developer-sdk/src/client/index.test.ts
@@ -137,6 +137,46 @@ describe('client signing helpers', () => {
     expect(signed).toHaveLength(2);
     expect(challenges).toEqual([firstMessageHash, secondMessageHash]);
   });
+
+  test('signPreparedSwigTransaction patches secp256k1 SignV2 authority payloads', async () => {
+    const publicKey = Uint8Array.from({ length: 33 }, (_, index) =>
+      index === 0 ? 2 : index + 20,
+    );
+    const messageHash = Uint8Array.from(
+      { length: 32 },
+      (_, index) => 200 - index,
+    );
+    const messageHashHex = bytesToHex(messageHash);
+    const signature = Uint8Array.from(
+      { length: 65 },
+      (_, index) => 120 - index,
+    );
+    signature[64] = 27;
+    const prefix = asciiToBytes('\x19Ethereum Signed Message:\n64');
+    const prepared = preparedSecp256k1SwigTransaction(
+      publicKey,
+      messageHashHex,
+      12,
+      34,
+    );
+
+    const signed = await signPreparedSwigTransaction(prepared, {
+      secp256k1: async (message) => {
+        expect(message).toEqual(asciiToBytes(messageHashHex));
+        return { signature, prefix };
+      },
+    });
+
+    const transaction = Transaction.from(base64ToBytes(signed.transaction));
+    const authorityPayload = readAuthorityPayload(
+      new Uint8Array(transaction.instructions[0].data),
+    );
+
+    expect(readU64(authorityPayload, 0)).toBe(12n);
+    expect(readU32(authorityPayload, 8)).toBe(34);
+    expect(authorityPayload.slice(12, 77)).toEqual(signature);
+    expect([...authorityPayload.slice(77)]).toEqual([...prefix]);
+  });
 });
 
 const SECP256R1_PROGRAM_ID = new PublicKey(
@@ -194,6 +234,46 @@ function preparedSwigTransaction(
   };
 }
 
+function preparedSecp256k1SwigTransaction(
+  publicKey: Uint8Array,
+  messageHash: string,
+  slot: number,
+  counter: number,
+): PreparedTransaction {
+  const transaction = new Transaction({
+    feePayer: FEE_PAYER,
+    recentBlockhash: '11111111111111111111111111111111',
+  }).add(
+    new TransactionInstruction({
+      programId: SWIG_PROGRAM_ID,
+      keys: [],
+      data: Buffer.from(
+        signV2InstructionData(secp256k1AuthorityPayload(slot, counter)),
+      ),
+    }),
+  );
+
+  return {
+    transaction: bytesToBase64(
+      transaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      }),
+    ),
+    transactionEncoding: 'base64',
+    network: 'devnet',
+    signatureRequests: [
+      {
+        scheme: 'secp256k1',
+        signer: bytesToHex(publicKey),
+        messageHash,
+        slot,
+        counter,
+      },
+    ],
+  };
+}
+
 function encodeSecp256r1InstructionData(args: {
   publicKey: Uint8Array;
   signature: Uint8Array;
@@ -237,10 +317,13 @@ function parseSecp256r1InstructionData(data: Uint8Array): {
   };
 }
 
-function signV2InstructionData(): Uint8Array {
+function signV2InstructionData(
+  authorityPayload = baseAuthorityPayload(),
+): Uint8Array {
   const compactInstructionPayload = Uint8Array.from([11, 22, 33]);
-  const authorityPayload = baseAuthorityPayload();
-  const data = new Uint8Array(8 + compactInstructionPayload.length + 17);
+  const data = new Uint8Array(
+    8 + compactInstructionPayload.length + authorityPayload.length,
+  );
   const view = new DataView(data.buffer);
 
   view.setUint16(0, 11, true);
@@ -250,6 +333,14 @@ function signV2InstructionData(): Uint8Array {
   data.set(authorityPayload, 8 + compactInstructionPayload.length);
 
   return data;
+}
+
+function secp256k1AuthorityPayload(slot: number, counter: number): Uint8Array {
+  const payload = new Uint8Array(77);
+  const view = new DataView(payload.buffer);
+  view.setBigUint64(0, BigInt(slot), true);
+  view.setUint32(8, counter, true);
+  return payload;
 }
 
 function baseAuthorityPayload(): Uint8Array {
@@ -268,6 +359,21 @@ function readU16(data: Uint8Array, offset: number): number {
   );
 }
 
+function readU32(data: Uint8Array, offset: number): number {
+  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(
+    offset,
+    true,
+  );
+}
+
+function readU64(data: Uint8Array, offset: number): bigint {
+  return new DataView(
+    data.buffer,
+    data.byteOffset,
+    data.byteLength,
+  ).getBigUint64(offset, true);
+}
+
 function bytesToHex(bytes: Uint8Array): string {
   return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
@@ -276,6 +382,14 @@ function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
   const bytes = new Uint8Array(left.length + right.length);
   bytes.set(left);
   bytes.set(right, left.length);
+  return bytes;
+}
+
+function asciiToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index++) {
+    bytes[index] = value.charCodeAt(index);
+  }
   return bytes;
 }
 

--- a/packages/developer-sdk/src/client/index.ts
+++ b/packages/developer-sdk/src/client/index.ts
@@ -1,10 +1,15 @@
 import type { PreparedTransaction } from '../types/index.js';
 
+export { createSecp256k1EvmSigningFn } from '../evm/index.js';
 export { createSecp256r1PasskeySigningFn } from '../passkeys/index.js';
 export type {
+  CreateSecp256k1EvmSigningFnOptions,
+  Eip1193Provider,
   PasskeySigningFn,
   PasskeySigningResult,
   PreparedTransaction,
+  Secp256k1SigningFn,
+  Secp256k1SigningResult,
   TransactionEncoding,
 } from '../types/index.js';
 export {
@@ -12,6 +17,7 @@ export {
   signPreparedSwigTransactions,
 } from './swig-signing.js';
 export type {
+  Secp256k1SigningFns,
   Secp256r1SigningFns,
   SignPreparedSwigTransactionOptions,
 } from './swig-signing.js';

--- a/packages/developer-sdk/src/client/swig-signing.ts
+++ b/packages/developer-sdk/src/client/swig-signing.ts
@@ -4,6 +4,7 @@ import type {
   ClientSignatureRequest,
   PasskeySigningFn,
   PreparedTransaction,
+  Secp256k1SigningFn,
 } from '../types/index.js';
 import type { SignedPreparedTransaction } from './index.js';
 
@@ -18,14 +19,21 @@ const SECP256R1_AUTHORITY_PAYLOAD_SIZE = 17;
 const SECP256R1_PUBLIC_KEY_SIZE = 33;
 const SECP256R1_SIGNATURE_SIZE = 64;
 const SECP256R1_HEADER_SIZE = 16;
+const SECP256K1_AUTHORITY_PAYLOAD_SIZE = 77;
+const SECP256K1_SIGNATURE_SIZE = 65;
+const SECP256K1_SIGNATURE_OFFSET = 12;
 const U16_MAX = 65535;
 
 export type Secp256r1SigningFns =
   | PasskeySigningFn
   | Record<string, PasskeySigningFn>;
+export type Secp256k1SigningFns =
+  | Secp256k1SigningFn
+  | Record<string, Secp256k1SigningFn>;
 
 export interface SignPreparedSwigTransactionOptions {
-  secp256r1: Secp256r1SigningFns;
+  secp256r1?: Secp256r1SigningFns;
+  secp256k1?: Secp256k1SigningFns;
 }
 
 type SwigTransaction = Transaction | VersionedTransaction;
@@ -76,12 +84,24 @@ async function applySignatureRequest(
   request: ClientSignatureRequest,
   options: SignPreparedSwigTransactionOptions,
 ) {
-  if (request.scheme !== 'secp256r1') {
-    throw new Error(
-      `Client signing for ${request.scheme} prepared transactions is not supported yet`,
-    );
+  switch (request.scheme) {
+    case 'secp256r1':
+      await applySecp256r1SignatureRequest(transaction, request, options);
+      return;
+    case 'secp256k1':
+      await applySecp256k1SignatureRequest(transaction, request, options);
+      return;
   }
+}
 
+async function applySecp256r1SignatureRequest(
+  transaction: SwigTransaction,
+  request: ClientSignatureRequest,
+  options: SignPreparedSwigTransactionOptions,
+) {
+  if (!options.secp256r1) {
+    throw new Error('No secp256r1 signing function registered');
+  }
   const publicKey = hexToBytes(request.signer);
   if (publicKey.length !== SECP256R1_PUBLIC_KEY_SIZE) {
     throw new Error('Secp256r1 signature request signer must be 33 bytes');
@@ -120,12 +140,47 @@ async function applySignatureRequest(
     setInstructionData(
       transaction,
       signV2InstructionIndex,
-      patchSignV2AuthorityPayload(
+      patchSignV2AuthorityPayloadPrefix(
         getInstructionData(transaction, signV2InstructionIndex),
         signingResult.prefix,
+        SECP256R1_AUTHORITY_PAYLOAD_SIZE,
+        'secp256r1',
       ),
     );
   }
+}
+
+async function applySecp256k1SignatureRequest(
+  transaction: SwigTransaction,
+  request: ClientSignatureRequest,
+  options: SignPreparedSwigTransactionOptions,
+) {
+  if (!options.secp256k1) {
+    throw new Error('No secp256k1 signing function registered');
+  }
+
+  const signingFn = resolveSecp256k1SigningFn(request, options.secp256k1);
+  const message = asciiToBytes(normalizeHex(request.messageHash));
+  const signingResult = await signingFn(message);
+
+  if (signingResult.signature.length !== SECP256K1_SIGNATURE_SIZE) {
+    throw new Error('Secp256k1 signature must be 65 bytes');
+  }
+
+  const signV2InstructionIndex = findSignV2InstructionIndexForSecp256k1(
+    transaction,
+    request,
+  );
+  setInstructionData(
+    transaction,
+    signV2InstructionIndex,
+    patchSignV2Secp256k1AuthorityPayload(
+      getInstructionData(transaction, signV2InstructionIndex),
+      request,
+      signingResult.signature,
+      signingResult.prefix,
+    ),
+  );
 }
 
 function resolveSecp256r1SigningFn(
@@ -145,6 +200,29 @@ function resolveSecp256r1SigningFn(
   if (!signingFn) {
     throw new Error(
       `No secp256r1 signing function registered for signer ${request.signer}`,
+    );
+  }
+
+  return signingFn;
+}
+
+function resolveSecp256k1SigningFn(
+  request: ClientSignatureRequest,
+  signingFns: Secp256k1SigningFns,
+): Secp256k1SigningFn {
+  if (typeof signingFns === 'function') {
+    return signingFns;
+  }
+
+  const normalizedSigner = normalizeHex(request.signer);
+  const signingFn =
+    signingFns[normalizedSigner] ??
+    signingFns[`0x${normalizedSigner}`] ??
+    signingFns[request.signer];
+
+  if (!signingFn) {
+    throw new Error(
+      `No secp256k1 signing function registered for signer ${request.signer}`,
     );
   }
 
@@ -224,6 +302,49 @@ function findFollowingSignV2InstructionIndex(
   );
 }
 
+function findSignV2InstructionIndexForSecp256k1(
+  transaction: SwigTransaction,
+  request: ClientSignatureRequest,
+): number {
+  const fallbackIndexes: number[] = [];
+
+  for (let index = 0; index < instructionCount(transaction); index++) {
+    if (!getInstructionProgramId(transaction, index).equals(SWIG_PROGRAM_ID)) {
+      continue;
+    }
+
+    const instructionData = getInstructionData(transaction, index);
+    if (readU16(instructionData, 0) !== SIGN_V2_DISCRIMINATOR) {
+      continue;
+    }
+
+    const authorityPayloadOffset =
+      getSignV2AuthorityPayloadOffset(instructionData);
+    if (
+      instructionData.length <
+      authorityPayloadOffset + SECP256K1_AUTHORITY_PAYLOAD_SIZE
+    ) {
+      continue;
+    }
+
+    fallbackIndexes.push(index);
+
+    if (
+      readU64(instructionData, authorityPayloadOffset) ===
+        BigInt(request.slot) &&
+      readU32(instructionData, authorityPayloadOffset + 8) === request.counter
+    ) {
+      return index;
+    }
+  }
+
+  if (fallbackIndexes.length === 1) {
+    return fallbackIndexes[0];
+  }
+
+  throw new Error('Matching secp256k1 Swig SignV2 instruction not found');
+}
+
 function encodeSecp256r1SignatureInstruction(args: {
   publicKey: Uint8Array;
   signature: Uint8Array;
@@ -282,29 +403,76 @@ function parseSecp256r1SignatureInstruction(data: Uint8Array):
   };
 }
 
-function patchSignV2AuthorityPayload(
+function patchSignV2AuthorityPayloadPrefix(
   instructionData: Uint8Array,
   prefix: Uint8Array,
+  fixedPayloadSize: number,
+  scheme: string,
 ): Uint8Array {
-  const instructionPayloadLength = readU16(instructionData, 2);
-  const authorityPayloadOffset = 8 + instructionPayloadLength;
+  const authorityPayloadOffset =
+    getSignV2AuthorityPayloadOffset(instructionData);
 
-  if (
-    instructionData.length <
-    authorityPayloadOffset + SECP256R1_AUTHORITY_PAYLOAD_SIZE
-  ) {
+  if (instructionData.length < authorityPayloadOffset + fixedPayloadSize) {
     throw new Error(
-      'Swig SignV2 instruction is missing secp256r1 authority payload',
+      `Swig SignV2 instruction is missing ${scheme} authority payload`,
     );
   }
 
-  const fixedPayloadEnd =
-    authorityPayloadOffset + SECP256R1_AUTHORITY_PAYLOAD_SIZE;
+  const fixedPayloadEnd = authorityPayloadOffset + fixedPayloadSize;
   const patched = new Uint8Array(fixedPayloadEnd + prefix.length);
   patched.set(instructionData.slice(0, fixedPayloadEnd));
   patched.set(prefix, fixedPayloadEnd);
 
   return patched;
+}
+
+function patchSignV2Secp256k1AuthorityPayload(
+  instructionData: Uint8Array,
+  request: ClientSignatureRequest,
+  signature: Uint8Array,
+  prefix?: Uint8Array,
+): Uint8Array {
+  const authorityPayloadOffset =
+    getSignV2AuthorityPayloadOffset(instructionData);
+
+  if (
+    instructionData.length <
+    authorityPayloadOffset + SECP256K1_AUTHORITY_PAYLOAD_SIZE
+  ) {
+    throw new Error(
+      'Swig SignV2 instruction is missing secp256k1 authority payload',
+    );
+  }
+
+  if (!Number.isSafeInteger(request.slot) || request.slot < 0) {
+    throw new Error('Secp256k1 signature request slot must be a safe integer');
+  }
+
+  if (
+    !Number.isSafeInteger(request.counter) ||
+    request.counter < 0 ||
+    request.counter > 0xffffffff
+  ) {
+    throw new Error('Secp256k1 signature request counter must fit in u32');
+  }
+
+  const fixedPayloadEnd =
+    authorityPayloadOffset + SECP256K1_AUTHORITY_PAYLOAD_SIZE;
+  const prefixPayload = prefix ?? new Uint8Array(0);
+  const patched = new Uint8Array(fixedPayloadEnd + prefixPayload.length);
+  patched.set(instructionData.slice(0, fixedPayloadEnd));
+
+  const view = new DataView(patched.buffer, patched.byteOffset);
+  view.setBigUint64(authorityPayloadOffset, BigInt(request.slot), true);
+  view.setUint32(authorityPayloadOffset + 8, request.counter, true);
+  patched.set(signature, authorityPayloadOffset + SECP256K1_SIGNATURE_OFFSET);
+  patched.set(prefixPayload, fixedPayloadEnd);
+
+  return patched;
+}
+
+function getSignV2AuthorityPayloadOffset(instructionData: Uint8Array): number {
+  return 8 + readU16(instructionData, 2);
 }
 
 function instructionCount(transaction: SwigTransaction): number {
@@ -389,12 +557,41 @@ function readU16(data: Uint8Array, offset: number): number {
   );
 }
 
+function readU32(data: Uint8Array, offset: number): number {
+  if (data.length < offset + 4) {
+    throw new Error('Instruction data is too short');
+  }
+  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(
+    offset,
+    true,
+  );
+}
+
+function readU64(data: Uint8Array, offset: number): bigint {
+  if (data.length < offset + 8) {
+    throw new Error('Instruction data is too short');
+  }
+  return new DataView(
+    data.buffer,
+    data.byteOffset,
+    data.byteLength,
+  ).getBigUint64(offset, true);
+}
+
 function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
   if (left.length !== right.length) {
     return false;
   }
 
   return left.every((value, index) => value === right[index]);
+}
+
+function asciiToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index++) {
+    bytes[index] = value.charCodeAt(index);
+  }
+  return bytes;
 }
 
 function base64ToBytes(value: string): Uint8Array {

--- a/packages/developer-sdk/src/evm/index.test.ts
+++ b/packages/developer-sdk/src/evm/index.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createSecp256k1EvmSigningFn } from './index.js';
+
+describe('EVM signing helpers', () => {
+  test('creates a personal_sign based secp256k1 signing function', async () => {
+    const address = '0x1234567890123456789012345678901234567890';
+    const message = Uint8Array.from([0xde, 0xad, 0xbe, 0xef]);
+    const signature = Uint8Array.from({ length: 65 }, (_, index) => index);
+    signature[64] = 1;
+
+    const signingFn = createSecp256k1EvmSigningFn({
+      address,
+      provider: {
+        request: async ({ method, params }) => {
+          expect(method).toBe('personal_sign');
+          expect(params).toEqual(['0xdeadbeef', address]);
+          return bytesToHex(signature);
+        },
+      },
+    });
+
+    const result = await signingFn(message);
+
+    const normalizedSignature = signature.slice();
+    normalizedSignature[64] = 28;
+    expect(result.signature).toEqual(normalizedSignature);
+    expect(result.prefix).toEqual(
+      asciiToBytes('\x19Ethereum Signed Message:\n4'),
+    );
+  });
+
+  test('rejects malformed EVM signatures', async () => {
+    const signingFn = createSecp256k1EvmSigningFn({
+      address: '0x1234567890123456789012345678901234567890',
+      provider: {
+        request: async () => '0x1234',
+      },
+    });
+
+    await expect(signingFn(Uint8Array.from([1]))).rejects.toThrow(
+      'EVM signature must be 65 bytes',
+    );
+  });
+});
+
+function bytesToHex(bytes: Uint8Array): string {
+  return `0x${[...bytes]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+function asciiToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index++) {
+    bytes[index] = value.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/packages/developer-sdk/src/evm/index.ts
+++ b/packages/developer-sdk/src/evm/index.ts
@@ -1,0 +1,89 @@
+import type {
+  CreateSecp256k1EvmSigningFnOptions,
+  Secp256k1SigningFn,
+} from '../types/index.js';
+
+export function createSecp256k1EvmSigningFn(
+  options: CreateSecp256k1EvmSigningFnOptions,
+): Secp256k1SigningFn {
+  return async (message) => {
+    const signature = await options.provider.request({
+      method: 'personal_sign',
+      params: [bytesToHex(message), options.address],
+    });
+
+    if (typeof signature !== 'string') {
+      throw new Error('EVM provider returned a non-string signature');
+    }
+
+    return {
+      signature: parseEvmSignature(signature),
+      prefix: evmPersonalSignPrefix(message.length),
+    };
+  };
+}
+
+function parseEvmSignature(signature: string): Uint8Array {
+  const bytes = hexToBytes(signature);
+  if (bytes.length !== 65) {
+    throw new Error('EVM signature must be 65 bytes');
+  }
+
+  bytes[64] = normalizeRecoveryByte(bytes[64]);
+  return bytes;
+}
+
+function normalizeRecoveryByte(value: number): number {
+  if (value === 0 || value === 1) {
+    return value + 27;
+  }
+
+  if (value === 27 || value === 28) {
+    return value;
+  }
+
+  if (value >= 35) {
+    return ((value - 35) % 2) + 27;
+  }
+
+  throw new Error('EVM signature has an invalid recovery byte');
+}
+
+function evmPersonalSignPrefix(messageLength: number): Uint8Array {
+  return asciiToBytes(`\x19Ethereum Signed Message:\n${messageLength}`);
+}
+
+function hexToBytes(value: string): Uint8Array {
+  const normalized = normalizeHex(value);
+  if (normalized.length % 2 !== 0) {
+    throw new Error('Hex strings must contain an even number of characters');
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < normalized.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(normalized.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return `0x${[...bytes]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+function normalizeHex(value: string): string {
+  const normalized = value.startsWith('0x') ? value.slice(2) : value;
+  if (!/^[\da-fA-F]+$/.test(normalized)) {
+    throw new Error('Invalid hex string');
+  }
+  return normalized.toLowerCase();
+}
+
+function asciiToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index++) {
+    bytes[index] = value.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/packages/developer-sdk/src/types/evm.ts
+++ b/packages/developer-sdk/src/types/evm.ts
@@ -1,0 +1,18 @@
+export interface Eip1193Provider {
+  request(args: { method: string; params?: unknown[] }): Promise<unknown>;
+}
+
+export interface Secp256k1SigningResult {
+  signature: Uint8Array;
+  prefix?: Uint8Array;
+  message?: Uint8Array;
+}
+
+export type Secp256k1SigningFn = (
+  message: Uint8Array,
+) => Promise<Secp256k1SigningResult>;
+
+export interface CreateSecp256k1EvmSigningFnOptions {
+  provider: Eip1193Provider;
+  address: string;
+}

--- a/packages/developer-sdk/src/types/index.ts
+++ b/packages/developer-sdk/src/types/index.ts
@@ -1,5 +1,6 @@
 export type * from './common.js';
 export type * from './config.js';
+export type * from './evm.js';
 export type * from './instruction.js';
 export type * from './passkeys.js';
 export type * from './policy.js';


### PR DESCRIPTION
## Summary
- add a client-side EIP-1193 personal_sign helper for secp256k1/EVM authorities
- extend prepared Swig transaction signing to patch secp256k1 SignV2 authority payloads
- document the EVM signing flow in the developer SDK README

## Verification
- bun --filter '@swig-wallet/developer-sdk' test
- bun --filter '@swig-wallet/developer-sdk' typecheck
- bun --filter '@swig-wallet/developer-sdk' lint
- bun --filter '@swig-wallet/developer-sdk' build
- git diff --check