### PR TITLE
Release developer SDK session authority declarations

### DIFF
--- a/.changeset/clean-chairs-sparkle.md
+++ b/.changeset/clean-chairs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@swig-wallet/developer-sdk": patch
+---
+
+Rebuild the developer SDK package with ProgramExec session authority declarations.


### PR DESCRIPTION
## Summary
- add a developer-sdk patch changeset so npm publishes rebuilt declarations with ProgramExec session authority support
- verified a fresh Bun/Nx developer-sdk build emits programExecSession in WalletAuthority

## Tests
- bun run build:developer-sdk
- bun --filter @swig-wallet/developer-sdk test
- bun --filter @swig-wallet/developer-sdk typecheck