### PR TITLE
feat(developer-sdk): support IDP session authorities

### DIFF
--- a/.changeset/khaki-idp-session-signers.md
+++ b/.changeset/khaki-idp-session-signers.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Add ProgramExecSession requester authority support and a structural prepared-transaction signer interface for IdP-backed signing flows.

--- a/packages/developer-sdk/src/client/index.test.ts
+++ b/packages/developer-sdk/src/client/index.test.ts
@@ -10,6 +10,7 @@ import {
   signPreparedSwigTransaction,
   signPreparedSwigTransactions,
   signPreparedTransaction,
+  signPreparedTransactionWithSigner,
 } from './index.js';
 
 const prepared: PreparedTransaction = {
@@ -27,6 +28,24 @@ describe('client signing helpers', () => {
       }),
     ).resolves.toEqual({
       transaction: 'base64-prepared-tx.signed',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+    });
+  });
+
+  test('signPreparedTransactionWithSigner accepts an isolated-host signer shape', async () => {
+    const signer = {
+      signPreparedTransaction: async (transaction: PreparedTransaction) => ({
+        transaction: `${transaction.transaction}.idp-signed`,
+        transactionEncoding: transaction.transactionEncoding,
+        network: transaction.network,
+      }),
+    };
+
+    await expect(
+      signPreparedTransactionWithSigner(prepared, signer),
+    ).resolves.toEqual({
+      transaction: 'base64-prepared-tx.idp-signed',
       transactionEncoding: 'base64',
       network: 'devnet',
     });

--- a/packages/developer-sdk/src/client/index.ts
+++ b/packages/developer-sdk/src/client/index.ts
@@ -37,6 +37,12 @@ export interface SignPreparedOptions {
   signTransaction: PreparedTransactionSigningFn;
 }
 
+export interface PreparedTransactionSigner {
+  signPreparedTransaction(
+    prepared: PreparedTransaction,
+  ): Promise<SignedPreparedTransaction>;
+}
+
 export async function signPreparedTransaction(
   prepared: PreparedTransaction,
   options: SignPreparedOptions,
@@ -46,4 +52,11 @@ export async function signPreparedTransaction(
     transactionEncoding: prepared.transactionEncoding,
     network: prepared.network,
   };
+}
+
+export async function signPreparedTransactionWithSigner(
+  prepared: PreparedTransaction,
+  signer: PreparedTransactionSigner,
+): Promise<SignedPreparedTransaction> {
+  return signer.signPreparedTransaction(prepared);
 }

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -334,6 +334,51 @@ describe('createSwigFetchHandler', () => {
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
   });
 
+  test('proxies ProgramExecSession requester authority to the transaction API', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transaction: 'base64-transfer-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+        };
+      }),
+    });
+
+    const requesterAuthority = {
+      programExecSession: {
+        roleId: 3,
+        sessionKey: 'session_key_123',
+      },
+    };
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/transfer/sol', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+            requesterAuthority,
+          },
+          network: 'devnet',
+          feePayer: 'payer_123',
+          destination: 'destination_123',
+          amount: '42',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls[0]?.body).toMatchObject({
+      requesterAuthority,
+    });
+  });
+
   test('uses configured requester and fee payer resolvers', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -593,6 +593,16 @@ function readWalletAuthority(
       return { [scheme]: { publicKey } } as WalletAuthority;
     }
   }
+  if (isRecord(value.programExecSession)) {
+    const roleId = readOptionalNumber(value.programExecSession, 'roleId');
+    const sessionKey = readOptionalString(
+      value.programExecSession,
+      'sessionKey',
+    );
+    if (roleId !== undefined && sessionKey) {
+      return { programExecSession: { roleId, sessionKey } };
+    }
+  }
   throw new SwigRouteError(`${field} must include a supported authority`);
 }
 

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -5,7 +5,8 @@ import type { CreateWalletResult } from './transaction.js';
 export type WalletAuthority =
   | { ed25519: { publicKey: string } }
   | { secp256k1: { publicKey: string } }
-  | { secp256r1: { publicKey: string } };
+  | { secp256r1: { publicKey: string } }
+  | { programExecSession: { roleId: number; sessionKey: string } };
 
 export interface CreateWalletArgs {
   policyId?: string;

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -386,6 +386,9 @@ function walletAuthorityFromPolicy(
   ) {
     return authority;
   }
+  if ('programExecSession' in authority) {
+    return undefined;
+  }
 
   switch (authority.type) {
     case 'Ed25519':
@@ -411,6 +414,9 @@ function publicKeyFromPolicyAuthority(
   }
   if ('secp256k1' in authority) {
     return authority.secp256k1.publicKey;
+  }
+  if ('programExecSession' in authority) {
+    return authority.programExecSession.sessionKey;
   }
   return authority.secp256r1.publicKey;
 }


### PR DESCRIPTION
## Summary
- Add `programExecSession` as a requester authority accepted by the developer SDK proxy/server path.
- Add a structural prepared-transaction signer interface so `swig-idp-sdk` isolated-host signers can be passed into developer-sdk signing helpers.
- Keep `programExecSession` out of policy creation normalization because it is runtime requester authority, not a policy authority.

## Tests
- `bun --filter @swig-wallet/developer-sdk test`
- `bun --filter @swig-wallet/developer-sdk typecheck`
- `bun run build:developer-sdk`
