### PR TITLE
Add IDP paymaster balance reads

### DIFF
--- a/.changeset/idp-paymaster-balance.md
+++ b/.changeset/idp-paymaster-balance.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': patch
+---
+
+Add IDP paymaster balance reads for One Business funding views.

--- a/packages/developer-sdk/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/src/browser-proxy.test.ts
@@ -344,6 +344,40 @@ describe('SwigBrowserClient', () => {
     });
   });
 
+  test('reads IDP paymaster balance through the local proxy', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          configured: true,
+          kind: 'idp',
+          id: 'paymaster_123',
+          address: 'paymaster_address_123',
+          label: 'IdP paymaster',
+          balanceLamports: '5000000000',
+          balanceSol: 5,
+        };
+      }),
+    });
+
+    const balance = await swig.paymaster.getIdpBalance();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/paymaster/balance?network=devnet&kind=PAYMASTER_KIND_IDP',
+      method: 'GET',
+      body: undefined,
+    });
+    expect(balance).toMatchObject({
+      configured: true,
+      kind: 'idp',
+      address: 'paymaster_address_123',
+      balanceSol: 5,
+    });
+  });
+
   test('throws proxy errors with the route response status and message', async () => {
     const swig = new SwigBrowserClient({
       fetch: jsonFetch(() => ({

--- a/packages/developer-sdk/src/browser-proxy.ts
+++ b/packages/developer-sdk/src/browser-proxy.ts
@@ -292,8 +292,26 @@ export class BrowserPaymasterClient {
   ): Promise<PaymasterBalance> => {
     return this.http.get<PaymasterBalance>('paymaster/balance', {
       network: args.network ?? this.defaultNetwork,
+      kind: args.kind ? paymasterKindQueryValue(args.kind) : undefined,
     });
   };
+
+  getIdpBalance = (
+    args: Omit<GetPaymasterBalanceArgs, 'kind'> = {},
+  ): Promise<PaymasterBalance> => {
+    return this.getBalance({ ...args, kind: 'idp' });
+  };
+}
+
+function paymasterKindQueryValue(
+  kind: NonNullable<GetPaymasterBalanceArgs['kind']>,
+): string {
+  switch (kind) {
+    case 'api':
+      return 'PAYMASTER_KIND_API';
+    case 'idp':
+      return 'PAYMASTER_KIND_IDP';
+  }
 }
 
 class BrowserProxyHttpClient {

--- a/packages/developer-sdk/src/paymaster/client.ts
+++ b/packages/developer-sdk/src/paymaster/client.ts
@@ -18,18 +18,44 @@ export class PaymasterClient {
     args: GetPaymasterBalanceArgs = {},
   ): Promise<PaymasterBalance> => {
     const response = await this.http.get<PaymasterBalanceWire>(
-      paymasterBalancePath(args.network ?? this.defaultNetwork),
+      paymasterBalancePath({
+        network: args.network ?? this.defaultNetwork,
+        kind: args.kind,
+      }),
     );
     return normalizePaymasterBalance(response);
   };
+
+  getIdpBalance = async (
+    args: Omit<GetPaymasterBalanceArgs, 'kind'> = {},
+  ): Promise<PaymasterBalance> => {
+    return this.getBalance({ ...args, kind: 'idp' });
+  };
 }
 
-function paymasterBalancePath(network?: Network): string {
-  if (!network) {
+function paymasterBalancePath(args: GetPaymasterBalanceArgs): string {
+  const params = new URLSearchParams();
+  if (args.network) {
+    params.set('network', args.network);
+  }
+  if (args.kind) {
+    params.set('kind', paymasterKindQueryValue(args.kind));
+  }
+  if (params.size === 0) {
     return '/paymaster/balance';
   }
-  const params = new URLSearchParams({ network });
   return `/paymaster/balance?${params.toString()}`;
+}
+
+function paymasterKindQueryValue(
+  kind: NonNullable<GetPaymasterBalanceArgs['kind']>,
+): string {
+  switch (kind) {
+    case 'api':
+      return 'PAYMASTER_KIND_API';
+    case 'idp':
+      return 'PAYMASTER_KIND_IDP';
+  }
 }
 
 function normalizePaymasterBalance(

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -687,4 +687,45 @@ describe('createSwigGetHandler', () => {
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
   });
+
+  test('proxies IDP paymaster balance reads by kind', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          configured: true,
+          kind: 'PAYMASTER_KIND_IDP',
+          id: 'paymaster_123',
+          address: 'paymaster_address_123',
+          label: 'IdP paymaster',
+          balance_lamports: '5000000000',
+          balance_sol: 5,
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/paymaster/balance?network=devnet&kind=idp',
+        {
+          method: 'GET',
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      kind: 'idp',
+      address: 'paymaster_address_123',
+      balanceSol: 5,
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/paymaster/balance?network=devnet&kind=PAYMASTER_KIND_IDP',
+      method: 'GET',
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+  });
 });

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -2,6 +2,7 @@ import type {
   Amount,
   CreateWalletArgs,
   Network,
+  PaymasterBalanceKind,
   PrepareArgs,
   PrepareOperation,
   SwapArgs,
@@ -150,9 +151,9 @@ async function handleGet(
 ): Promise<Response> {
   try {
     const route = resolveReadRoute(request);
-    const network =
-      readNetwork(new URL(request.url).searchParams.get('network')) ??
-      config.network;
+    const searchParams = new URL(request.url).searchParams;
+    const network = readNetwork(searchParams.get('network')) ?? config.network;
+    const paymasterKind = readPaymasterBalanceKind(searchParams.get('kind'));
     const apiKey = resolveApiKey(config);
     const transactionApiUrl = resolveTransactionApiUrl(config);
     const swig = new SwigClient({
@@ -187,7 +188,11 @@ async function handleGet(
         );
       }
       case 'paymaster/balance':
-        return json(await swig.paymaster.getBalance(walletOptions(network)));
+        return json(
+          await swig.paymaster.getBalance(
+            paymasterOptions(network, paymasterKind),
+          ),
+        );
     }
   } catch (error) {
     const message =
@@ -199,6 +204,16 @@ async function handleGet(
 
 function walletOptions(network: Network | undefined): { network?: Network } {
   return network ? { network } : {};
+}
+
+function paymasterOptions(
+  network: Network | undefined,
+  kind: PaymasterBalanceKind | undefined,
+) {
+  return {
+    ...(network ? { network } : {}),
+    ...(kind ? { kind } : {}),
+  };
 }
 
 async function prepareWalletCreation(
@@ -654,6 +669,24 @@ function readNetwork(value: unknown): Network | undefined {
     return value;
   }
   return undefined;
+}
+
+function readPaymasterBalanceKind(
+  value: string | null,
+): PaymasterBalanceKind | undefined {
+  switch (value?.trim().toUpperCase()) {
+    case undefined:
+    case '':
+      return undefined;
+    case 'API':
+    case 'PAYMASTER_KIND_API':
+      return 'api';
+    case 'IDP':
+    case 'PAYMASTER_KIND_IDP':
+      return 'idp';
+    default:
+      throw new SwigRouteError('kind must be api or idp');
+  }
 }
 
 function readRequiredString(

--- a/packages/developer-sdk/src/types/paymaster.ts
+++ b/packages/developer-sdk/src/types/paymaster.ts
@@ -2,9 +2,11 @@ import type { Network } from './common.js';
 
 export interface GetPaymasterBalanceArgs {
   network?: Network;
+  kind?: PaymasterBalanceKind;
 }
 
 export type PaymasterKind = 'api' | 'idp' | 'unspecified';
+export type PaymasterBalanceKind = Exclude<PaymasterKind, 'unspecified'>;
 
 export type PaymasterKindWire =
   | PaymasterKind


### PR DESCRIPTION
## Summary
- add an optional paymaster balance kind to the developer SDK
- expose getIdpBalance on browser and server paymaster clients
- proxy kind=idp through local SDK route handlers

## Tests
- bun --filter '@swig-wallet/developer-sdk' test src/browser-proxy.test.ts src/server/fetch/index.test.ts
- bun --filter '@swig-wallet/developer-sdk' typecheck
- bun --filter '@swig-wallet/developer-sdk' lint