### PR TITLE
Use ProgramExec proof authority in developer SDK

### DIFF
--- a/.changeset/fresh-proofs-drum.md
+++ b/.changeset/fresh-proofs-drum.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Replace ProgramExecSession requester authorities with ProgramExecProof requester authorities for keyless IdP flows.

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -334,7 +334,7 @@ describe('createSwigFetchHandler', () => {
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
   });
 
-  test('proxies ProgramExecSession requester authority to the transaction API', async () => {
+  test('proxies ProgramExecProof requester authority to the transaction API', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({
       apiKey: 'sk_test',
@@ -350,9 +350,9 @@ describe('createSwigFetchHandler', () => {
     });
 
     const requesterAuthority = {
-      programExecSession: {
-        roleId: 3,
-        sessionKey: 'session_key_123',
+      programExecProof: {
+        roleId: 0,
+        zkProof: 'proof_b64',
       },
     };
 

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -593,14 +593,11 @@ function readWalletAuthority(
       return { [scheme]: { publicKey } } as WalletAuthority;
     }
   }
-  if (isRecord(value.programExecSession)) {
-    const roleId = readOptionalNumber(value.programExecSession, 'roleId');
-    const sessionKey = readOptionalString(
-      value.programExecSession,
-      'sessionKey',
-    );
-    if (roleId !== undefined && sessionKey) {
-      return { programExecSession: { roleId, sessionKey } };
+  if (isRecord(value.programExecProof)) {
+    const roleId = readOptionalNumber(value.programExecProof, 'roleId');
+    const zkProof = readOptionalString(value.programExecProof, 'zkProof');
+    if (roleId !== undefined && zkProof) {
+      return { programExecProof: { roleId, zkProof } };
     }
   }
   throw new SwigRouteError(`${field} must include a supported authority`);

--- a/packages/developer-sdk/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/src/types/wallet-actions.ts
@@ -6,7 +6,7 @@ export type WalletAuthority =
   | { ed25519: { publicKey: string } }
   | { secp256k1: { publicKey: string } }
   | { secp256r1: { publicKey: string } }
-  | { programExecSession: { roleId: number; sessionKey: string } };
+  | { programExecProof: { roleId: number; zkProof: string } };
 
 export interface CreateWalletArgs {
   policyId?: string;

--- a/packages/developer-sdk/src/wallets/client.ts
+++ b/packages/developer-sdk/src/wallets/client.ts
@@ -386,7 +386,7 @@ function walletAuthorityFromPolicy(
   ) {
     return authority;
   }
-  if ('programExecSession' in authority) {
+  if ('programExecProof' in authority) {
     return undefined;
   }
 
@@ -415,8 +415,8 @@ function publicKeyFromPolicyAuthority(
   if ('secp256k1' in authority) {
     return authority.secp256k1.publicKey;
   }
-  if ('programExecSession' in authority) {
-    return authority.programExecSession.sessionKey;
+  if ('programExecProof' in authority) {
+    return undefined;
   }
   return authority.secp256r1.publicKey;
 }


### PR DESCRIPTION
## Summary
- replace ProgramExecSession requester authorities with ProgramExecProof in the developer SDK
- proxy ProgramExecProof through the server route handler
- add a changeset for the SDK release

## Checks
- bun run typecheck
- bun test packages/developer-sdk/src/server/fetch/index.test.ts