### PR TITLE
Add developer SDK business read helpers

### DIFF
--- a/.changeset/few-dancers-wave.md
+++ b/.changeset/few-dancers-wave.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Add API-key scoped Swig wallet balance, token activity, and paymaster balance read helpers.

--- a/packages/developer-sdk/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/src/browser-proxy.test.ts
@@ -275,6 +275,75 @@ describe('SwigBrowserClient', () => {
     expect(prepared.transaction).toBe('base64-swap-tx');
   });
 
+  test('reads wallet balances through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          usdValue: 123.45,
+        };
+      }),
+    });
+    const wallet = swig.wallets.fromIdpSession({
+      configAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      roleId: 0,
+    });
+
+    const balance = await wallet.getUsdBalance();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/wallet/swig_config_123/balance/usd?network=devnet',
+      method: 'GET',
+      body: undefined,
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(balance).toEqual({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      usdValue: 123.45,
+    });
+  });
+
+  test('reads paymaster balance through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          configured: true,
+          kind: 'idp',
+          id: 'paymaster_123',
+          address: 'paymaster_address_123',
+          label: 'IdP paymaster',
+          balanceLamports: '5000000000',
+          balanceSol: 5,
+        };
+      }),
+    });
+
+    const balance = await swig.paymaster.getBalance();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/paymaster/balance?network=devnet',
+      method: 'GET',
+      body: undefined,
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(balance).toMatchObject({
+      configured: true,
+      address: 'paymaster_address_123',
+      balanceSol: 5,
+    });
+  });
+
   test('throws proxy errors with the route response status and message', async () => {
     const swig = new SwigBrowserClient({
       fetch: jsonFetch(() => ({

--- a/packages/developer-sdk/src/browser-proxy.ts
+++ b/packages/developer-sdk/src/browser-proxy.ts
@@ -1,6 +1,11 @@
 import type {
+  GetPaymasterBalanceArgs,
   IdpWalletSession,
+  ListSwigTokenBalancesResult,
+  ListSwigTokenTransactionsArgs,
+  ListSwigTokenTransactionsResult,
   Network,
+  PaymasterBalance,
   PrepareArgs,
   PreparedTransaction,
   PreparedTransactionsResult,
@@ -8,10 +13,12 @@ import type {
   PrepareOperation,
   PrepareTransactionsResponseWire,
   SwapArgs,
+  SwigUsdBalance,
   TransferSolArgs,
   TransferTokenArgs,
   WalletAuthority,
   WalletHandleOptions,
+  WalletReadArgs,
   WalletReference,
 } from './types/index.js';
 import {
@@ -87,9 +94,11 @@ export class SwigBrowserProxyError extends Error {
 }
 
 export class SwigBrowserClient {
+  readonly paymaster: BrowserPaymasterClient;
   readonly wallets: BrowserWalletsClient;
 
   constructor(config: SwigBrowserClientConfig = {}) {
+    this.paymaster = new BrowserPaymasterClient(config);
     this.wallets = new BrowserWalletsClient(config);
   }
 }
@@ -231,34 +240,60 @@ export class BrowserWalletsClient {
     );
     return normalizePreparedTransaction(response);
   };
+
+  getUsdBalance = (
+    wallet: BrowserWalletHandle,
+    args: WalletReadArgs = {},
+  ): Promise<SwigUsdBalance> => {
+    return this.http.get<SwigUsdBalance>(
+      walletReadRoute(wallet, 'balance/usd'),
+      { network: args.network ?? wallet.network ?? this.defaultNetwork },
+    );
+  };
+
+  listTokenBalances = (
+    wallet: BrowserWalletHandle,
+    args: WalletReadArgs = {},
+  ): Promise<ListSwigTokenBalancesResult> => {
+    return this.http.get<ListSwigTokenBalancesResult>(
+      walletReadRoute(wallet, 'token-balances'),
+      { network: args.network ?? wallet.network ?? this.defaultNetwork },
+    );
+  };
+
+  listTokenTransactions = (
+    wallet: BrowserWalletHandle,
+    args: ListSwigTokenTransactionsArgs = {},
+  ): Promise<ListSwigTokenTransactionsResult> => {
+    return this.http.get<ListSwigTokenTransactionsResult>(
+      walletReadRoute(wallet, 'token-transactions'),
+      {
+        network: args.network ?? wallet.network ?? this.defaultNetwork,
+        limit: args.limit,
+      },
+    );
+  };
 }
 
-export class BrowserWalletHandle {
-  readonly swigConfigAddress: string;
-  readonly walletAddress?: string;
-  readonly roleId?: number;
-  readonly authorityPublicKey?: string;
-  readonly network?: Network;
-  readonly requesterAuthority?: WalletAuthority;
-  readonly transfer: BrowserWalletTransferClient;
-  readonly swap: BrowserWalletSwapClient;
+export class BrowserPaymasterClient {
+  private readonly http: BrowserProxyHttpClient;
+  private readonly defaultNetwork?: Network;
 
-  constructor(
-    private readonly wallets: BrowserWalletsClient,
-    init: BrowserWalletReference,
-  ) {
-    this.swigConfigAddress = init.swigConfigAddress;
-    this.walletAddress = init.walletAddress;
-    this.roleId = init.roleId;
-    this.authorityPublicKey = init.authorityPublicKey;
-    this.network = init.network;
-    this.requesterAuthority = init.requesterAuthority;
-    this.transfer = createBrowserWalletTransferClient(wallets, this);
-    this.swap = createBrowserWalletSwapClient(wallets, this);
+  constructor(config: SwigBrowserClientConfig = {}) {
+    this.http = new BrowserProxyHttpClient({
+      basePath: config.basePath ?? '/api/swig',
+      fetch: resolveFetch(config.fetch),
+    });
+    this.defaultNetwork = config.network;
   }
 
-  prepare = (args: BrowserPrepareArgs): Promise<PreparedTransactionsResult> =>
-    this.wallets.prepare(this, args);
+  getBalance = (
+    args: GetPaymasterBalanceArgs = {},
+  ): Promise<PaymasterBalance> => {
+    return this.http.get<PaymasterBalance>('paymaster/balance', {
+      network: args.network ?? this.defaultNetwork,
+    });
+  };
 }
 
 class BrowserProxyHttpClient {
@@ -293,6 +328,84 @@ class BrowserProxyHttpClient {
 
     return readPrepared<TResponse>(responseBody);
   };
+
+  get = async <TResponse>(
+    route: string,
+    query: Record<string, string | number | undefined> = {},
+  ): Promise<TResponse> => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        params.set(key, String(value));
+      }
+    }
+    const suffix = params.size > 0 ? `?${params.toString()}` : '';
+    const response = await this.#fetch(`${this.#basePath}/${route}${suffix}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+    const responseBody = await parseResponseBody(response);
+
+    if (!response.ok) {
+      throw new SwigBrowserProxyError(
+        errorMessageFromBody(responseBody),
+        response.status,
+        responseBody,
+      );
+    }
+
+    return responseBody as TResponse;
+  };
+}
+
+export class BrowserWalletHandle {
+  readonly swigConfigAddress: string;
+  readonly walletAddress?: string;
+  readonly roleId?: number;
+  readonly authorityPublicKey?: string;
+  readonly network?: Network;
+  readonly requesterAuthority?: WalletAuthority;
+  readonly transfer: BrowserWalletTransferClient;
+  readonly swap: BrowserWalletSwapClient;
+
+  constructor(
+    private readonly wallets: BrowserWalletsClient,
+    init: BrowserWalletReference,
+  ) {
+    this.swigConfigAddress = init.swigConfigAddress;
+    this.walletAddress = init.walletAddress;
+    this.roleId = init.roleId;
+    this.authorityPublicKey = init.authorityPublicKey;
+    this.network = init.network;
+    this.requesterAuthority = init.requesterAuthority;
+    this.transfer = createBrowserWalletTransferClient(wallets, this);
+    this.swap = createBrowserWalletSwapClient(wallets, this);
+  }
+
+  prepare = (args: BrowserPrepareArgs): Promise<PreparedTransactionsResult> =>
+    this.wallets.prepare(this, args);
+
+  getUsdBalance = (args?: WalletReadArgs): Promise<SwigUsdBalance> =>
+    this.wallets.getUsdBalance(this, args);
+
+  listTokenBalances = (
+    args?: WalletReadArgs,
+  ): Promise<ListSwigTokenBalancesResult> =>
+    this.wallets.listTokenBalances(this, args);
+
+  listTokenTransactions = (
+    args?: ListSwigTokenTransactionsArgs,
+  ): Promise<ListSwigTokenTransactionsResult> =>
+    this.wallets.listTokenTransactions(this, args);
+}
+
+function walletReadRoute(
+  wallet: BrowserWalletHandle,
+  route: 'balance/usd' | 'token-balances' | 'token-transactions',
+): string {
+  return `wallet/${encodeURIComponent(wallet.swigConfigAddress)}/${route}`;
 }
 
 function createBrowserWalletTransferClient(

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_BACKEND_URL, SwigDeveloperSdkError } from './core/index.js';
+export { PaymasterClient } from './paymaster/index.js';
 export { SwigClient } from './server/typescript/index.js';
 export { TransactionsClient } from './transactions/index.js';
 export { WalletHandle, WalletsClient } from './wallets/index.js';

--- a/packages/developer-sdk/src/paymaster/client.ts
+++ b/packages/developer-sdk/src/paymaster/client.ts
@@ -1,0 +1,87 @@
+import type { HttpClient } from '../core/index.js';
+import type {
+  GetPaymasterBalanceArgs,
+  Network,
+  PaymasterBalance,
+  PaymasterBalanceWire,
+  PaymasterKind,
+  PaymasterKindWire,
+} from '../types/index.js';
+
+export class PaymasterClient {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly defaultNetwork?: Network,
+  ) {}
+
+  getBalance = async (
+    args: GetPaymasterBalanceArgs = {},
+  ): Promise<PaymasterBalance> => {
+    const response = await this.http.get<PaymasterBalanceWire>(
+      paymasterBalancePath(args.network ?? this.defaultNetwork),
+    );
+    return normalizePaymasterBalance(response);
+  };
+}
+
+function paymasterBalancePath(network?: Network): string {
+  if (!network) {
+    return '/paymaster/balance';
+  }
+  const params = new URLSearchParams({ network });
+  return `/paymaster/balance?${params.toString()}`;
+}
+
+function normalizePaymasterBalance(
+  response: PaymasterBalanceWire,
+): PaymasterBalance {
+  return {
+    configured: response.configured ?? false,
+    kind: normalizePaymasterKind(response.kind),
+    id: response.id ?? '',
+    address: response.address ?? '',
+    label: response.label ?? '',
+    balanceLamports: stringField(
+      response.balanceLamports ?? response.balance_lamports ?? '0',
+    ),
+    balanceSol: numberField(
+      response.balanceSol ?? response.balance_sol ?? 0,
+      'balanceSol',
+    ),
+  };
+}
+
+function normalizePaymasterKind(kind?: PaymasterKindWire): PaymasterKind {
+  switch (kind) {
+    case 'api':
+    case 'PAYMASTER_KIND_API':
+    case 1:
+      return 'api';
+    case 'idp':
+    case 'PAYMASTER_KIND_IDP':
+    case 2:
+      return 'idp';
+    case 'unspecified':
+    case 'PAYMASTER_KIND_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Paymaster balance response has invalid kind');
+  }
+}
+
+function stringField(value: number | string): string {
+  return String(value);
+}
+
+function numberField(value: number | string, field: string): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  throw new Error(`Paymaster balance response is missing ${field}`);
+}

--- a/packages/developer-sdk/src/paymaster/index.ts
+++ b/packages/developer-sdk/src/paymaster/index.ts
@@ -1,0 +1,1 @@
+export { PaymasterClient } from './client.js';

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { createSwigFetchHandler } from './index.js';
+import { createSwigFetchHandler, createSwigGetHandler } from './index.js';
 
 type CapturedRequest = {
   url: string;
@@ -604,5 +604,87 @@ describe('createSwigFetchHandler', () => {
         mode: 'fast',
       },
     });
+  });
+});
+
+describe('createSwigGetHandler', () => {
+  test('proxies wallet USD balance reads with the configured API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          swig_config_address: 'swig_config_123',
+          wallet_address: 'wallet_123',
+          usd_value: 42.5,
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/wallet/swig_config_123/balance/usd?network=devnet',
+        { method: 'GET' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      usdValue: 42.5,
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/swig/swig_config_123/balance/usd?network=NETWORK_DEVNET',
+      method: 'GET',
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+  });
+
+  test('proxies paymaster balance reads without exposing config fields', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          configured: true,
+          kind: 'PAYMASTER_KIND_IDP',
+          id: 'paymaster_123',
+          address: 'paymaster_address_123',
+          label: 'IdP paymaster',
+          balance_lamports: '5000000000',
+          balance_sol: 5,
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/paymaster/balance?network=devnet',
+        {
+          method: 'GET',
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      configured: true,
+      kind: 'idp',
+      id: 'paymaster_123',
+      address: 'paymaster_address_123',
+      label: 'IdP paymaster',
+      balanceLamports: '5000000000',
+      balanceSol: 5,
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/paymaster/balance?network=devnet',
+      method: 'GET',
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
   });
 });

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -11,12 +11,20 @@ import type {
 } from '../../types/index.js';
 import { SwigClient } from '../typescript/index.js';
 
-export type SwigProxyRoute =
+export type SwigPostProxyRoute =
   | 'wallet/create'
   | 'prepare'
   | 'transfer/sol'
   | 'transfer/spl-token'
   | 'swap/jupiter';
+
+export type SwigReadProxyRoute =
+  | 'wallet/balance/usd'
+  | 'wallet/token-balances'
+  | 'wallet/token-transactions'
+  | 'paymaster/balance';
+
+export type SwigProxyRoute = SwigPostProxyRoute | SwigReadProxyRoute;
 
 export interface SwigProxyWalletReference extends WalletReference {
   roleId?: number;
@@ -59,7 +67,7 @@ class SwigRouteError extends Error {
   }
 }
 
-const swigProxyRoutes: SwigProxyRoute[] = [
+const swigPostProxyRoutes: SwigPostProxyRoute[] = [
   'wallet/create',
   'prepare',
   'transfer/sol',
@@ -75,12 +83,18 @@ export function createSwigFetchHandler(
   return (request: Request) => handlePost(request, config);
 }
 
+export function createSwigGetHandler(
+  config: CreateSwigFetchHandlerConfig = {},
+): SwigFetchHandler {
+  return (request: Request) => handleGet(request, config);
+}
+
 async function handlePost(
   request: Request,
   config: CreateSwigFetchHandlerConfig,
 ): Promise<Response> {
   try {
-    const route = resolveRoute(request);
+    const route = resolvePostRoute(request);
     const body = await readJsonObject(request);
     const network = readNetwork(body.network) ?? config.network;
     const wallet = readWallet(body.wallet);
@@ -128,6 +142,63 @@ async function handlePost(
     const status = error instanceof SwigRouteError ? error.status : 400;
     return json({ error: message }, status);
   }
+}
+
+async function handleGet(
+  request: Request,
+  config: CreateSwigFetchHandlerConfig,
+): Promise<Response> {
+  try {
+    const route = resolveReadRoute(request);
+    const network =
+      readNetwork(new URL(request.url).searchParams.get('network')) ??
+      config.network;
+    const apiKey = resolveApiKey(config);
+    const transactionApiUrl = resolveTransactionApiUrl(config);
+    const swig = new SwigClient({
+      apiKey,
+      ...(transactionApiUrl ? { baseUrl: transactionApiUrl } : {}),
+      ...(network ? { network } : {}),
+      ...(config.fetch ? { fetch: config.fetch } : {}),
+    });
+
+    switch (route.route) {
+      case 'wallet/balance/usd':
+        return json(
+          await swig.wallets
+            .use(route.swigConfigAddress, walletOptions(network))
+            .getUsdBalance(walletOptions(network)),
+        );
+      case 'wallet/token-balances':
+        return json(
+          await swig.wallets
+            .use(route.swigConfigAddress, walletOptions(network))
+            .listTokenBalances(walletOptions(network)),
+        );
+      case 'wallet/token-transactions': {
+        const limit = readOptionalQueryNumber(request, 'limit');
+        return json(
+          await swig.wallets
+            .use(route.swigConfigAddress, walletOptions(network))
+            .listTokenTransactions({
+              ...walletOptions(network),
+              ...(limit === undefined ? {} : { limit }),
+            }),
+        );
+      }
+      case 'paymaster/balance':
+        return json(await swig.paymaster.getBalance(walletOptions(network)));
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unable to fetch Swig resource';
+    const status = error instanceof SwigRouteError ? error.status : 400;
+    return json({ error: message }, status);
+  }
+}
+
+function walletOptions(network: Network | undefined): { network?: Network } {
+  return network ? { network } : {};
 }
 
 async function prepareWalletCreation(
@@ -403,9 +474,9 @@ function resolveTransactionApiUrl(config: CreateSwigFetchHandlerConfig) {
   );
 }
 
-function resolveRoute(request: Request): SwigProxyRoute {
+function resolvePostRoute(request: Request): SwigPostProxyRoute {
   const pathname = new URL(request.url).pathname.replace(/\/$/, '');
-  const route = swigProxyRoutes.find(
+  const route = swigPostProxyRoutes.find(
     (candidate) =>
       pathname === `/${candidate}` || pathname.endsWith(`/${candidate}`),
   );
@@ -415,6 +486,45 @@ function resolveRoute(request: Request): SwigProxyRoute {
   }
 
   return route;
+}
+
+function resolveReadRoute(
+  request: Request,
+):
+  | { route: 'wallet/balance/usd'; swigConfigAddress: string }
+  | { route: 'wallet/token-balances'; swigConfigAddress: string }
+  | { route: 'wallet/token-transactions'; swigConfigAddress: string }
+  | { route: 'paymaster/balance' } {
+  const pathname = new URL(request.url).pathname.replace(/\/$/, '');
+  if (
+    pathname === '/paymaster/balance' ||
+    pathname.endsWith('/paymaster/balance')
+  ) {
+    return { route: 'paymaster/balance' };
+  }
+
+  const match = pathname.match(
+    /\/wallet\/([^/]+)\/(balance\/usd|token-balances|token-transactions)$/,
+  );
+  if (!match) {
+    throw new SwigRouteError('Unsupported Swig route', 404);
+  }
+
+  const swigConfigAddress = decodeURIComponent(match[1] ?? '');
+  if (!swigConfigAddress) {
+    throw new SwigRouteError('swigConfigAddress is required');
+  }
+
+  switch (match[2]) {
+    case 'balance/usd':
+      return { route: 'wallet/balance/usd', swigConfigAddress };
+    case 'token-balances':
+      return { route: 'wallet/token-balances', swigConfigAddress };
+    case 'token-transactions':
+      return { route: 'wallet/token-transactions', swigConfigAddress };
+    default:
+      throw new SwigRouteError('Unsupported Swig route', 404);
+  }
 }
 
 async function readJsonObject(
@@ -581,6 +691,18 @@ function readOptionalNumber(
   return typeof value === 'number' && Number.isFinite(value)
     ? value
     : undefined;
+}
+
+function readOptionalQueryNumber(
+  request: Request,
+  key: string,
+): number | undefined {
+  const value = new URL(request.url).searchParams.get(key);
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function readEnv(...names: string[]): string | undefined {

--- a/packages/developer-sdk/src/server/next/index.test.ts
+++ b/packages/developer-sdk/src/server/next/index.test.ts
@@ -40,4 +40,40 @@ describe('createSwigRouteHandlers', () => {
       },
     });
   });
+
+  test('wraps the fetch handler as a Next.js GET export', async () => {
+    const { GET } = createSwigRouteHandlers({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: (async () =>
+        new Response(
+          JSON.stringify({
+            configured: true,
+            kind: 'PAYMASTER_KIND_API',
+            id: 'paymaster_123',
+            address: 'paymaster_address_123',
+            label: 'Primary',
+            balance_lamports: '1000000000',
+            balance_sol: 1,
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        )) as unknown as typeof fetch,
+    });
+
+    const response = await GET(
+      new Request(
+        'https://app.example/api/swig/paymaster/balance?network=devnet',
+        {
+          method: 'GET',
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      configured: true,
+      address: 'paymaster_address_123',
+      balanceSol: 1,
+    });
+  });
 });

--- a/packages/developer-sdk/src/server/next/index.ts
+++ b/packages/developer-sdk/src/server/next/index.ts
@@ -1,5 +1,6 @@
 import {
   createSwigFetchHandler,
+  createSwigGetHandler,
   type CreateSwigFetchHandlerConfig,
   type SwigFetchHandler,
 } from '../fetch/index.js';
@@ -10,8 +11,9 @@ export type { SwigProxyRoute, SwigRouteContext } from '../fetch/index.js';
 
 export function createSwigRouteHandlers(
   config: CreateSwigRouteHandlersConfig = {},
-): { POST: SwigFetchHandler } {
+): { GET: SwigFetchHandler; POST: SwigFetchHandler } {
   return {
+    GET: createSwigGetHandler(config),
     POST: createSwigFetchHandler(config),
   };
 }

--- a/packages/developer-sdk/src/server/typescript/index.ts
+++ b/packages/developer-sdk/src/server/typescript/index.ts
@@ -3,6 +3,7 @@ import {
   HttpClient,
   resolveRetryOptions,
 } from '../../core/index.js';
+import { PaymasterClient } from '../../paymaster/index.js';
 import { TransactionsClient } from '../../transactions/index.js';
 import type { SwigClientConfig } from '../../types/index.js';
 import { WalletsClient } from '../../wallets/index.js';
@@ -10,6 +11,7 @@ import { WalletsClient } from '../../wallets/index.js';
 export class SwigClient {
   readonly #http: HttpClient;
   readonly defaultNetwork: SwigClientConfig['network'];
+  readonly paymaster: PaymasterClient;
   readonly transactions: TransactionsClient;
   readonly wallets: WalletsClient;
 
@@ -21,6 +23,7 @@ export class SwigClient {
       fetch: config.fetch ?? fetch,
       retry: resolveRetryOptions(config.retryOptions),
     });
+    this.paymaster = new PaymasterClient(this.#http, this.defaultNetwork);
     this.transactions = new TransactionsClient(this.#http, this.defaultNetwork);
     this.wallets = new WalletsClient(this.#http, this.defaultNetwork);
   }

--- a/packages/developer-sdk/src/types/index.ts
+++ b/packages/developer-sdk/src/types/index.ts
@@ -3,6 +3,7 @@ export type * from './config.js';
 export type * from './evm.js';
 export type * from './instruction.js';
 export type * from './passkeys.js';
+export type * from './paymaster.js';
 export type * from './policy.js';
 export type * from './transaction.js';
 export type * from './wallet-actions.js';

--- a/packages/developer-sdk/src/types/paymaster.ts
+++ b/packages/developer-sdk/src/types/paymaster.ts
@@ -1,0 +1,36 @@
+import type { Network } from './common.js';
+
+export interface GetPaymasterBalanceArgs {
+  network?: Network;
+}
+
+export type PaymasterKind = 'api' | 'idp' | 'unspecified';
+
+export type PaymasterKindWire =
+  | PaymasterKind
+  | 'PAYMASTER_KIND_API'
+  | 'PAYMASTER_KIND_IDP'
+  | 'PAYMASTER_KIND_UNSPECIFIED'
+  | number;
+
+export interface PaymasterBalance {
+  configured: boolean;
+  kind: PaymasterKind;
+  id: string;
+  address: string;
+  label: string;
+  balanceLamports: string;
+  balanceSol: number;
+}
+
+export interface PaymasterBalanceWire {
+  configured?: boolean;
+  kind?: PaymasterKindWire;
+  id?: string;
+  address?: string;
+  label?: string;
+  balance_lamports?: number | string;
+  balanceLamports?: number | string;
+  balance_sol?: number;
+  balanceSol?: number;
+}

--- a/packages/developer-sdk/src/types/wallet.ts
+++ b/packages/developer-sdk/src/types/wallet.ts
@@ -31,3 +31,151 @@ export interface WalletHandleOptions {
   network?: Network;
   requesterAuthority?: WalletAuthority;
 }
+
+export interface WalletReadArgs {
+  network?: Network;
+}
+
+export interface ListSwigTokenTransactionsArgs extends WalletReadArgs {
+  limit?: number;
+}
+
+export interface SwigUsdBalance {
+  swigConfigAddress: string;
+  walletAddress: string;
+  usdValue: number;
+}
+
+export interface SwigUsdBalanceWire {
+  swig_config_address?: string;
+  swigConfigAddress?: string;
+  wallet_address?: string;
+  walletAddress?: string;
+  usd_value?: number;
+  usdValue?: number;
+}
+
+export interface SwigTokenBalance {
+  mintAddress: string;
+  tokenProgram: number;
+  tokenSymbol: string;
+  tokenName: string;
+  decimals: number;
+  amountRaw: string;
+  uiAmount: number;
+  usdPrice: number;
+  usdValue: number;
+}
+
+export interface SwigTokenBalanceWire {
+  mint_address?: string;
+  mintAddress?: string;
+  token_program?: number;
+  tokenProgram?: number;
+  token_symbol?: string;
+  tokenSymbol?: string;
+  token_name?: string;
+  tokenName?: string;
+  decimals?: number;
+  amount_raw?: string;
+  amountRaw?: string;
+  ui_amount?: number;
+  uiAmount?: number;
+  usd_price?: number;
+  usdPrice?: number;
+  usd_value?: number;
+  usdValue?: number;
+}
+
+export interface ListSwigTokenBalancesResult {
+  swigConfigAddress: string;
+  walletAddress: string;
+  balances: SwigTokenBalance[];
+  totalUsdValue: number;
+}
+
+export interface ListSwigTokenBalancesWire {
+  swig_config_address?: string;
+  swigConfigAddress?: string;
+  wallet_address?: string;
+  walletAddress?: string;
+  balances?: SwigTokenBalanceWire[];
+  total_usd_value?: number;
+  totalUsdValue?: number;
+}
+
+export type SwigTokenTransactionDirection = 'inflow' | 'outflow';
+
+export type SwigTokenTransactionDirectionWire =
+  | SwigTokenTransactionDirection
+  | 'SWIG_TOKEN_TRANSACTION_DIRECTION_INFLOW'
+  | 'SWIG_TOKEN_TRANSACTION_DIRECTION_OUTFLOW'
+  | number;
+
+export interface SwigTokenTransaction {
+  transactionSignature: string;
+  slot: number;
+  blockTime?: string;
+  ownerAddress: string;
+  walletAddress: string;
+  isSubaccount: boolean;
+  tokenAccountAddress: string;
+  mintAddress: string;
+  tokenProgram: number;
+  direction: SwigTokenTransactionDirection;
+  amountRaw: string;
+  decimals: number;
+  uiAmount: number;
+  usdPrice: number;
+  usdValue: number;
+  tokenSymbol: string;
+  tokenName: string;
+}
+
+export interface SwigTokenTransactionWire {
+  transaction_signature?: string;
+  transactionSignature?: string;
+  slot?: number | string;
+  block_time?: string;
+  blockTime?: string;
+  owner_address?: string;
+  ownerAddress?: string;
+  wallet_address?: string;
+  walletAddress?: string;
+  is_subaccount?: boolean;
+  isSubaccount?: boolean;
+  token_account_address?: string;
+  tokenAccountAddress?: string;
+  mint_address?: string;
+  mintAddress?: string;
+  token_program?: number;
+  tokenProgram?: number;
+  direction?: SwigTokenTransactionDirectionWire;
+  amount_raw?: string;
+  amountRaw?: string;
+  decimals?: number;
+  ui_amount?: number;
+  uiAmount?: number;
+  usd_price?: number;
+  usdPrice?: number;
+  usd_value?: number;
+  usdValue?: number;
+  token_symbol?: string;
+  tokenSymbol?: string;
+  token_name?: string;
+  tokenName?: string;
+}
+
+export interface ListSwigTokenTransactionsResult {
+  swigConfigAddress: string;
+  walletAddress: string;
+  transactions: SwigTokenTransaction[];
+}
+
+export interface ListSwigTokenTransactionsWire {
+  swig_config_address?: string;
+  swigConfigAddress?: string;
+  wallet_address?: string;
+  walletAddress?: string;
+  transactions?: SwigTokenTransactionWire[];
+}

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -9,6 +9,11 @@ import type {
   ExecuteArgs,
   ExecuteRecoveryArgs,
   IdpWalletSession,
+  ListSwigTokenBalancesResult,
+  ListSwigTokenBalancesWire,
+  ListSwigTokenTransactionsArgs,
+  ListSwigTokenTransactionsResult,
+  ListSwigTokenTransactionsWire,
   Network,
   Policy,
   PrepareArgs,
@@ -21,9 +26,12 @@ import type {
   RecoverySetupPlan,
   StartRecoveryArgs,
   SwapArgs,
+  SwigUsdBalance,
+  SwigUsdBalanceWire,
   TransferArgs,
   WalletAuthority,
   WalletHandleOptions,
+  WalletReadArgs,
   WalletReference,
 } from '../types/index.js';
 import { WalletHandle } from './handle.js';
@@ -31,6 +39,9 @@ import {
   normalizeCreateWalletResponse,
   normalizePreparedTransaction,
   normalizePrepareTransactionsResponse,
+  normalizeSwigTokenBalances,
+  normalizeSwigTokenTransactions,
+  normalizeSwigUsdBalance,
 } from './normalizers.js';
 import {
   addRecoveryAuthorityRequest,
@@ -83,6 +94,43 @@ export class WalletsClient {
     return this.http.get<Policy>(
       `/wallet/policies/${encodeURIComponent(policyId)}`,
     );
+  };
+
+  getUsdBalance = async (
+    wallet: WalletHandle,
+    args: WalletReadArgs = {},
+  ): Promise<SwigUsdBalance> => {
+    const response = await this.http.get<SwigUsdBalanceWire>(
+      walletReadPath(wallet, 'balance/usd', {
+        network: args.network ?? wallet.network ?? this.defaultNetwork,
+      }),
+    );
+    return normalizeSwigUsdBalance(response);
+  };
+
+  listTokenBalances = async (
+    wallet: WalletHandle,
+    args: WalletReadArgs = {},
+  ): Promise<ListSwigTokenBalancesResult> => {
+    const response = await this.http.get<ListSwigTokenBalancesWire>(
+      walletReadPath(wallet, 'token-balances', {
+        network: args.network ?? wallet.network ?? this.defaultNetwork,
+      }),
+    );
+    return normalizeSwigTokenBalances(response);
+  };
+
+  listTokenTransactions = async (
+    wallet: WalletHandle,
+    args: ListSwigTokenTransactionsArgs = {},
+  ): Promise<ListSwigTokenTransactionsResult> => {
+    const response = await this.http.get<ListSwigTokenTransactionsWire>(
+      walletReadPath(wallet, 'token-transactions', {
+        network: args.network ?? wallet.network ?? this.defaultNetwork,
+        limit: args.limit,
+      }),
+    );
+    return normalizeSwigTokenTransactions(response);
   };
 
   use = (
@@ -263,6 +311,26 @@ export class WalletsClient {
     );
     return normalizePreparedTransaction(response);
   };
+}
+
+function walletReadPath(
+  wallet: WalletHandle,
+  route: 'balance/usd' | 'token-balances' | 'token-transactions',
+  query: { network?: Network; limit?: number },
+): string {
+  const params = new URLSearchParams();
+  if (query.network) {
+    params.set('network', networkParam(query.network));
+  }
+  if (query.limit !== undefined) {
+    params.set('limit', String(query.limit));
+  }
+  const suffix = params.size > 0 ? `?${params.toString()}` : '';
+  return `/wallet/swig/${encodeURIComponent(wallet.swigConfigAddress)}/${route}${suffix}`;
+}
+
+function networkParam(network: Network): string {
+  return network === 'mainnet' ? 'NETWORK_MAINNET' : 'NETWORK_DEVNET';
 }
 
 function recoverySetupPlanFromPolicy(

--- a/packages/developer-sdk/src/wallets/handle.ts
+++ b/packages/developer-sdk/src/wallets/handle.ts
@@ -2,6 +2,9 @@ import type {
   CancelRecoveryArgs,
   ExecuteArgs,
   ExecuteRecoveryArgs,
+  ListSwigTokenBalancesResult,
+  ListSwigTokenTransactionsArgs,
+  ListSwigTokenTransactionsResult,
   Network,
   PrepareArgs,
   PreparedRecoverySetupResult,
@@ -10,9 +13,11 @@ import type {
   PrepareRecoverySetupArgs,
   StartRecoveryArgs,
   SwapArgs,
+  SwigUsdBalance,
   TransferArgs,
   TransferSolArgs,
   TransferTokenArgs,
+  WalletReadArgs,
   WalletReference,
 } from '../types/index.js';
 import type { WalletsClient } from './client.js';
@@ -66,6 +71,19 @@ export class WalletHandle {
     this.wallets.prepare(this, args);
 
   execute = (args: ExecuteArgs) => this.wallets.execute(this, args);
+
+  getUsdBalance = (args?: WalletReadArgs): Promise<SwigUsdBalance> =>
+    this.wallets.getUsdBalance(this, args);
+
+  listTokenBalances = (
+    args?: WalletReadArgs,
+  ): Promise<ListSwigTokenBalancesResult> =>
+    this.wallets.listTokenBalances(this, args);
+
+  listTokenTransactions = (
+    args?: ListSwigTokenTransactionsArgs,
+  ): Promise<ListSwigTokenTransactionsResult> =>
+    this.wallets.listTokenTransactions(this, args);
 }
 
 function createWalletTransferClient(

--- a/packages/developer-sdk/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/src/wallets/normalizers.ts
@@ -4,6 +4,10 @@ import type {
   ClientSignatureRequestWire,
   CreateWalletResponseWire,
   CreateWalletResult,
+  ListSwigTokenBalancesResult,
+  ListSwigTokenBalancesWire,
+  ListSwigTokenTransactionsResult,
+  ListSwigTokenTransactionsWire,
   Network,
   NetworkWire,
   PreparedTransaction,
@@ -16,6 +20,14 @@ import type {
   SolanaInstructionInput,
   SubmittedTransaction,
   SubmittedTransactionWire,
+  SwigTokenBalance,
+  SwigTokenBalanceWire,
+  SwigTokenTransaction,
+  SwigTokenTransactionDirection,
+  SwigTokenTransactionDirectionWire,
+  SwigTokenTransactionWire,
+  SwigUsdBalance,
+  SwigUsdBalanceWire,
   TransactionEncoding,
   TransactionEncodingWire,
 } from '../types/index.js';
@@ -141,6 +153,146 @@ export function normalizeSubmittedTransaction(
   };
 }
 
+export function normalizeSwigUsdBalance(
+  response: SwigUsdBalanceWire,
+): SwigUsdBalance {
+  return {
+    swigConfigAddress: readString(
+      response.swigConfigAddress ?? response.swig_config_address,
+      'swigConfigAddress',
+    ),
+    walletAddress: readString(
+      response.walletAddress ?? response.wallet_address,
+      'walletAddress',
+    ),
+    usdValue: readNumber(response.usdValue ?? response.usd_value, 'usdValue'),
+  };
+}
+
+export function normalizeSwigTokenBalances(
+  response: ListSwigTokenBalancesWire,
+): ListSwigTokenBalancesResult {
+  return {
+    swigConfigAddress: readString(
+      response.swigConfigAddress ?? response.swig_config_address,
+      'swigConfigAddress',
+    ),
+    walletAddress: readString(
+      response.walletAddress ?? response.wallet_address,
+      'walletAddress',
+    ),
+    balances: (response.balances ?? []).map(normalizeSwigTokenBalance),
+    totalUsdValue: readNumber(
+      response.totalUsdValue ?? response.total_usd_value,
+      'totalUsdValue',
+    ),
+  };
+}
+
+export function normalizeSwigTokenTransactions(
+  response: ListSwigTokenTransactionsWire,
+): ListSwigTokenTransactionsResult {
+  return {
+    swigConfigAddress: readString(
+      response.swigConfigAddress ?? response.swig_config_address,
+      'swigConfigAddress',
+    ),
+    walletAddress: readString(
+      response.walletAddress ?? response.wallet_address,
+      'walletAddress',
+    ),
+    transactions: (response.transactions ?? []).map(
+      normalizeSwigTokenTransaction,
+    ),
+  };
+}
+
+function normalizeSwigTokenBalance(
+  response: SwigTokenBalanceWire,
+): SwigTokenBalance {
+  return {
+    mintAddress: readString(
+      response.mintAddress ?? response.mint_address,
+      'mintAddress',
+    ),
+    tokenProgram: readNumber(
+      response.tokenProgram ?? response.token_program,
+      'tokenProgram',
+    ),
+    tokenSymbol: readString(
+      response.tokenSymbol ?? response.token_symbol ?? '',
+      'tokenSymbol',
+    ),
+    tokenName: readString(
+      response.tokenName ?? response.token_name ?? '',
+      'tokenName',
+    ),
+    decimals: readNumber(response.decimals, 'decimals'),
+    amountRaw: readString(
+      response.amountRaw ?? response.amount_raw,
+      'amountRaw',
+    ),
+    uiAmount: readNumber(response.uiAmount ?? response.ui_amount, 'uiAmount'),
+    usdPrice: readNumber(response.usdPrice ?? response.usd_price, 'usdPrice'),
+    usdValue: readNumber(response.usdValue ?? response.usd_value, 'usdValue'),
+  };
+}
+
+function normalizeSwigTokenTransaction(
+  response: SwigTokenTransactionWire,
+): SwigTokenTransaction {
+  const blockTime = response.blockTime ?? response.block_time;
+  return {
+    transactionSignature: readString(
+      response.transactionSignature ?? response.transaction_signature,
+      'transactionSignature',
+    ),
+    slot: readNumber(response.slot, 'slot'),
+    ...(blockTime ? { blockTime } : {}),
+    ownerAddress: readString(
+      response.ownerAddress ?? response.owner_address,
+      'ownerAddress',
+    ),
+    walletAddress: readString(
+      response.walletAddress ?? response.wallet_address,
+      'walletAddress',
+    ),
+    isSubaccount: readBoolean(
+      response.isSubaccount ?? response.is_subaccount,
+      'isSubaccount',
+    ),
+    tokenAccountAddress: readString(
+      response.tokenAccountAddress ?? response.token_account_address,
+      'tokenAccountAddress',
+    ),
+    mintAddress: readString(
+      response.mintAddress ?? response.mint_address,
+      'mintAddress',
+    ),
+    tokenProgram: readNumber(
+      response.tokenProgram ?? response.token_program,
+      'tokenProgram',
+    ),
+    direction: normalizeTokenTransactionDirection(response.direction),
+    amountRaw: readString(
+      response.amountRaw ?? response.amount_raw,
+      'amountRaw',
+    ),
+    decimals: readNumber(response.decimals, 'decimals'),
+    uiAmount: readNumber(response.uiAmount ?? response.ui_amount, 'uiAmount'),
+    usdPrice: readNumber(response.usdPrice ?? response.usd_price, 'usdPrice'),
+    usdValue: readNumber(response.usdValue ?? response.usd_value, 'usdValue'),
+    tokenSymbol: readString(
+      response.tokenSymbol ?? response.token_symbol ?? '',
+      'tokenSymbol',
+    ),
+    tokenName: readString(
+      response.tokenName ?? response.token_name ?? '',
+      'tokenName',
+    ),
+  };
+}
+
 export function normalizeInstruction(
   instruction: SolanaInstructionInput,
 ): SolanaInstruction {
@@ -218,6 +370,50 @@ function normalizePreparedTransactionKind(
     default:
       return undefined;
   }
+}
+
+function normalizeTokenTransactionDirection(
+  direction?: SwigTokenTransactionDirectionWire,
+): SwigTokenTransactionDirection {
+  switch (direction) {
+    case 'inflow':
+    case 'SWIG_TOKEN_TRANSACTION_DIRECTION_INFLOW':
+    case 1:
+      return 'inflow';
+    case 'outflow':
+    case 'SWIG_TOKEN_TRANSACTION_DIRECTION_OUTFLOW':
+    case 2:
+      return 'outflow';
+    default:
+      throw new Error('Token transaction response has invalid direction');
+  }
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  throw new Error(`Response is missing ${field}`);
+}
+
+function readNumber(value: unknown, field: string): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  throw new Error(`Response is missing ${field}`);
+}
+
+function readBoolean(value: unknown, field: string): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  throw new Error(`Response is missing ${field}`);
 }
 
 function normalizeSignatureRequests(


### PR DESCRIPTION
## Summary
- add API-key scoped Swig wallet USD balance, token balance, and token transaction read helpers
- add paymaster balance read helper for top-up displays
- expose GET proxy routes through browser/fetch/Next SDK adapters

## Validation
- bun --filter '@swig-wallet/developer-sdk' typecheck
- bun --filter '@swig-wallet/developer-sdk' test
- bun --filter '@swig-wallet/developer-sdk' lint
- bun --filter '@swig-wallet/developer-sdk' build