### PR TITLE
Add One Business grant access helpers

### DIFF
--- a/.changeset/small-cups-approve.md
+++ b/.changeset/small-cups-approve.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Add One Business grant-access URL and callback helpers.

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -193,6 +193,41 @@ return preparedSwap;
 Client code should only sign prepared transactions. It should not hold the API
 key or call the Swig backend directly.
 
+### One Business Grant Access
+
+Use this when a local app needs an admin to grant one of the app's keys access
+to an existing One Business Swig. The local app sends the admin to One Business,
+then reads the result on its callback page.
+
+```typescript
+import {
+  buildOneBusinessGrantAccessUrl,
+  completeOneBusinessGrantAccess,
+} from '@swig-wallet/developer-sdk/browser';
+
+const grantUrl = buildOneBusinessGrantAccessUrl({
+  swigPubkey,
+  authorityPublicKey: appAuthorityPublicKey,
+  appName: 'Local Trading App',
+  redirectUri: 'http://localhost:5173/swig/grant/callback',
+  state: crypto.randomUUID(),
+  actions: [
+    {
+      type: 'transferToken',
+      mint: usdcMint,
+      amount: '10000000',
+      cadence: 'daily',
+    },
+  ],
+});
+
+window.location.assign(grantUrl);
+
+// In /swig/grant/callback:
+const grant = completeOneBusinessGrantAccess(window.location.href);
+// grant.roleId and grant.walletAddress identify the newly granted authority.
+```
+
 ### Solana Transaction Signing
 
 Use this for prepared transactions whose requester authority is Ed25519.

--- a/packages/developer-sdk/src/browser.ts
+++ b/packages/developer-sdk/src/browser.ts
@@ -1,2 +1,3 @@
 export * from './browser-proxy.js';
 export * from './client/index.js';
+export * from './one-business/index.js';

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -1,9 +1,23 @@
 export { DEFAULT_BACKEND_URL, SwigDeveloperSdkError } from './core/index.js';
+export {
+  DEFAULT_ONE_BUSINESS_URL,
+  OneBusinessGrantAccessCallbackError,
+  buildOneBusinessGrantAccessUrl,
+  completeOneBusinessGrantAccess,
+  redirectToOneBusinessGrantAccess,
+} from './one-business/index.js';
 export { PaymasterClient } from './paymaster/index.js';
 export { SwigClient } from './server/typescript/index.js';
 export { TransactionsClient } from './transactions/index.js';
 export { WalletHandle, WalletsClient } from './wallets/index.js';
 
+export type {
+  BuildOneBusinessGrantAccessUrlArgs,
+  OneBusinessGrantAccessAction,
+  OneBusinessGrantAccessCallbackInput,
+  OneBusinessGrantAccessResult,
+  RedirectToOneBusinessGrantAccessOptions,
+} from './one-business/index.js';
 export type {
   AddRecoveryAuthorityArgs,
   Amount,

--- a/packages/developer-sdk/src/one-business/index.test.ts
+++ b/packages/developer-sdk/src/one-business/index.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildOneBusinessGrantAccessUrl,
+  completeOneBusinessGrantAccess,
+  DEFAULT_ONE_BUSINESS_URL,
+  OneBusinessGrantAccessCallbackError,
+  redirectToOneBusinessGrantAccess,
+} from './index.js';
+
+describe('One Business grant access helpers', () => {
+  test('builds a One Business grant access URL', () => {
+    const url = new URL(
+      buildOneBusinessGrantAccessUrl({
+        oneBusinessUrl: 'https://business.example/',
+        swigPubkey: 'swig_config_123',
+        authorityPublicKey: 'authority_123',
+        appName: 'Local Trading App',
+        redirectUri: 'http://localhost:5173/callback',
+        state: 'state_123',
+        actions: [
+          {
+            type: 'transferToken',
+            mint: 'usdc_mint',
+            amount: '10000000',
+            cadence: 'daily',
+          },
+        ],
+      }),
+    );
+
+    expect(url.origin).toBe('https://business.example');
+    expect(url.pathname).toBe('/authorize/grant-access');
+    expect(url.searchParams.get('swig_pubkey')).toBe('swig_config_123');
+    expect(url.searchParams.get('authority_public_key')).toBe('authority_123');
+    expect(url.searchParams.get('app_name')).toBe('Local Trading App');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'http://localhost:5173/callback',
+    );
+    expect(url.searchParams.get('state')).toBe('state_123');
+    expect(decodeBase64UrlJson(url.searchParams.get('actions'))).toEqual([
+      {
+        type: 'transferToken',
+        mint: 'usdc_mint',
+        amount: '10000000',
+        cadence: 'daily',
+      },
+    ]);
+  });
+
+  test('uses the production One Business URL by default', () => {
+    const url = new URL(
+      buildOneBusinessGrantAccessUrl({
+        swigPubkey: 'swig_config_123',
+        authorityPublicKey: 'authority_123',
+      }),
+    );
+
+    expect(url.origin).toBe(new URL(DEFAULT_ONE_BUSINESS_URL).origin);
+  });
+
+  test('redirects to One Business with assign or replace', () => {
+    const assigned: string[] = [];
+    const replaced: string[] = [];
+    const location: Pick<Location, 'assign' | 'replace'> = {
+      assign: (url: string | URL) => assigned.push(String(url)),
+      replace: (url: string | URL) => replaced.push(String(url)),
+    };
+
+    redirectToOneBusinessGrantAccess(
+      {
+        oneBusinessUrl: 'https://business.example',
+        swigPubkey: 'swig_config_123',
+        authorityPublicKey: 'authority_123',
+      },
+      { location },
+    );
+    redirectToOneBusinessGrantAccess(
+      {
+        oneBusinessUrl: 'https://business.example',
+        swigPubkey: 'swig_config_456',
+        authorityPublicKey: 'authority_456',
+      },
+      { location, mode: 'replace' },
+    );
+
+    expect(assigned).toHaveLength(1);
+    expect(assigned[0]).toContain('swig_pubkey=swig_config_123');
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0]).toContain('swig_pubkey=swig_config_456');
+  });
+
+  test('parses a successful grant access callback', () => {
+    const result = completeOneBusinessGrantAccess(
+      'http://localhost:5173/callback?status=granted&swig_pubkey=swig_config_123&wallet_address=wallet_123&role_id=3&authority_public_key=authority_123&signature=sig_123&state=state_123',
+    );
+
+    expect(result).toEqual({
+      status: 'granted',
+      swigPubkey: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      roleId: 3,
+      authorityPublicKey: 'authority_123',
+      signature: 'sig_123',
+      state: 'state_123',
+    });
+  });
+
+  test('parses callback errors as typed grant access errors', () => {
+    expect(() =>
+      completeOneBusinessGrantAccess(
+        'http://localhost:5173/callback?error=grant_access_failed&error_description=Not%20admin&state=state_123',
+      ),
+    ).toThrow(OneBusinessGrantAccessCallbackError);
+
+    try {
+      completeOneBusinessGrantAccess(
+        'http://localhost:5173/callback?error=grant_access_failed&error_description=Not%20admin&state=state_123',
+      );
+      throw new Error('Expected callback parsing to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(OneBusinessGrantAccessCallbackError);
+      expect(error).toMatchObject({
+        code: 'grant_access_failed',
+        description: 'Not admin',
+        state: 'state_123',
+      });
+    }
+  });
+});
+
+function decodeBase64UrlJson(value: string | null): unknown {
+  if (!value) {
+    return undefined;
+  }
+  let base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4 !== 0) {
+    base64 += '=';
+  }
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}

--- a/packages/developer-sdk/src/one-business/index.ts
+++ b/packages/developer-sdk/src/one-business/index.ts
@@ -1,0 +1,213 @@
+import type { JsonObject } from '../types/index.js';
+
+export const DEFAULT_ONE_BUSINESS_URL = 'https://swig-one-business.vercel.app';
+
+export type OneBusinessGrantAccessAction = JsonObject;
+
+export interface BuildOneBusinessGrantAccessUrlArgs {
+  swigPubkey: string;
+  authorityPublicKey: string;
+  actions?: OneBusinessGrantAccessAction[];
+  appName?: string;
+  oneBusinessUrl?: string;
+  redirectUri?: string;
+  state?: string;
+}
+
+export interface RedirectToOneBusinessGrantAccessOptions {
+  mode?: 'assign' | 'replace';
+  location?: Pick<Location, 'assign' | 'replace'>;
+}
+
+export interface OneBusinessGrantAccessResult {
+  status: string;
+  swigPubkey: string;
+  walletAddress: string;
+  roleId: number;
+  authorityPublicKey: string;
+  signature?: string;
+  state?: string;
+}
+
+export type OneBusinessGrantAccessCallbackInput =
+  | string
+  | URL
+  | Pick<Location, 'href'>;
+
+export class OneBusinessGrantAccessCallbackError extends Error {
+  readonly code: string;
+  readonly description?: string;
+  readonly state?: string;
+
+  constructor(args: { code: string; description?: string; state?: string }) {
+    super(args.description ?? args.code);
+    this.name = 'OneBusinessGrantAccessCallbackError';
+    this.code = args.code;
+    this.description = args.description;
+    this.state = args.state;
+  }
+}
+
+export function buildOneBusinessGrantAccessUrl(
+  args: BuildOneBusinessGrantAccessUrlArgs,
+): string {
+  const url = new URL(
+    '/authorize/grant-access',
+    normalizeBaseUrl(args.oneBusinessUrl ?? DEFAULT_ONE_BUSINESS_URL),
+  );
+
+  url.searchParams.set('swig_pubkey', requireNonEmpty(args.swigPubkey));
+  url.searchParams.set(
+    'authority_public_key',
+    requireNonEmpty(args.authorityPublicKey),
+  );
+
+  if (args.appName) {
+    url.searchParams.set('app_name', args.appName);
+  }
+  if (args.redirectUri) {
+    url.searchParams.set('redirect_uri', args.redirectUri);
+  }
+  if (args.state) {
+    url.searchParams.set('state', args.state);
+  }
+  if (args.actions !== undefined) {
+    url.searchParams.set('actions', encodeBase64UrlJson(args.actions));
+  }
+
+  return url.toString();
+}
+
+export function redirectToOneBusinessGrantAccess(
+  args: BuildOneBusinessGrantAccessUrlArgs,
+  options: RedirectToOneBusinessGrantAccessOptions = {},
+): void {
+  const location = options.location ?? getBrowserLocation();
+  const url = buildOneBusinessGrantAccessUrl(args);
+
+  if (options.mode === 'replace') {
+    location.replace(url);
+    return;
+  }
+
+  location.assign(url);
+}
+
+export function completeOneBusinessGrantAccess(
+  input?: OneBusinessGrantAccessCallbackInput,
+): OneBusinessGrantAccessResult {
+  const url = new URL(callbackUrl(input));
+  const errorCode = readParam(url.searchParams, 'error');
+  const state = readParam(url.searchParams, 'state');
+
+  if (errorCode) {
+    throw new OneBusinessGrantAccessCallbackError({
+      code: errorCode,
+      description: readParam(url.searchParams, 'error_description'),
+      state,
+    });
+  }
+
+  const swigPubkey = requireCallbackParam(url.searchParams, 'swig_pubkey');
+  const walletAddress = requireCallbackParam(
+    url.searchParams,
+    'wallet_address',
+  );
+  const authorityPublicKey = requireCallbackParam(
+    url.searchParams,
+    'authority_public_key',
+  );
+  const roleId = Number(requireCallbackParam(url.searchParams, 'role_id'));
+
+  if (!Number.isSafeInteger(roleId) || roleId < 0) {
+    throw new Error('Grant access callback has an invalid role_id');
+  }
+
+  return {
+    status:
+      readParam(url.searchParams, 'status') ??
+      readParam(url.searchParams, 'grant_status') ??
+      'granted',
+    swigPubkey,
+    walletAddress,
+    roleId,
+    authorityPublicKey,
+    ...(readParam(url.searchParams, 'signature')
+      ? { signature: readParam(url.searchParams, 'signature') }
+      : {}),
+    ...(state ? { state } : {}),
+  };
+}
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('oneBusinessUrl is required');
+  }
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+function requireNonEmpty(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('swigPubkey and authorityPublicKey are required');
+  }
+  return trimmed;
+}
+
+function encodeBase64UrlJson(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function getBrowserLocation(): Pick<Location, 'assign' | 'replace' | 'href'> {
+  if (typeof location === 'undefined') {
+    throw new Error('Browser location is not available');
+  }
+  return location;
+}
+
+function callbackUrl(input?: OneBusinessGrantAccessCallbackInput): string {
+  if (input === undefined) {
+    return getBrowserLocation().href;
+  }
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.href;
+}
+
+function requireCallbackParam(
+  params: URLSearchParams,
+  snakeName: string,
+): string {
+  const value = readParam(params, snakeName);
+  if (!value) {
+    throw new Error(`Grant access callback is missing ${snakeName}`);
+  }
+  return value;
+}
+
+function readParam(
+  params: URLSearchParams,
+  snakeName: string,
+): string | undefined {
+  const camelName = snakeToCamel(snakeName);
+  return (
+    params.get(snakeName)?.trim() || params.get(camelName)?.trim() || undefined
+  );
+}
+
+function snakeToCamel(value: string): string {
+  return value.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- add browser/root helpers to build and redirect to the One Business grant-access URL
- add callback parsing for successful grants and typed callback errors
- document the local app grant-access flow and add a developer SDK changeset

## Validation
- bun --filter '@swig-wallet/developer-sdk' test\n- bun --filter '@swig-wallet/developer-sdk' typecheck\n- bun --filter '@swig-wallet/developer-sdk' lint\n- bun --filter '@swig-wallet/developer-sdk' build\n- git diff --check