### PR TITLE
Feat(developer-sdk): Meld Developer SDK support

### DIFF
--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -197,8 +197,8 @@ and transaction history.
 ```typescript
 const quotes = await swig.ramp.quote({
   customer: {
-    organizationId,
     partnerApplicationId,
+    swigUserId,
     customerType: 'individual',
   },
   wallet: {
@@ -216,8 +216,8 @@ const quotes = await swig.ramp.quote({
 
 const session = await swig.ramp.createSession({
   customer: {
-    organizationId,
     partnerApplicationId,
+    swigUserId,
     customerType: 'individual',
   },
   wallet: {

--- a/packages/developer-sdk/README.md
+++ b/packages/developer-sdk/README.md
@@ -188,6 +188,73 @@ const preparedSwap = await wallet.swap.jupiter({
 return preparedSwap;
 ```
 
+### Add Funds With Ramp
+
+Use `swig.ramp` to build a headless Add Funds UI. The server SDK keeps the
+developer API key server-side while returning frontend-safe quotes, launch URLs,
+and transaction history.
+
+```typescript
+const quotes = await swig.ramp.quote({
+  customer: {
+    organizationId,
+    partnerApplicationId,
+    customerType: 'individual',
+  },
+  wallet: {
+    walletId,
+    walletAddress,
+    network: 'devnet',
+  },
+  direction: 'onramp',
+  sourceAmount: '100.00',
+  sourceCurrencyCode: 'USD',
+  destinationCurrencyCode: 'USDC_SOLANA',
+  countryCode: 'US',
+  paymentMethodType: 'credit-debit-card',
+});
+
+const session = await swig.ramp.createSession({
+  customer: {
+    organizationId,
+    partnerApplicationId,
+    customerType: 'individual',
+  },
+  wallet: {
+    walletId,
+    walletAddress,
+    network: 'devnet',
+  },
+  direction: 'onramp',
+  selectedQuoteId: quotes.quotes[0].quoteId,
+  sourceAmount: '100.00',
+  sourceCurrencyCode: 'USD',
+  destinationCurrencyCode: 'USDC_SOLANA',
+  countryCode: 'US',
+  serviceProvider: quotes.quotes[0].serviceProvider,
+  paymentMethodType: quotes.quotes[0].paymentMethodType,
+  redirectUrl: 'https://app.example/ramp/return',
+});
+
+return {
+  launchUrl: session.launchUrl,
+};
+```
+
+Browser apps can call the local proxy surface with `SwigBrowserClient`:
+
+```typescript
+import { SwigBrowserClient } from '@swig-wallet/developer-sdk/browser';
+
+const swig = new SwigBrowserClient({ network: 'devnet' });
+
+const history = await swig.ramp.listTransactions({
+  walletId,
+  direction: 'onramp',
+  limit: 25,
+});
+```
+
 ## Client Signing
 
 Client code should only sign prepared transactions. It should not hold the API

--- a/packages/developer-sdk/nest/README.md
+++ b/packages/developer-sdk/nest/README.md
@@ -13,7 +13,7 @@ endpoint.
 Create one controller mounted at your Swig proxy prefix:
 
 ```typescript
-import { Controller, Post, Req, Res } from '@nestjs/common';
+import { All, Controller, Req, Res } from '@nestjs/common';
 import { createSwigNestHandler } from '@swig-wallet/developer-sdk/nest';
 import type { Request, Response } from 'express';
 
@@ -21,7 +21,7 @@ const swigHandler = createSwigNestHandler();
 
 @Controller('swig')
 export class SwigController {
-  @Post('*')
+  @All('*')
   handle(@Req() request: Request, @Res() response: Response) {
     return swigHandler(request, response);
   }
@@ -36,6 +36,11 @@ POST /swig/prepare
 POST /swig/transfer/sol
 POST /swig/transfer/spl-token
 POST /swig/swap/jupiter
+GET  /swig/ramp/options
+POST /swig/ramp/quote
+POST /swig/ramp/sessions
+GET  /swig/ramp/transactions/:transactionId
+GET  /swig/ramp/wallets/:walletId/transactions
 ```
 
 ## Configuration

--- a/packages/developer-sdk/next/README.md
+++ b/packages/developer-sdk/next/README.md
@@ -125,7 +125,6 @@ export const { GET, POST } = createSwigRouteHandlers({
     const user = await getUserFromSession(request);
 
     return {
-      organizationId: user.organizationId,
       swigUserId: user.id,
       customerType: 'individual',
     };

--- a/packages/developer-sdk/next/README.md
+++ b/packages/developer-sdk/next/README.md
@@ -16,7 +16,7 @@ Create one catch-all route:
 // app/api/swig/[...swig]/route.ts
 import { createSwigRouteHandlers } from '@swig-wallet/developer-sdk/next';
 
-export const { POST } = createSwigRouteHandlers();
+export const { GET, POST } = createSwigRouteHandlers();
 ```
 
 The helper handles:
@@ -27,6 +27,11 @@ POST /api/swig/prepare
 POST /api/swig/transfer/sol
 POST /api/swig/transfer/spl-token
 POST /api/swig/swap/jupiter
+GET  /api/swig/ramp/options
+POST /api/swig/ramp/quote
+POST /api/swig/ramp/sessions
+GET  /api/swig/ramp/transactions/:transactionId
+GET  /api/swig/ramp/wallets/:walletId/transactions
 ```
 
 ## Configuration
@@ -107,3 +112,26 @@ export const { POST } = createSwigRouteHandlers({
   },
 });
 ```
+
+## Ramp Customer Resolution
+
+Ramp routes can also resolve customer identity server-side. This keeps browser
+code from choosing the Meld customer identity while still letting each app map
+its own authenticated user or downstream customer.
+
+```typescript
+export const { GET, POST } = createSwigRouteHandlers({
+  resolveRampCustomer: async ({ request }) => {
+    const user = await getUserFromSession(request);
+
+    return {
+      organizationId: user.organizationId,
+      swigUserId: user.id,
+      customerType: 'individual',
+    };
+  },
+});
+```
+
+For embedded partner apps, return `partnerApplicationId` plus either
+`externalCustomerId` or `externalBusinessId` instead of `swigUserId`.

--- a/packages/developer-sdk/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/src/browser-proxy.test.ts
@@ -408,7 +408,7 @@ describe('SwigBrowserClient', () => {
 
     const result = await swig.ramp.quote({
       customer: {
-        organizationId: 'org_123',
+        swigUserId: 'user_123',
         customerType: 'individual',
       },
       wallet: {
@@ -430,7 +430,7 @@ describe('SwigBrowserClient', () => {
       method: 'POST',
       body: {
         customer: {
-          organizationId: 'org_123',
+          swigUserId: 'user_123',
           customerType: 'individual',
         },
         wallet: {

--- a/packages/developer-sdk/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/src/browser-proxy.test.ts
@@ -378,6 +378,130 @@ describe('SwigBrowserClient', () => {
     });
   });
 
+  test('quotes ramp options through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          quotes: [
+            {
+              quote_id: 'quote_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              payment_method_type: 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_amount: '99.00',
+              destination_currency_code: 'USDC_SOLANA',
+              exchange_rate: '0.99',
+              total_fee: '1.00',
+              network_fee: '0.10',
+              transaction_fee: '0.70',
+              partner_fee: '0.20',
+            },
+          ],
+        };
+      }),
+    });
+
+    const result = await swig.ramp.quote({
+      customer: {
+        organizationId: 'org_123',
+        customerType: 'individual',
+      },
+      wallet: {
+        walletId: 'wallet_123',
+        walletAddress: 'wallet_address_123',
+        network: 'devnet',
+      },
+      direction: 'onramp',
+      sourceAmount: '100.00',
+      sourceCurrencyCode: 'USD',
+      destinationCurrencyCode: 'USDC_SOLANA',
+      countryCode: 'US',
+      paymentMethodType: 'credit-debit-card',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/ramp/quote',
+      method: 'POST',
+      body: {
+        customer: {
+          organizationId: 'org_123',
+          customerType: 'individual',
+        },
+        wallet: {
+          walletId: 'wallet_123',
+          walletAddress: 'wallet_address_123',
+          network: 'devnet',
+        },
+        direction: 'onramp',
+        sourceAmount: '100.00',
+        sourceCurrencyCode: 'USD',
+        destinationCurrencyCode: 'USDC_SOLANA',
+        countryCode: 'US',
+        paymentMethodType: 'credit-debit-card',
+      },
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(result.quotes[0]).toMatchObject({
+      quoteId: 'quote_123',
+      direction: 'onramp',
+      paymentMethodType: 'credit-debit-card',
+    });
+  });
+
+  test('lists ramp transactions through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transactions: [
+            {
+              transaction_id: 'txn_123',
+              wallet_id: 'wallet_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              transaction_type: 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE',
+              status: 'RAMP_TRANSACTION_STATUS_SETTLED',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_amount: '99.00',
+              destination_currency_code: 'USDC_SOLANA',
+              created_at: '2026-06-06T00:00:00Z',
+              updated_at: '2026-06-06T00:01:00Z',
+            },
+          ],
+        };
+      }),
+    });
+
+    const result = await swig.ramp.listTransactions({
+      walletId: 'wallet_123',
+      direction: 'onramp',
+      status: 'settled',
+      limit: 10,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/ramp/wallets/wallet_123/transactions?network=devnet&direction=onramp&status=settled&limit=10',
+      method: 'GET',
+      body: undefined,
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(result.transactions[0]).toMatchObject({
+      transactionId: 'txn_123',
+      transactionType: 'crypto-purchase',
+      status: 'settled',
+    });
+  });
+
   test('throws proxy errors with the route response status and message', async () => {
     const swig = new SwigBrowserClient({
       fetch: jsonFetch(() => ({

--- a/packages/developer-sdk/src/browser-proxy.ts
+++ b/packages/developer-sdk/src/browser-proxy.ts
@@ -356,7 +356,6 @@ export class BrowserRampClient {
     const response = await this.http.get<GetRampOptionsResultWire>(
       'ramp/options',
       {
-        organizationId: args.organizationId,
         partnerApplicationId: args.partnerApplicationId,
         countryCode: args.countryCode,
         fiatCurrencyCode: args.fiatCurrencyCode,

--- a/packages/developer-sdk/src/browser-proxy.ts
+++ b/packages/developer-sdk/src/browser-proxy.ts
@@ -1,6 +1,25 @@
+import {
+  normalizeCreateRampSessionResult,
+  normalizeGetRampTransactionResult,
+  normalizeListRampTransactionsResult,
+  normalizeQuoteRampResult,
+  normalizeRampOptions,
+} from './ramp/client.js';
 import type {
+  CreateRampSessionArgs,
+  CreateRampSessionResult,
+  CreateRampSessionResultWire,
   GetPaymasterBalanceArgs,
+  GetRampOptionsArgs,
+  GetRampOptionsResult,
+  GetRampOptionsResultWire,
+  GetRampTransactionArgs,
+  GetRampTransactionResult,
+  GetRampTransactionResultWire,
   IdpWalletSession,
+  ListRampTransactionsArgs,
+  ListRampTransactionsResult,
+  ListRampTransactionsResultWire,
   ListSwigTokenBalancesResult,
   ListSwigTokenTransactionsArgs,
   ListSwigTokenTransactionsResult,
@@ -12,6 +31,9 @@ import type {
   PreparedTransactionWire,
   PrepareOperation,
   PrepareTransactionsResponseWire,
+  QuoteRampArgs,
+  QuoteRampResult,
+  QuoteRampResultWire,
   SwapArgs,
   SwigUsdBalance,
   TransferSolArgs,
@@ -95,10 +117,12 @@ export class SwigBrowserProxyError extends Error {
 
 export class SwigBrowserClient {
   readonly paymaster: BrowserPaymasterClient;
+  readonly ramp: BrowserRampClient;
   readonly wallets: BrowserWalletsClient;
 
   constructor(config: SwigBrowserClientConfig = {}) {
     this.paymaster = new BrowserPaymasterClient(config);
+    this.ramp = new BrowserRampClient(config);
     this.wallets = new BrowserWalletsClient(config);
   }
 }
@@ -314,6 +338,76 @@ function paymasterKindQueryValue(
   }
 }
 
+export class BrowserRampClient {
+  private readonly http: BrowserProxyHttpClient;
+  private readonly defaultNetwork?: Network;
+
+  constructor(config: SwigBrowserClientConfig = {}) {
+    this.http = new BrowserProxyHttpClient({
+      basePath: config.basePath ?? '/api/swig',
+      fetch: resolveFetch(config.fetch),
+    });
+    this.defaultNetwork = config.network;
+  }
+
+  getOptions = async (
+    args: GetRampOptionsArgs,
+  ): Promise<GetRampOptionsResult> => {
+    const response = await this.http.get<GetRampOptionsResultWire>(
+      'ramp/options',
+      {
+        organizationId: args.organizationId,
+        partnerApplicationId: args.partnerApplicationId,
+        countryCode: args.countryCode,
+        fiatCurrencyCode: args.fiatCurrencyCode,
+      },
+    );
+    return normalizeRampOptions(response);
+  };
+
+  quote = async (args: QuoteRampArgs): Promise<QuoteRampResult> => {
+    const response = await this.http.postResource<QuoteRampResultWire>(
+      'ramp/quote',
+      args,
+    );
+    return normalizeQuoteRampResult(response);
+  };
+
+  createSession = async (
+    args: CreateRampSessionArgs,
+  ): Promise<CreateRampSessionResult> => {
+    const response = await this.http.postResource<CreateRampSessionResultWire>(
+      'ramp/sessions',
+      args,
+    );
+    return normalizeCreateRampSessionResult(response);
+  };
+
+  getTransaction = async (
+    args: GetRampTransactionArgs,
+  ): Promise<GetRampTransactionResult> => {
+    const response = await this.http.get<GetRampTransactionResultWire>(
+      `ramp/transactions/${encodeURIComponent(args.transactionId)}`,
+    );
+    return normalizeGetRampTransactionResult(response);
+  };
+
+  listTransactions = async (
+    args: ListRampTransactionsArgs,
+  ): Promise<ListRampTransactionsResult> => {
+    const response = await this.http.get<ListRampTransactionsResultWire>(
+      `ramp/wallets/${encodeURIComponent(args.walletId)}/transactions`,
+      {
+        network: args.network ?? this.defaultNetwork,
+        direction: args.direction,
+        status: args.status,
+        limit: args.limit,
+      },
+    );
+    return normalizeListRampTransactionsResult(response);
+  };
+}
+
 class BrowserProxyHttpClient {
   readonly #basePath: string;
   readonly #fetch: typeof fetch;
@@ -345,6 +439,30 @@ class BrowserProxyHttpClient {
     }
 
     return readPrepared<TResponse>(responseBody);
+  };
+
+  postResource = async <TResponse>(
+    route: string,
+    body: unknown,
+  ): Promise<TResponse> => {
+    const response = await this.#fetch(`${this.#basePath}/${route}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const responseBody = await parseResponseBody(response);
+
+    if (!response.ok) {
+      throw new SwigBrowserProxyError(
+        errorMessageFromBody(responseBody),
+        response.status,
+        responseBody,
+      );
+    }
+
+    return responseBody as TResponse;
   };
 
   get = async <TResponse>(

--- a/packages/developer-sdk/src/index.ts
+++ b/packages/developer-sdk/src/index.ts
@@ -7,6 +7,7 @@ export {
   redirectToOneBusinessGrantAccess,
 } from './one-business/index.js';
 export { PaymasterClient } from './paymaster/index.js';
+export { RampClient, rampCustomer } from './ramp/index.js';
 export { SwigClient } from './server/typescript/index.js';
 export { TransactionsClient } from './transactions/index.js';
 export { WalletHandle, WalletsClient } from './wallets/index.js';
@@ -23,14 +24,22 @@ export type {
   Amount,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
+  CreateRampSessionArgs,
+  CreateRampSessionResult,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
   ExecuteArgs,
   ExecuteRecoveryArgs,
+  GetRampOptionsArgs,
+  GetRampOptionsResult,
+  GetRampTransactionArgs,
+  GetRampTransactionResult,
   IdpWalletSession,
   JsonObject,
   JsonValue,
+  ListRampTransactionsArgs,
+  ListRampTransactionsResult,
   Network,
   Policy,
   PolicyAuthority,
@@ -39,6 +48,18 @@ export type {
   PreparedTransaction,
   PreparedTransactionWire,
   PreparedTransactionsResult,
+  QuoteRampArgs,
+  QuoteRampResult,
+  RampCustomerContext,
+  RampCustomerType,
+  RampDirection,
+  RampPaymentMethodType,
+  RampQuote,
+  RampServiceProvider,
+  RampTransaction,
+  RampTransactionStatus,
+  RampTransactionType,
+  RampWalletContext,
   RecoverySetupPlan,
   RetryOptions,
   SolanaAccountMeta,
@@ -56,3 +77,9 @@ export type {
   WalletHandleOptions,
   WalletReference,
 } from './types/index.js';
+
+export type {
+  DirectSwigUserRampCustomerArgs,
+  PartnerBusinessRampCustomerArgs,
+  PartnerCustomerRampCustomerArgs,
+} from './ramp/index.js';

--- a/packages/developer-sdk/src/nest.ts
+++ b/packages/developer-sdk/src/nest.ts
@@ -5,3 +5,10 @@ export {
   type SwigNestRequestLike,
   type SwigNestResponseLike,
 } from './server/nest/index.js';
+export { rampCustomer } from './ramp/index.js';
+
+export type {
+  DirectSwigUserRampCustomerArgs,
+  PartnerBusinessRampCustomerArgs,
+  PartnerCustomerRampCustomerArgs,
+} from './ramp/index.js';

--- a/packages/developer-sdk/src/nest.ts
+++ b/packages/developer-sdk/src/nest.ts
@@ -1,3 +1,4 @@
+export { rampCustomer } from './ramp/index.js';
 export {
   createSwigNestHandler,
   type CreateSwigNestHandlerConfig,
@@ -5,7 +6,6 @@ export {
   type SwigNestRequestLike,
   type SwigNestResponseLike,
 } from './server/nest/index.js';
-export { rampCustomer } from './ramp/index.js';
 
 export type {
   DirectSwigUserRampCustomerArgs,

--- a/packages/developer-sdk/src/next.ts
+++ b/packages/developer-sdk/src/next.ts
@@ -4,3 +4,10 @@ export {
   type SwigProxyRoute,
   type SwigRouteContext,
 } from './server/next/index.js';
+export { rampCustomer } from './ramp/index.js';
+
+export type {
+  DirectSwigUserRampCustomerArgs,
+  PartnerBusinessRampCustomerArgs,
+  PartnerCustomerRampCustomerArgs,
+} from './ramp/index.js';

--- a/packages/developer-sdk/src/next.ts
+++ b/packages/developer-sdk/src/next.ts
@@ -1,10 +1,10 @@
+export { rampCustomer } from './ramp/index.js';
 export {
   createSwigRouteHandlers,
   type CreateSwigRouteHandlersConfig,
   type SwigProxyRoute,
   type SwigRouteContext,
 } from './server/next/index.js';
-export { rampCustomer } from './ramp/index.js';
 
 export type {
   DirectSwigUserRampCustomerArgs,

--- a/packages/developer-sdk/src/ramp/client.test.ts
+++ b/packages/developer-sdk/src/ramp/client.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test';
+
+import { SwigClient } from '../server/typescript/index.js';
+
+type CapturedRequest = {
+  url: string;
+  method?: string;
+  headers: Headers;
+  body: unknown;
+};
+
+function jsonFetch(
+  handler: (request: CapturedRequest) => unknown,
+): typeof fetch {
+  return (async (input, init) => {
+    const request = new Request(input, init);
+    const text = await request.text();
+
+    return new Response(
+      JSON.stringify(
+        handler({
+          url: request.url,
+          method: request.method,
+          headers: request.headers,
+          body: text ? JSON.parse(text) : undefined,
+        }),
+      ),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }) as typeof fetch;
+}
+
+describe('RampClient', () => {
+  test('quotes ramp options through the backend API with proto wire enums', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          quotes: [
+            {
+              quote_id: 'quote_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              payment_method_type: 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_amount: '99.00',
+              destination_currency_code: 'USDC_SOLANA',
+              exchange_rate: '0.99',
+              total_fee: '1.00',
+              network_fee: '0.10',
+              transaction_fee: '0.70',
+              partner_fee: '0.20',
+              ramp_score: '92.5',
+              low_kyc: true,
+            },
+          ],
+        };
+      }),
+    });
+
+    const result = await swig.ramp.quote({
+      customer: {
+        organizationId: 'org_123',
+        partnerApplicationId: 'app_123',
+        customerType: 'individual',
+      },
+      wallet: {
+        walletId: 'wallet_123',
+        walletAddress: 'wallet_address_123',
+        network: 'devnet',
+      },
+      direction: 'onramp',
+      sourceAmount: '100.00',
+      sourceCurrencyCode: 'USD',
+      destinationCurrencyCode: 'USDC_SOLANA',
+      countryCode: 'US',
+      paymentMethodType: 'credit-debit-card',
+      serviceProviders: ['other'],
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/quote',
+      method: 'POST',
+      body: {
+        customer: {
+          organizationId: 'org_123',
+          partnerApplicationId: 'app_123',
+          customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
+        },
+        wallet: {
+          walletId: 'wallet_123',
+          walletAddress: 'wallet_address_123',
+          network: 'NETWORK_DEVNET',
+        },
+        direction: 'RAMP_DIRECTION_ONRAMP',
+        sourceAmount: '100.00',
+        sourceCurrencyCode: 'USD',
+        destinationCurrencyCode: 'USDC_SOLANA',
+        countryCode: 'US',
+        paymentMethodType: 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD',
+        serviceProviders: ['RAMP_SERVICE_PROVIDER_OTHER'],
+      },
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+    expect(result.quotes[0]).toMatchObject({
+      quoteId: 'quote_123',
+      direction: 'onramp',
+      serviceProvider: 'other',
+      paymentMethodType: 'credit-debit-card',
+      rampScore: '92.5',
+      lowKyc: true,
+    });
+  });
+
+  test('creates sessions and lists ramp transaction history', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        if (request.method === 'POST') {
+          return {
+            local_session_id: 'session_local_123',
+            meld_session_id: 'meld_session_123',
+            external_customer_id: 'customer_123',
+            external_session_id: 'swig:ramp:on:wallet_123:session_123',
+            launch_url: 'https://provider.example/launch',
+            fallback_launch_url: 'https://meld.example/widget',
+          };
+        }
+        return {
+          transactions: [
+            {
+              transaction_id: 'txn_123',
+              meld_transaction_id: 'meld_txn_123',
+              meld_session_id: 'meld_session_123',
+              wallet_id: 'wallet_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              transaction_type: 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE',
+              status: 'RAMP_TRANSACTION_STATUS_PENDING',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              payment_method_type: 'RAMP_PAYMENT_METHOD_TYPE_ACH',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_amount: '99.00',
+              destination_currency_code: 'USDC_SOLANA',
+              created_at: '2026-06-06T00:00:00Z',
+              updated_at: '2026-06-06T00:01:00Z',
+            },
+          ],
+        };
+      }),
+    });
+
+    const session = await swig.ramp.createSession({
+      customer: {
+        organizationId: 'org_123',
+        customerType: 'individual',
+      },
+      wallet: {
+        walletId: 'wallet_123',
+        walletAddress: 'wallet_address_123',
+        network: 'devnet',
+      },
+      direction: 'onramp',
+      selectedQuoteId: 'quote_123',
+      sourceAmount: '100.00',
+      sourceCurrencyCode: 'USD',
+      destinationCurrencyCode: 'USDC_SOLANA',
+      countryCode: 'US',
+      serviceProvider: 'other',
+      paymentMethodType: 'ach',
+      redirectUrl: 'https://app.example/ramp/return',
+    });
+    const history = await swig.ramp.listTransactions({
+      walletId: 'wallet_123',
+      direction: 'onramp',
+      status: 'pending',
+      limit: 25,
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/sessions',
+      method: 'POST',
+      body: {
+        direction: 'RAMP_DIRECTION_ONRAMP',
+        selectedQuoteId: 'quote_123',
+        serviceProvider: 'RAMP_SERVICE_PROVIDER_OTHER',
+        paymentMethodType: 'RAMP_PAYMENT_METHOD_TYPE_ACH',
+        redirectUrl: 'https://app.example/ramp/return',
+      },
+    });
+    expect(session).toMatchObject({
+      localSessionId: 'session_local_123',
+      meldSessionId: 'meld_session_123',
+      launchUrl: 'https://provider.example/launch',
+      fallbackLaunchUrl: 'https://meld.example/widget',
+    });
+    expect(calls[1]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/wallets/wallet_123/transactions?network=NETWORK_DEVNET&direction=RAMP_DIRECTION_ONRAMP&status=RAMP_TRANSACTION_STATUS_PENDING&limit=25',
+      method: 'GET',
+    });
+    expect(history.transactions[0]).toMatchObject({
+      transactionId: 'txn_123',
+      transactionType: 'crypto-purchase',
+      status: 'pending',
+      paymentMethodType: 'ach',
+    });
+  });
+});

--- a/packages/developer-sdk/src/ramp/client.test.ts
+++ b/packages/developer-sdk/src/ramp/client.test.ts
@@ -68,8 +68,8 @@ describe('RampClient', () => {
 
     const result = await swig.ramp.quote({
       customer: {
-        organizationId: 'org_123',
         partnerApplicationId: 'app_123',
+        swigUserId: 'user_123',
         customerType: 'individual',
       },
       wallet: {
@@ -91,8 +91,8 @@ describe('RampClient', () => {
       method: 'POST',
       body: {
         customer: {
-          organizationId: 'org_123',
           partnerApplicationId: 'app_123',
+          swigUserId: 'user_123',
           customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
         },
         wallet: {
@@ -164,7 +164,7 @@ describe('RampClient', () => {
 
     const session = await swig.ramp.createSession({
       customer: {
-        organizationId: 'org_123',
+        swigUserId: 'user_123',
         customerType: 'individual',
       },
       wallet: {

--- a/packages/developer-sdk/src/ramp/client.ts
+++ b/packages/developer-sdk/src/ramp/client.ts
@@ -1,0 +1,716 @@
+import type { HttpClient } from '../core/index.js';
+import type {
+  CreateRampSessionArgs,
+  CreateRampSessionRequestWire,
+  CreateRampSessionResult,
+  CreateRampSessionResultWire,
+  GetRampOptionsArgs,
+  GetRampOptionsResult,
+  GetRampOptionsResultWire,
+  GetRampTransactionArgs,
+  GetRampTransactionResult,
+  GetRampTransactionResultWire,
+  ListRampTransactionsArgs,
+  ListRampTransactionsResult,
+  ListRampTransactionsResultWire,
+  Network,
+  NetworkWire,
+  QuoteRampArgs,
+  QuoteRampRequestWire,
+  QuoteRampResult,
+  QuoteRampResultWire,
+  RampCustomerContext,
+  RampCustomerContextWire,
+  RampCustomerTypeWire,
+  RampDirection,
+  RampDirectionWire,
+  RampPaymentMethodType,
+  RampPaymentMethodTypeWire,
+  RampQuote,
+  RampQuoteWire,
+  RampServiceProvider,
+  RampServiceProviderWire,
+  RampTransaction,
+  RampTransactionStatus,
+  RampTransactionStatusWire,
+  RampTransactionType,
+  RampTransactionTypeWire,
+  RampTransactionWire,
+  RampWalletContext,
+  RampWalletContextWire,
+} from '../types/index.js';
+
+export class RampClient {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly defaultNetwork?: Network,
+  ) {}
+
+  getOptions = async (
+    args: GetRampOptionsArgs,
+  ): Promise<GetRampOptionsResult> => {
+    const response = await this.http.get<GetRampOptionsResultWire>(
+      rampOptionsPath(args),
+    );
+    return normalizeRampOptions(response);
+  };
+
+  quote = async (args: QuoteRampArgs): Promise<QuoteRampResult> => {
+    const response = await this.http.post<QuoteRampResultWire>(
+      '/wallet/api/ramp/quote',
+      quoteRampRequest(args),
+    );
+    return normalizeQuoteRampResult(response);
+  };
+
+  createSession = async (
+    args: CreateRampSessionArgs,
+  ): Promise<CreateRampSessionResult> => {
+    const response = await this.http.post<CreateRampSessionResultWire>(
+      '/wallet/api/ramp/sessions',
+      createRampSessionRequest(args),
+    );
+    return normalizeCreateRampSessionResult(response);
+  };
+
+  getTransaction = async (
+    args: GetRampTransactionArgs,
+  ): Promise<GetRampTransactionResult> => {
+    const response = await this.http.get<GetRampTransactionResultWire>(
+      `/wallet/api/ramp/transactions/${encodeURIComponent(args.transactionId)}`,
+    );
+    return normalizeGetRampTransactionResult(response);
+  };
+
+  listTransactions = async (
+    args: ListRampTransactionsArgs,
+  ): Promise<ListRampTransactionsResult> => {
+    const response = await this.http.get<ListRampTransactionsResultWire>(
+      listRampTransactionsPath({
+        ...args,
+        network: args.network ?? this.defaultNetwork,
+      }),
+    );
+    return normalizeListRampTransactionsResult(response);
+  };
+}
+
+export function normalizeRampOptions(
+  response: GetRampOptionsResultWire,
+): GetRampOptionsResult {
+  return {
+    countryCodes: response.countryCodes ?? response.country_codes ?? [],
+    fiatCurrencyCodes:
+      response.fiatCurrencyCodes ?? response.fiat_currency_codes ?? [],
+    paymentMethodTypes: (
+      response.paymentMethodTypes ??
+      response.payment_method_types ??
+      []
+    ).map(normalizeRampPaymentMethodType),
+    cryptoCurrencyCodes:
+      response.cryptoCurrencyCodes ?? response.crypto_currency_codes ?? [],
+  };
+}
+
+export function normalizeQuoteRampResult(
+  response: QuoteRampResultWire,
+): QuoteRampResult {
+  return {
+    quotes: (response.quotes ?? []).map(normalizeRampQuote),
+  };
+}
+
+export function normalizeCreateRampSessionResult(
+  response: CreateRampSessionResultWire,
+): CreateRampSessionResult {
+  const fallbackLaunchUrl =
+    response.fallbackLaunchUrl ?? response.fallback_launch_url;
+  return {
+    localSessionId: readString(
+      response.localSessionId ?? response.local_session_id,
+      'localSessionId',
+    ),
+    meldSessionId: readString(
+      response.meldSessionId ?? response.meld_session_id,
+      'meldSessionId',
+    ),
+    externalCustomerId: readString(
+      response.externalCustomerId ?? response.external_customer_id,
+      'externalCustomerId',
+    ),
+    externalSessionId: readString(
+      response.externalSessionId ?? response.external_session_id,
+      'externalSessionId',
+    ),
+    launchUrl: readString(
+      response.launchUrl ?? response.launch_url,
+      'launchUrl',
+    ),
+    ...(fallbackLaunchUrl ? { fallbackLaunchUrl } : {}),
+  };
+}
+
+export function normalizeGetRampTransactionResult(
+  response: GetRampTransactionResultWire,
+): GetRampTransactionResult {
+  return {
+    ...(response.transaction
+      ? { transaction: normalizeRampTransaction(response.transaction) }
+      : {}),
+  };
+}
+
+export function normalizeListRampTransactionsResult(
+  response: ListRampTransactionsResultWire,
+): ListRampTransactionsResult {
+  return {
+    transactions: (response.transactions ?? []).map(normalizeRampTransaction),
+  };
+}
+
+function rampOptionsPath(args: GetRampOptionsArgs): string {
+  return pathWithQuery('/wallet/api/ramp/options', {
+    organizationId: args.organizationId,
+    partnerApplicationId: args.partnerApplicationId,
+    countryCode: args.countryCode,
+    fiatCurrencyCode: args.fiatCurrencyCode,
+  });
+}
+
+function listRampTransactionsPath(args: {
+  walletId: string;
+  network?: Network;
+  direction?: Exclude<RampDirection, 'unspecified'>;
+  status?: Exclude<RampTransactionStatus, 'unspecified'>;
+  limit?: number;
+}): string {
+  if (!args.network) {
+    throw new Error('network is required');
+  }
+  return pathWithQuery(
+    `/wallet/api/ramp/wallets/${encodeURIComponent(args.walletId)}/transactions`,
+    {
+      network: networkToWire(args.network),
+      direction:
+        args.direction === undefined
+          ? undefined
+          : rampDirectionToWire(args.direction),
+      status:
+        args.status === undefined
+          ? undefined
+          : rampTransactionStatusToWire(args.status),
+      limit: args.limit,
+    },
+  );
+}
+
+function quoteRampRequest(args: QuoteRampArgs): QuoteRampRequestWire {
+  return {
+    customer: rampCustomerContextRequest(args.customer),
+    wallet: rampWalletContextRequest(args.wallet),
+    direction: rampDirectionToWire(args.direction),
+    sourceAmount: args.sourceAmount,
+    sourceCurrencyCode: args.sourceCurrencyCode,
+    destinationCurrencyCode: args.destinationCurrencyCode,
+    countryCode: args.countryCode,
+    subdivision: args.subdivision,
+    paymentMethodType:
+      args.paymentMethodType === undefined
+        ? undefined
+        : rampPaymentMethodTypeToWire(args.paymentMethodType),
+    serviceProviders: (args.serviceProviders ?? []).map(
+      rampServiceProviderToWire,
+    ),
+  };
+}
+
+function createRampSessionRequest(
+  args: CreateRampSessionArgs,
+): CreateRampSessionRequestWire {
+  return {
+    ...quoteRampRequest(args),
+    selectedQuoteId: args.selectedQuoteId,
+    serviceProvider: rampServiceProviderToWire(args.serviceProvider),
+    redirectUrl: args.redirectUrl,
+  };
+}
+
+function rampCustomerContextRequest(
+  customer: RampCustomerContext,
+): RampCustomerContextWire {
+  return {
+    organizationId: customer.organizationId,
+    partnerApplicationId: customer.partnerApplicationId,
+    swigUserId: customer.swigUserId,
+    externalCustomerId: customer.externalCustomerId,
+    externalBusinessId: customer.externalBusinessId,
+    customerType: rampCustomerTypeToWire(customer.customerType),
+  };
+}
+
+function rampWalletContextRequest(
+  wallet: RampWalletContext,
+): RampWalletContextWire {
+  return {
+    walletId: wallet.walletId,
+    walletAddress: wallet.walletAddress,
+    network: networkToWire(wallet.network),
+  };
+}
+
+function normalizeRampQuote(response: RampQuoteWire): RampQuote {
+  const rampScore = response.rampScore ?? response.ramp_score;
+  const lowKyc = response.lowKyc ?? response.low_kyc;
+  return {
+    quoteId: readString(response.quoteId ?? response.quote_id, 'quoteId'),
+    direction: normalizeRampDirection(response.direction),
+    serviceProvider: normalizeRampServiceProvider(
+      response.serviceProvider ?? response.service_provider,
+    ),
+    paymentMethodType: normalizeRampPaymentMethodType(
+      response.paymentMethodType ?? response.payment_method_type,
+    ),
+    sourceAmount: readString(
+      response.sourceAmount ?? response.source_amount,
+      'sourceAmount',
+    ),
+    sourceCurrencyCode: readString(
+      response.sourceCurrencyCode ?? response.source_currency_code,
+      'sourceCurrencyCode',
+    ),
+    destinationAmount: readString(
+      response.destinationAmount ?? response.destination_amount,
+      'destinationAmount',
+    ),
+    destinationCurrencyCode: readString(
+      response.destinationCurrencyCode ?? response.destination_currency_code,
+      'destinationCurrencyCode',
+    ),
+    exchangeRate: readString(
+      response.exchangeRate ?? response.exchange_rate,
+      'exchangeRate',
+    ),
+    totalFee: readString(response.totalFee ?? response.total_fee, 'totalFee'),
+    networkFee: readString(
+      response.networkFee ?? response.network_fee,
+      'networkFee',
+    ),
+    transactionFee: readString(
+      response.transactionFee ?? response.transaction_fee,
+      'transactionFee',
+    ),
+    partnerFee: readString(
+      response.partnerFee ?? response.partner_fee,
+      'partnerFee',
+    ),
+    ...(rampScore ? { rampScore } : {}),
+    ...(lowKyc === undefined ? {} : { lowKyc }),
+  };
+}
+
+function normalizeRampTransaction(
+  response: RampTransactionWire,
+): RampTransaction {
+  const meldTransactionId =
+    response.meldTransactionId ?? response.meld_transaction_id;
+  const meldSessionId = response.meldSessionId ?? response.meld_session_id;
+  const paymentMethodType =
+    response.paymentMethodType ?? response.payment_method_type;
+  const destinationAmount =
+    response.destinationAmount ?? response.destination_amount;
+  return {
+    transactionId: readString(
+      response.transactionId ?? response.transaction_id,
+      'transactionId',
+    ),
+    ...(meldTransactionId ? { meldTransactionId } : {}),
+    ...(meldSessionId ? { meldSessionId } : {}),
+    walletId: readString(response.walletId ?? response.wallet_id, 'walletId'),
+    direction: normalizeRampDirection(response.direction),
+    transactionType: normalizeRampTransactionType(
+      response.transactionType ?? response.transaction_type,
+    ),
+    status: normalizeRampTransactionStatus(response.status),
+    serviceProvider: normalizeRampServiceProvider(
+      response.serviceProvider ?? response.service_provider,
+    ),
+    ...(paymentMethodType === undefined
+      ? {}
+      : {
+          paymentMethodType: normalizeRampPaymentMethodType(paymentMethodType),
+        }),
+    sourceAmount: readString(
+      response.sourceAmount ?? response.source_amount,
+      'sourceAmount',
+    ),
+    sourceCurrencyCode: readString(
+      response.sourceCurrencyCode ?? response.source_currency_code,
+      'sourceCurrencyCode',
+    ),
+    ...(destinationAmount ? { destinationAmount } : {}),
+    destinationCurrencyCode: readString(
+      response.destinationCurrencyCode ?? response.destination_currency_code,
+      'destinationCurrencyCode',
+    ),
+    createdAt: readString(
+      response.createdAt ?? response.created_at,
+      'createdAt',
+    ),
+    updatedAt: readString(
+      response.updatedAt ?? response.updated_at,
+      'updatedAt',
+    ),
+  };
+}
+
+function rampDirectionToWire(direction: RampDirectionWire): RampDirectionWire {
+  switch (direction) {
+    case 'onramp':
+    case 'RAMP_DIRECTION_ONRAMP':
+    case 1:
+      return 'RAMP_DIRECTION_ONRAMP';
+    case 'offramp':
+    case 'RAMP_DIRECTION_OFFRAMP':
+    case 2:
+      return 'RAMP_DIRECTION_OFFRAMP';
+    case 'transfer':
+    case 'RAMP_DIRECTION_TRANSFER':
+    case 3:
+      return 'RAMP_DIRECTION_TRANSFER';
+    case 'unspecified':
+    case 'RAMP_DIRECTION_UNSPECIFIED':
+    case 0:
+      return 'RAMP_DIRECTION_UNSPECIFIED';
+    default:
+      throw new Error('Invalid ramp direction');
+  }
+}
+
+function rampCustomerTypeToWire(
+  customerType: RampCustomerTypeWire,
+): RampCustomerTypeWire {
+  switch (customerType) {
+    case 'individual':
+    case 'RAMP_CUSTOMER_TYPE_INDIVIDUAL':
+    case 1:
+      return 'RAMP_CUSTOMER_TYPE_INDIVIDUAL';
+    case 'business':
+    case 'RAMP_CUSTOMER_TYPE_BUSINESS':
+    case 2:
+      return 'RAMP_CUSTOMER_TYPE_BUSINESS';
+    case 'unspecified':
+    case 'RAMP_CUSTOMER_TYPE_UNSPECIFIED':
+    case 0:
+      return 'RAMP_CUSTOMER_TYPE_UNSPECIFIED';
+    default:
+      throw new Error('Invalid ramp customer type');
+  }
+}
+
+function rampServiceProviderToWire(
+  provider: RampServiceProviderWire,
+): RampServiceProviderWire {
+  switch (provider) {
+    case 'other':
+    case 'RAMP_SERVICE_PROVIDER_OTHER':
+    case 1:
+      return 'RAMP_SERVICE_PROVIDER_OTHER';
+    case 'unspecified':
+    case 'RAMP_SERVICE_PROVIDER_UNSPECIFIED':
+    case 0:
+      return 'RAMP_SERVICE_PROVIDER_UNSPECIFIED';
+    default:
+      throw new Error('Invalid ramp service provider');
+  }
+}
+
+function rampPaymentMethodTypeToWire(
+  paymentMethodType: RampPaymentMethodTypeWire,
+): RampPaymentMethodTypeWire {
+  switch (paymentMethodType) {
+    case 'other':
+    case 'RAMP_PAYMENT_METHOD_TYPE_OTHER':
+    case 1:
+      return 'RAMP_PAYMENT_METHOD_TYPE_OTHER';
+    case 'credit-debit-card':
+    case 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD':
+    case 2:
+      return 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD';
+    case 'ach':
+    case 'RAMP_PAYMENT_METHOD_TYPE_ACH':
+    case 3:
+      return 'RAMP_PAYMENT_METHOD_TYPE_ACH';
+    case 'bank-transfer':
+    case 'RAMP_PAYMENT_METHOD_TYPE_BANK_TRANSFER':
+    case 4:
+      return 'RAMP_PAYMENT_METHOD_TYPE_BANK_TRANSFER';
+    case 'apple-pay':
+    case 'RAMP_PAYMENT_METHOD_TYPE_APPLE_PAY':
+    case 5:
+      return 'RAMP_PAYMENT_METHOD_TYPE_APPLE_PAY';
+    case 'google-pay':
+    case 'RAMP_PAYMENT_METHOD_TYPE_GOOGLE_PAY':
+    case 6:
+      return 'RAMP_PAYMENT_METHOD_TYPE_GOOGLE_PAY';
+    case 'pix':
+    case 'RAMP_PAYMENT_METHOD_TYPE_PIX':
+    case 7:
+      return 'RAMP_PAYMENT_METHOD_TYPE_PIX';
+    case 'unspecified':
+    case 'RAMP_PAYMENT_METHOD_TYPE_UNSPECIFIED':
+    case 0:
+      return 'RAMP_PAYMENT_METHOD_TYPE_UNSPECIFIED';
+    default:
+      throw new Error('Invalid ramp payment method type');
+  }
+}
+
+function rampTransactionStatusToWire(
+  status: RampTransactionStatusWire,
+): RampTransactionStatusWire {
+  switch (status) {
+    case 'created':
+    case 'RAMP_TRANSACTION_STATUS_CREATED':
+    case 1:
+      return 'RAMP_TRANSACTION_STATUS_CREATED';
+    case 'pending':
+    case 'RAMP_TRANSACTION_STATUS_PENDING':
+    case 2:
+      return 'RAMP_TRANSACTION_STATUS_PENDING';
+    case 'settling':
+    case 'RAMP_TRANSACTION_STATUS_SETTLING':
+    case 3:
+      return 'RAMP_TRANSACTION_STATUS_SETTLING';
+    case 'settled':
+    case 'RAMP_TRANSACTION_STATUS_SETTLED':
+    case 4:
+      return 'RAMP_TRANSACTION_STATUS_SETTLED';
+    case 'failed':
+    case 'RAMP_TRANSACTION_STATUS_FAILED':
+    case 5:
+      return 'RAMP_TRANSACTION_STATUS_FAILED';
+    case 'declined':
+    case 'RAMP_TRANSACTION_STATUS_DECLINED':
+    case 6:
+      return 'RAMP_TRANSACTION_STATUS_DECLINED';
+    case 'cancelled':
+    case 'RAMP_TRANSACTION_STATUS_CANCELLED':
+    case 7:
+      return 'RAMP_TRANSACTION_STATUS_CANCELLED';
+    case 'refunded':
+    case 'RAMP_TRANSACTION_STATUS_REFUNDED':
+    case 8:
+      return 'RAMP_TRANSACTION_STATUS_REFUNDED';
+    case 'unspecified':
+    case 'RAMP_TRANSACTION_STATUS_UNSPECIFIED':
+    case 0:
+      return 'RAMP_TRANSACTION_STATUS_UNSPECIFIED';
+    default:
+      throw new Error('Invalid ramp transaction status');
+  }
+}
+
+function networkToWire(network: NetworkWire): NetworkWire {
+  switch (network) {
+    case 'devnet':
+    case 'NETWORK_DEVNET':
+    case 1:
+      return 'NETWORK_DEVNET';
+    case 'mainnet':
+    case 'NETWORK_MAINNET':
+    case 2:
+      return 'NETWORK_MAINNET';
+    case 'NETWORK_UNSPECIFIED':
+    case 0:
+      return 'NETWORK_UNSPECIFIED';
+    default:
+      throw new Error('Invalid network');
+  }
+}
+
+function normalizeRampDirection(direction?: RampDirectionWire): RampDirection {
+  switch (direction) {
+    case 'onramp':
+    case 'RAMP_DIRECTION_ONRAMP':
+    case 1:
+      return 'onramp';
+    case 'offramp':
+    case 'RAMP_DIRECTION_OFFRAMP':
+    case 2:
+      return 'offramp';
+    case 'transfer':
+    case 'RAMP_DIRECTION_TRANSFER':
+    case 3:
+      return 'transfer';
+    case 'unspecified':
+    case 'RAMP_DIRECTION_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Ramp response has invalid direction');
+  }
+}
+
+function normalizeRampServiceProvider(
+  provider?: RampServiceProviderWire,
+): RampServiceProvider {
+  switch (provider) {
+    case 'other':
+    case 'RAMP_SERVICE_PROVIDER_OTHER':
+    case 1:
+      return 'other';
+    case 'unspecified':
+    case 'RAMP_SERVICE_PROVIDER_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Ramp response has invalid serviceProvider');
+  }
+}
+
+function normalizeRampPaymentMethodType(
+  paymentMethodType?: RampPaymentMethodTypeWire,
+): RampPaymentMethodType {
+  switch (paymentMethodType) {
+    case 'other':
+    case 'RAMP_PAYMENT_METHOD_TYPE_OTHER':
+    case 1:
+      return 'other';
+    case 'credit-debit-card':
+    case 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD':
+    case 2:
+      return 'credit-debit-card';
+    case 'ach':
+    case 'RAMP_PAYMENT_METHOD_TYPE_ACH':
+    case 3:
+      return 'ach';
+    case 'bank-transfer':
+    case 'RAMP_PAYMENT_METHOD_TYPE_BANK_TRANSFER':
+    case 4:
+      return 'bank-transfer';
+    case 'apple-pay':
+    case 'RAMP_PAYMENT_METHOD_TYPE_APPLE_PAY':
+    case 5:
+      return 'apple-pay';
+    case 'google-pay':
+    case 'RAMP_PAYMENT_METHOD_TYPE_GOOGLE_PAY':
+    case 6:
+      return 'google-pay';
+    case 'pix':
+    case 'RAMP_PAYMENT_METHOD_TYPE_PIX':
+    case 7:
+      return 'pix';
+    case 'unspecified':
+    case 'RAMP_PAYMENT_METHOD_TYPE_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Ramp response has invalid paymentMethodType');
+  }
+}
+
+function normalizeRampTransactionType(
+  transactionType?: RampTransactionTypeWire,
+): RampTransactionType {
+  switch (transactionType) {
+    case 'crypto-purchase':
+    case 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE':
+    case 1:
+      return 'crypto-purchase';
+    case 'crypto-sell':
+    case 'RAMP_TRANSACTION_TYPE_CRYPTO_SELL':
+    case 2:
+      return 'crypto-sell';
+    case 'crypto-purchase-swap':
+    case 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE_SWAP':
+    case 3:
+      return 'crypto-purchase-swap';
+    case 'crypto-sell-swap':
+    case 'RAMP_TRANSACTION_TYPE_CRYPTO_SELL_SWAP':
+    case 4:
+      return 'crypto-sell-swap';
+    case 'transfer':
+    case 'RAMP_TRANSACTION_TYPE_TRANSFER':
+    case 5:
+      return 'transfer';
+    case 'unspecified':
+    case 'RAMP_TRANSACTION_TYPE_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Ramp response has invalid transactionType');
+  }
+}
+
+function normalizeRampTransactionStatus(
+  status?: RampTransactionStatusWire,
+): RampTransactionStatus {
+  switch (status) {
+    case 'created':
+    case 'RAMP_TRANSACTION_STATUS_CREATED':
+    case 1:
+      return 'created';
+    case 'pending':
+    case 'RAMP_TRANSACTION_STATUS_PENDING':
+    case 2:
+      return 'pending';
+    case 'settling':
+    case 'RAMP_TRANSACTION_STATUS_SETTLING':
+    case 3:
+      return 'settling';
+    case 'settled':
+    case 'RAMP_TRANSACTION_STATUS_SETTLED':
+    case 4:
+      return 'settled';
+    case 'failed':
+    case 'RAMP_TRANSACTION_STATUS_FAILED':
+    case 5:
+      return 'failed';
+    case 'declined':
+    case 'RAMP_TRANSACTION_STATUS_DECLINED':
+    case 6:
+      return 'declined';
+    case 'cancelled':
+    case 'RAMP_TRANSACTION_STATUS_CANCELLED':
+    case 7:
+      return 'cancelled';
+    case 'refunded':
+    case 'RAMP_TRANSACTION_STATUS_REFUNDED':
+    case 8:
+      return 'refunded';
+    case 'unspecified':
+    case 'RAMP_TRANSACTION_STATUS_UNSPECIFIED':
+    case 0:
+    case undefined:
+      return 'unspecified';
+    default:
+      throw new Error('Ramp response has invalid status');
+  }
+}
+
+function pathWithQuery(
+  path: string,
+  query: Record<string, string | number | undefined>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) {
+      params.set(key, String(value));
+    }
+  }
+  return params.size > 0 ? `${path}?${params.toString()}` : path;
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  throw new Error(`Ramp response is missing ${field}`);
+}

--- a/packages/developer-sdk/src/ramp/client.ts
+++ b/packages/developer-sdk/src/ramp/client.ts
@@ -170,7 +170,6 @@ export function normalizeListRampTransactionsResult(
 
 function rampOptionsPath(args: GetRampOptionsArgs): string {
   return pathWithQuery('/wallet/api/ramp/options', {
-    organizationId: args.organizationId,
     partnerApplicationId: args.partnerApplicationId,
     countryCode: args.countryCode,
     fiatCurrencyCode: args.fiatCurrencyCode,
@@ -239,7 +238,6 @@ function rampCustomerContextRequest(
   customer: RampCustomerContext,
 ): RampCustomerContextWire {
   return {
-    organizationId: customer.organizationId,
     partnerApplicationId: customer.partnerApplicationId,
     swigUserId: customer.swigUserId,
     externalCustomerId: customer.externalCustomerId,

--- a/packages/developer-sdk/src/ramp/customer.test.ts
+++ b/packages/developer-sdk/src/ramp/customer.test.ts
@@ -6,11 +6,9 @@ describe('rampCustomer', () => {
   test('builds direct Swig user context', () => {
     expect(
       rampCustomer.directSwigUser({
-        organizationId: 'org_123',
         swigUserId: 'user_123',
       }),
     ).toEqual({
-      organizationId: 'org_123',
       swigUserId: 'user_123',
       customerType: 'individual',
     });
@@ -19,12 +17,10 @@ describe('rampCustomer', () => {
   test('preserves optional partner application id for direct Swig users', () => {
     expect(
       rampCustomer.directSwigUser({
-        organizationId: 'org_123',
         partnerApplicationId: 'app_123',
         swigUserId: 'user_123',
       }),
     ).toEqual({
-      organizationId: 'org_123',
       partnerApplicationId: 'app_123',
       swigUserId: 'user_123',
       customerType: 'individual',
@@ -34,12 +30,10 @@ describe('rampCustomer', () => {
   test('builds downstream partner customer context', () => {
     expect(
       rampCustomer.partnerCustomer({
-        organizationId: 'org_123',
         partnerApplicationId: 'app_123',
         externalCustomerId: 'customer_123',
       }),
     ).toEqual({
-      organizationId: 'org_123',
       partnerApplicationId: 'app_123',
       externalCustomerId: 'customer_123',
       customerType: 'individual',
@@ -49,12 +43,10 @@ describe('rampCustomer', () => {
   test('builds downstream partner business context', () => {
     expect(
       rampCustomer.partnerBusiness({
-        organizationId: 'org_123',
         partnerApplicationId: 'app_123',
         externalBusinessId: 'business_123',
       }),
     ).toEqual({
-      organizationId: 'org_123',
       partnerApplicationId: 'app_123',
       externalBusinessId: 'business_123',
       customerType: 'business',
@@ -64,7 +56,6 @@ describe('rampCustomer', () => {
   test('rejects blank required ids', () => {
     expect(() =>
       rampCustomer.partnerCustomer({
-        organizationId: 'org_123',
         partnerApplicationId: '',
         externalCustomerId: 'customer_123',
       }),

--- a/packages/developer-sdk/src/ramp/customer.test.ts
+++ b/packages/developer-sdk/src/ramp/customer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+
+import { rampCustomer } from './customer.js';
+
+describe('rampCustomer', () => {
+  test('builds direct Swig user context', () => {
+    expect(
+      rampCustomer.directSwigUser({
+        organizationId: 'org_123',
+        swigUserId: 'user_123',
+      }),
+    ).toEqual({
+      organizationId: 'org_123',
+      swigUserId: 'user_123',
+      customerType: 'individual',
+    });
+  });
+
+  test('preserves optional partner application id for direct Swig users', () => {
+    expect(
+      rampCustomer.directSwigUser({
+        organizationId: 'org_123',
+        partnerApplicationId: 'app_123',
+        swigUserId: 'user_123',
+      }),
+    ).toEqual({
+      organizationId: 'org_123',
+      partnerApplicationId: 'app_123',
+      swigUserId: 'user_123',
+      customerType: 'individual',
+    });
+  });
+
+  test('builds downstream partner customer context', () => {
+    expect(
+      rampCustomer.partnerCustomer({
+        organizationId: 'org_123',
+        partnerApplicationId: 'app_123',
+        externalCustomerId: 'customer_123',
+      }),
+    ).toEqual({
+      organizationId: 'org_123',
+      partnerApplicationId: 'app_123',
+      externalCustomerId: 'customer_123',
+      customerType: 'individual',
+    });
+  });
+
+  test('builds downstream partner business context', () => {
+    expect(
+      rampCustomer.partnerBusiness({
+        organizationId: 'org_123',
+        partnerApplicationId: 'app_123',
+        externalBusinessId: 'business_123',
+      }),
+    ).toEqual({
+      organizationId: 'org_123',
+      partnerApplicationId: 'app_123',
+      externalBusinessId: 'business_123',
+      customerType: 'business',
+    });
+  });
+
+  test('rejects blank required ids', () => {
+    expect(() =>
+      rampCustomer.partnerCustomer({
+        organizationId: 'org_123',
+        partnerApplicationId: '',
+        externalCustomerId: 'customer_123',
+      }),
+    ).toThrow('partnerApplicationId is required');
+  });
+});

--- a/packages/developer-sdk/src/ramp/customer.ts
+++ b/packages/developer-sdk/src/ramp/customer.ts
@@ -56,9 +56,7 @@ export const rampCustomer = {
 function optionalPartnerApplicationId(
   partnerApplicationId: string | undefined,
 ): Pick<RampCustomerContext, 'partnerApplicationId'> | Record<string, never> {
-  return partnerApplicationId?.trim()
-    ? { partnerApplicationId }
-    : {};
+  return partnerApplicationId?.trim() ? { partnerApplicationId } : {};
 }
 
 function requireNonEmpty(value: string, fieldName: string): string {

--- a/packages/developer-sdk/src/ramp/customer.ts
+++ b/packages/developer-sdk/src/ramp/customer.ts
@@ -1,0 +1,75 @@
+import type { RampCustomerContext } from '../types/ramp.js';
+
+export interface DirectSwigUserRampCustomerArgs {
+  organizationId: string;
+  partnerApplicationId?: string;
+  swigUserId: string;
+}
+
+export interface PartnerCustomerRampCustomerArgs {
+  organizationId: string;
+  partnerApplicationId: string;
+  externalCustomerId: string;
+}
+
+export interface PartnerBusinessRampCustomerArgs {
+  organizationId: string;
+  partnerApplicationId: string;
+  externalBusinessId: string;
+}
+
+export const rampCustomer = {
+  directSwigUser(args: DirectSwigUserRampCustomerArgs): RampCustomerContext {
+    return {
+      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
+      ...optionalPartnerApplicationId(args.partnerApplicationId),
+      swigUserId: requireNonEmpty(args.swigUserId, 'swigUserId'),
+      customerType: 'individual',
+    };
+  },
+
+  partnerCustomer(args: PartnerCustomerRampCustomerArgs): RampCustomerContext {
+    return {
+      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
+      partnerApplicationId: requireNonEmpty(
+        args.partnerApplicationId,
+        'partnerApplicationId',
+      ),
+      externalCustomerId: requireNonEmpty(
+        args.externalCustomerId,
+        'externalCustomerId',
+      ),
+      customerType: 'individual',
+    };
+  },
+
+  partnerBusiness(args: PartnerBusinessRampCustomerArgs): RampCustomerContext {
+    return {
+      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
+      partnerApplicationId: requireNonEmpty(
+        args.partnerApplicationId,
+        'partnerApplicationId',
+      ),
+      externalBusinessId: requireNonEmpty(
+        args.externalBusinessId,
+        'externalBusinessId',
+      ),
+      customerType: 'business',
+    };
+  },
+} as const;
+
+function optionalPartnerApplicationId(
+  partnerApplicationId: string | undefined,
+): Pick<RampCustomerContext, 'partnerApplicationId'> | Record<string, never> {
+  return partnerApplicationId?.trim()
+    ? { partnerApplicationId }
+    : {};
+}
+
+function requireNonEmpty(value: string, fieldName: string): string {
+  if (!value.trim()) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return value;
+}

--- a/packages/developer-sdk/src/ramp/customer.ts
+++ b/packages/developer-sdk/src/ramp/customer.ts
@@ -1,19 +1,16 @@
 import type { RampCustomerContext } from '../types/ramp.js';
 
 export interface DirectSwigUserRampCustomerArgs {
-  organizationId: string;
   partnerApplicationId?: string;
   swigUserId: string;
 }
 
 export interface PartnerCustomerRampCustomerArgs {
-  organizationId: string;
   partnerApplicationId: string;
   externalCustomerId: string;
 }
 
 export interface PartnerBusinessRampCustomerArgs {
-  organizationId: string;
   partnerApplicationId: string;
   externalBusinessId: string;
 }
@@ -21,7 +18,6 @@ export interface PartnerBusinessRampCustomerArgs {
 export const rampCustomer = {
   directSwigUser(args: DirectSwigUserRampCustomerArgs): RampCustomerContext {
     return {
-      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
       ...optionalPartnerApplicationId(args.partnerApplicationId),
       swigUserId: requireNonEmpty(args.swigUserId, 'swigUserId'),
       customerType: 'individual',
@@ -30,7 +26,6 @@ export const rampCustomer = {
 
   partnerCustomer(args: PartnerCustomerRampCustomerArgs): RampCustomerContext {
     return {
-      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
       partnerApplicationId: requireNonEmpty(
         args.partnerApplicationId,
         'partnerApplicationId',
@@ -45,7 +40,6 @@ export const rampCustomer = {
 
   partnerBusiness(args: PartnerBusinessRampCustomerArgs): RampCustomerContext {
     return {
-      organizationId: requireNonEmpty(args.organizationId, 'organizationId'),
       partnerApplicationId: requireNonEmpty(
         args.partnerApplicationId,
         'partnerApplicationId',

--- a/packages/developer-sdk/src/ramp/index.ts
+++ b/packages/developer-sdk/src/ramp/index.ts
@@ -1,0 +1,8 @@
+export { RampClient } from './client.js';
+export { rampCustomer } from './customer.js';
+
+export type {
+  DirectSwigUserRampCustomerArgs,
+  PartnerBusinessRampCustomerArgs,
+  PartnerCustomerRampCustomerArgs,
+} from './customer.js';

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -724,7 +724,7 @@ describe('createSwigFetchHandler', () => {
         method: 'POST',
         body: JSON.stringify({
           customer: {
-            organizationId: 'org_123',
+            swigUserId: 'user_123',
             customerType: 'individual',
           },
           wallet: {
@@ -757,7 +757,7 @@ describe('createSwigFetchHandler', () => {
       method: 'POST',
       body: {
         customer: {
-          organizationId: 'org_123',
+          swigUserId: 'user_123',
           customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
         },
         wallet: {
@@ -784,7 +784,6 @@ describe('createSwigFetchHandler', () => {
           externalCustomerId: 'browser_customer',
         });
         return {
-          organizationId: 'server_org',
           partnerApplicationId: 'server_app',
           externalCustomerId: 'server_customer',
           customerType: 'individual',
@@ -825,13 +824,16 @@ describe('createSwigFetchHandler', () => {
       url: 'http://localhost:8080/wallet/api/ramp/quote',
       body: {
         customer: {
-          organizationId: 'server_org',
           partnerApplicationId: 'server_app',
           externalCustomerId: 'server_customer',
           customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
         },
       },
     });
+    const forwardedCustomer = (calls[0]!.body as Record<string, unknown>)
+      .customer as Record<string, unknown>;
+    expect(forwardedCustomer).not.toHaveProperty('organizationId');
+    expect(forwardedCustomer).not.toHaveProperty('organization_id');
   });
 
   test('resolves ramp customer context server-side for session requests', async () => {
@@ -840,7 +842,6 @@ describe('createSwigFetchHandler', () => {
       apiKey: 'sk_test',
       transactionApiUrl: 'http://localhost:8080',
       resolveRampCustomer: () => ({
-        organizationId: 'server_org',
         swigUserId: 'swig_user_123',
         customerType: 'individual',
       }),
@@ -890,13 +891,16 @@ describe('createSwigFetchHandler', () => {
       url: 'http://localhost:8080/wallet/api/ramp/sessions',
       body: {
         customer: {
-          organizationId: 'server_org',
           swigUserId: 'swig_user_123',
           customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
         },
         selectedQuoteId: 'quote_123',
       },
     });
+    const forwardedCustomer = (calls[0]!.body as Record<string, unknown>)
+      .customer as Record<string, unknown>;
+    expect(forwardedCustomer).not.toHaveProperty('organizationId');
+    expect(forwardedCustomer).not.toHaveProperty('organization_id');
   });
 });
 
@@ -1030,7 +1034,6 @@ describe('createSwigGetHandler', () => {
       resolveRampCustomer: ({ route }) => {
         expect(route).toBe('ramp/options');
         return {
-          organizationId: 'server_org',
           partnerApplicationId: 'server_app',
           customerType: 'individual',
         };
@@ -1059,7 +1062,44 @@ describe('createSwigGetHandler', () => {
       fiatCurrencyCodes: ['USD'],
     });
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/wallet/api/ramp/options?organizationId=server_org&partnerApplicationId=server_app&countryCode=US&fiatCurrencyCode=USD',
+      url: 'http://localhost:8080/wallet/api/ramp/options?partnerApplicationId=server_app&countryCode=US&fiatCurrencyCode=USD',
+      method: 'GET',
+    });
+  });
+
+  test('proxies ramp options without an organization id', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      resolveRampCustomer: ({ route }) => {
+        expect(route).toBe('ramp/options');
+        return {
+          partnerApplicationId: 'server_app',
+          customerType: 'individual',
+        };
+      },
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          country_codes: ['US'],
+          fiat_currency_codes: ['USD'],
+          payment_method_types: ['RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD'],
+          crypto_currency_codes: ['USDC_SOLANA'],
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/ramp/options?countryCode=US&fiatCurrencyCode=USD',
+        { method: 'GET' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/options?partnerApplicationId=server_app&countryCode=US&fiatCurrencyCode=USD',
       method: 'GET',
     });
   });

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -423,6 +423,45 @@ describe('createSwigFetchHandler', () => {
     });
   });
 
+  test('supports legacy requester pubkey resolvers', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: 'payer_123',
+      resolveRequesterPubkey: ({ wallet }) => {
+        expect(wallet?.roleId).toBe(2);
+        return 'requester_123';
+      },
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transaction: 'base64-transfer-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+        };
+      }),
+    });
+
+    await handler(
+      new Request('https://app.example/api/swig/transfer/sol', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            roleId: 2,
+          },
+          network: 'devnet',
+          destination: 'destination_123',
+          amount: '42',
+        }),
+      }),
+    );
+
+    expect(calls[0]?.body).toMatchObject({
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+  });
+
   test('prepares grouped operations through the API-key server client', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({
@@ -650,6 +689,215 @@ describe('createSwigFetchHandler', () => {
       },
     });
   });
+
+  test('proxies ramp quote requests without exposing the API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          quotes: [
+            {
+              quote_id: 'quote_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              payment_method_type: 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_amount: '99.00',
+              destination_currency_code: 'USDC_SOLANA',
+              exchange_rate: '0.99',
+              total_fee: '1.00',
+              network_fee: '0.10',
+              transaction_fee: '0.70',
+              partner_fee: '0.20',
+            },
+          ],
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/ramp/quote', {
+        method: 'POST',
+        body: JSON.stringify({
+          customer: {
+            organizationId: 'org_123',
+            customerType: 'individual',
+          },
+          wallet: {
+            walletId: 'wallet_123',
+            walletAddress: 'wallet_address_123',
+            network: 'devnet',
+          },
+          direction: 'onramp',
+          sourceAmount: '100.00',
+          sourceCurrencyCode: 'USD',
+          destinationCurrencyCode: 'USDC_SOLANA',
+          countryCode: 'US',
+          paymentMethodType: 'credit-debit-card',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      quotes: [
+        {
+          quoteId: 'quote_123',
+          direction: 'onramp',
+          paymentMethodType: 'credit-debit-card',
+        },
+      ],
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/quote',
+      method: 'POST',
+      body: {
+        customer: {
+          organizationId: 'org_123',
+          customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
+        },
+        wallet: {
+          walletId: 'wallet_123',
+          walletAddress: 'wallet_address_123',
+          network: 'NETWORK_DEVNET',
+        },
+        direction: 'RAMP_DIRECTION_ONRAMP',
+        paymentMethodType: 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD',
+      },
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+  });
+
+  test('resolves ramp customer context server-side for quote requests', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      resolveRampCustomer: ({ route, body }) => {
+        expect(route).toBe('ramp/quote');
+        expect(body.customer).toMatchObject({
+          organizationId: 'browser_org',
+          externalCustomerId: 'browser_customer',
+        });
+        return {
+          organizationId: 'server_org',
+          partnerApplicationId: 'server_app',
+          externalCustomerId: 'server_customer',
+          customerType: 'individual',
+        };
+      },
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return { quotes: [] };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/ramp/quote', {
+        method: 'POST',
+        body: JSON.stringify({
+          customer: {
+            organizationId: 'browser_org',
+            partnerApplicationId: 'browser_app',
+            externalCustomerId: 'browser_customer',
+            customerType: 'business',
+          },
+          wallet: {
+            walletId: 'wallet_123',
+            walletAddress: 'wallet_address_123',
+            network: 'devnet',
+          },
+          direction: 'onramp',
+          sourceAmount: '100.00',
+          sourceCurrencyCode: 'USD',
+          destinationCurrencyCode: 'USDC_SOLANA',
+          countryCode: 'US',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/quote',
+      body: {
+        customer: {
+          organizationId: 'server_org',
+          partnerApplicationId: 'server_app',
+          externalCustomerId: 'server_customer',
+          customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
+        },
+      },
+    });
+  });
+
+  test('resolves ramp customer context server-side for session requests', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      resolveRampCustomer: () => ({
+        organizationId: 'server_org',
+        swigUserId: 'swig_user_123',
+        customerType: 'individual',
+      }),
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          local_session_id: 'session_123',
+          meld_session_id: 'meld_session_123',
+          external_customer_id: 'swig:user:swig_user_123',
+          external_session_id: 'external_session_123',
+          launch_url: 'https://checkout.example/session_123',
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/ramp/sessions', {
+        method: 'POST',
+        body: JSON.stringify({
+          customer: {
+            organizationId: 'browser_org',
+            externalCustomerId: 'browser_customer',
+            customerType: 'business',
+          },
+          wallet: {
+            walletId: 'wallet_123',
+            walletAddress: 'wallet_address_123',
+            network: 'devnet',
+          },
+          direction: 'onramp',
+          selectedQuoteId: 'quote_123',
+          sourceAmount: '100.00',
+          sourceCurrencyCode: 'USD',
+          destinationCurrencyCode: 'USDC_SOLANA',
+          countryCode: 'US',
+          serviceProvider: 'other',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      localSessionId: 'session_123',
+      externalCustomerId: 'swig:user:swig_user_123',
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/sessions',
+      body: {
+        customer: {
+          organizationId: 'server_org',
+          swigUserId: 'swig_user_123',
+          customerType: 'RAMP_CUSTOMER_TYPE_INDIVIDUAL',
+        },
+        selectedQuoteId: 'quote_123',
+      },
+    });
+  });
 });
 
 describe('createSwigGetHandler', () => {
@@ -769,6 +1017,99 @@ describe('createSwigGetHandler', () => {
     });
     expect(calls[0]).toMatchObject({
       url: 'http://localhost:8080/paymaster/balance?network=devnet&kind=PAYMASTER_KIND_IDP',
+      method: 'GET',
+    });
+    expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');
+  });
+
+  test('resolves ramp customer context server-side for options reads', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      resolveRampCustomer: ({ route }) => {
+        expect(route).toBe('ramp/options');
+        return {
+          organizationId: 'server_org',
+          partnerApplicationId: 'server_app',
+          customerType: 'individual',
+        };
+      },
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          country_codes: ['US'],
+          fiat_currency_codes: ['USD'],
+          payment_method_types: ['RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD'],
+          crypto_currency_codes: ['USDC_SOLANA'],
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/ramp/options?organizationId=browser_org&partnerApplicationId=browser_app&countryCode=US&fiatCurrencyCode=USD',
+        { method: 'GET' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      countryCodes: ['US'],
+      fiatCurrencyCodes: ['USD'],
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/options?organizationId=server_org&partnerApplicationId=server_app&countryCode=US&fiatCurrencyCode=USD',
+      method: 'GET',
+    });
+  });
+
+  test('proxies ramp transaction history reads without exposing the API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigGetHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transactions: [
+            {
+              transaction_id: 'txn_123',
+              wallet_id: 'wallet_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              transaction_type: 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE',
+              status: 'RAMP_TRANSACTION_STATUS_PENDING',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_currency_code: 'USDC_SOLANA',
+              created_at: '2026-06-06T00:00:00Z',
+              updated_at: '2026-06-06T00:01:00Z',
+            },
+          ],
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request(
+        'https://app.example/api/swig/ramp/wallets/wallet_123/transactions?network=NETWORK_DEVNET&direction=RAMP_DIRECTION_ONRAMP&status=RAMP_TRANSACTION_STATUS_PENDING&limit=25',
+        { method: 'GET' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      transactions: [
+        {
+          transactionId: 'txn_123',
+          status: 'pending',
+          transactionType: 'crypto-purchase',
+        },
+      ],
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/wallets/wallet_123/transactions?network=NETWORK_DEVNET&direction=RAMP_DIRECTION_ONRAMP&status=RAMP_TRANSACTION_STATUS_PENDING&limit=25',
       method: 'GET',
     });
     expect(calls[0]?.headers.get('authorization')).toBe('Bearer sk_test');

--- a/packages/developer-sdk/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/src/server/fetch/index.test.ts
@@ -863,7 +863,9 @@ describe('createSwigFetchHandler', () => {
         body: JSON.stringify({
           customer: {
             organizationId: 'browser_org',
+            partnerApplicationId: 'browser_app',
             externalCustomerId: 'browser_customer',
+            externalBusinessId: 'browser_business',
             customerType: 'business',
           },
           wallet: {
@@ -901,10 +903,65 @@ describe('createSwigFetchHandler', () => {
       .customer as Record<string, unknown>;
     expect(forwardedCustomer).not.toHaveProperty('organizationId');
     expect(forwardedCustomer).not.toHaveProperty('organization_id');
+    expect(forwardedCustomer).not.toHaveProperty('partnerApplicationId');
+    expect(forwardedCustomer).not.toHaveProperty('externalCustomerId');
+    expect(forwardedCustomer).not.toHaveProperty('externalBusinessId');
   });
 });
 
 describe('createSwigGetHandler', () => {
+  test('uses SWIG_BACKEND_URL as a deprecated transaction API fallback', async () => {
+    const previousTransactionApiUrl = process.env.SWIG_TRANSACTION_API_URL;
+    const previousBackendUrl = process.env.SWIG_BACKEND_URL;
+    const previousPublicBackendUrl = process.env.NEXT_PUBLIC_SWIG_BACKEND_URL;
+    delete process.env.SWIG_TRANSACTION_API_URL;
+    process.env.SWIG_BACKEND_URL = 'http://localhost:8080';
+    delete process.env.NEXT_PUBLIC_SWIG_BACKEND_URL;
+
+    try {
+      const calls: CapturedRequest[] = [];
+      const handler = createSwigGetHandler({
+        apiKey: 'sk_test',
+        fetch: jsonFetch((request) => {
+          calls.push(request);
+          return {
+            kind: 'idp',
+            address: 'paymaster_address_123',
+            balanceSol: 5,
+          };
+        }),
+      });
+
+      const response = await handler(
+        new Request('https://app.example/api/swig/paymaster/balance', {
+          method: 'GET',
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(calls[0]).toMatchObject({
+        url: 'http://localhost:8080/paymaster/balance',
+        method: 'GET',
+      });
+    } finally {
+      if (previousTransactionApiUrl === undefined) {
+        delete process.env.SWIG_TRANSACTION_API_URL;
+      } else {
+        process.env.SWIG_TRANSACTION_API_URL = previousTransactionApiUrl;
+      }
+      if (previousBackendUrl === undefined) {
+        delete process.env.SWIG_BACKEND_URL;
+      } else {
+        process.env.SWIG_BACKEND_URL = previousBackendUrl;
+      }
+      if (previousPublicBackendUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_SWIG_BACKEND_URL;
+      } else {
+        process.env.NEXT_PUBLIC_SWIG_BACKEND_URL = previousPublicBackendUrl;
+      }
+    }
+  });
+
   test('proxies wallet USD balance reads with the configured API key', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigGetHandler({

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -1,10 +1,14 @@
 import type {
   Amount,
+  CreateRampSessionArgs,
   CreateWalletArgs,
+  GetRampOptionsArgs,
   Network,
   PaymasterBalanceKind,
   PrepareArgs,
   PrepareOperation,
+  QuoteRampArgs,
+  RampCustomerContext,
   SwapArgs,
   TransferTokenArgs,
   WalletAuthority,
@@ -17,13 +21,18 @@ export type SwigPostProxyRoute =
   | 'prepare'
   | 'transfer/sol'
   | 'transfer/spl-token'
-  | 'swap/jupiter';
+  | 'swap/jupiter'
+  | 'ramp/quote'
+  | 'ramp/sessions';
 
 export type SwigReadProxyRoute =
   | 'wallet/balance/usd'
   | 'wallet/token-balances'
   | 'wallet/token-transactions'
-  | 'paymaster/balance';
+  | 'paymaster/balance'
+  | 'ramp/options'
+  | 'ramp/transaction'
+  | 'ramp/wallet-transactions';
 
 export type SwigProxyRoute = SwigPostProxyRoute | SwigReadProxyRoute;
 
@@ -54,6 +63,12 @@ export interface CreateSwigFetchHandlerConfig {
   resolveRequesterAuthority?: (
     context: SwigRouteContext,
   ) => MaybePromise<WalletAuthority | undefined>;
+  resolveRequesterPubkey?: (
+    context: SwigRouteContext,
+  ) => MaybePromise<string | undefined>;
+  resolveRampCustomer?: (
+    context: SwigRouteContext,
+  ) => MaybePromise<RampCustomerContext | undefined>;
   fetch?: typeof fetch;
 }
 
@@ -74,6 +89,8 @@ const swigPostProxyRoutes: SwigPostProxyRoute[] = [
   'transfer/sol',
   'transfer/spl-token',
   'swap/jupiter',
+  'ramp/quote',
+  'ramp/sessions',
 ];
 
 export type SwigFetchHandler = (request: Request) => Promise<Response>;
@@ -98,7 +115,9 @@ async function handlePost(
     const route = resolvePostRoute(request);
     const body = await readJsonObject(request);
     const network = readNetwork(body.network) ?? config.network;
-    const wallet = readWallet(body.wallet);
+    const wallet = route.startsWith('ramp/')
+      ? undefined
+      : readWallet(body.wallet);
     const context: SwigRouteContext = {
       request,
       route,
@@ -136,6 +155,26 @@ async function handlePost(
         return json({
           prepared: await prepareJupiterSwap(swig, body, context, config),
         });
+      case 'ramp/quote':
+        return json(
+          await swig.ramp.quote(
+            (await bodyWithResolvedRampCustomer(
+              body,
+              context,
+              config,
+            )) as unknown as QuoteRampArgs,
+          ),
+        );
+      case 'ramp/sessions':
+        return json(
+          await swig.ramp.createSession(
+            (await bodyWithResolvedRampCustomer(
+              body,
+              context,
+              config,
+            )) as unknown as CreateRampSessionArgs,
+          ),
+        );
     }
   } catch (error) {
     const message =
@@ -162,6 +201,12 @@ async function handleGet(
       ...(network ? { network } : {}),
       ...(config.fetch ? { fetch: config.fetch } : {}),
     });
+    const context: SwigRouteContext = {
+      request,
+      route: route.route,
+      body: {},
+      network,
+    };
 
     switch (route.route) {
       case 'wallet/balance/usd':
@@ -191,6 +236,24 @@ async function handleGet(
         return json(
           await swig.paymaster.getBalance(
             paymasterOptions(network, paymasterKind),
+          ),
+        );
+      case 'ramp/options':
+        return json(
+          await swig.ramp.getOptions(
+            await readRampOptionsArgs(request, context, config),
+          ),
+        );
+      case 'ramp/transaction':
+        return json(
+          await swig.ramp.getTransaction({
+            transactionId: route.transactionId,
+          }),
+        );
+      case 'ramp/wallet-transactions':
+        return json(
+          await swig.ramp.listTransactions(
+            readListRampTransactionsArgs(request, route.walletId),
           ),
         );
     }
@@ -435,13 +498,22 @@ async function resolveRequesterAuthority(
       context.body.requesterAuthority,
       'requesterAuthority',
     ) ??
-    (await config.resolveRequesterAuthority?.(context));
+    (await config.resolveRequesterAuthority?.(context)) ??
+    (await resolveLegacyRequesterAuthority(context, config));
 
   if (!requesterAuthority) {
     throw new SwigRouteError('requesterAuthority is required');
   }
 
   return requesterAuthority;
+}
+
+async function resolveLegacyRequesterAuthority(
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+): Promise<WalletAuthority | undefined> {
+  const publicKey = await config.resolveRequesterPubkey?.(context);
+  return publicKey ? { ed25519: { publicKey } } : undefined;
 }
 
 async function resolveFeePayer(
@@ -509,13 +581,39 @@ function resolveReadRoute(
   | { route: 'wallet/balance/usd'; swigConfigAddress: string }
   | { route: 'wallet/token-balances'; swigConfigAddress: string }
   | { route: 'wallet/token-transactions'; swigConfigAddress: string }
-  | { route: 'paymaster/balance' } {
+  | { route: 'paymaster/balance' }
+  | { route: 'ramp/options' }
+  | { route: 'ramp/transaction'; transactionId: string }
+  | { route: 'ramp/wallet-transactions'; walletId: string } {
   const pathname = new URL(request.url).pathname.replace(/\/$/, '');
   if (
     pathname === '/paymaster/balance' ||
     pathname.endsWith('/paymaster/balance')
   ) {
     return { route: 'paymaster/balance' };
+  }
+  if (pathname === '/ramp/options' || pathname.endsWith('/ramp/options')) {
+    return { route: 'ramp/options' };
+  }
+
+  const rampTransactionMatch = pathname.match(/\/ramp\/transactions\/([^/]+)$/);
+  if (rampTransactionMatch) {
+    const transactionId = decodeURIComponent(rampTransactionMatch[1] ?? '');
+    if (!transactionId) {
+      throw new SwigRouteError('transactionId is required');
+    }
+    return { route: 'ramp/transaction', transactionId };
+  }
+
+  const rampWalletTransactionsMatch = pathname.match(
+    /\/ramp\/wallets\/([^/]+)\/transactions$/,
+  );
+  if (rampWalletTransactionsMatch) {
+    const walletId = decodeURIComponent(rampWalletTransactionsMatch[1] ?? '');
+    if (!walletId) {
+      throw new SwigRouteError('walletId is required');
+    }
+    return { route: 'ramp/wallet-transactions', walletId };
   }
 
   const match = pathname.match(
@@ -540,6 +638,70 @@ function resolveReadRoute(
     default:
       throw new SwigRouteError('Unsupported Swig route', 404);
   }
+}
+
+async function readRampOptionsArgs(
+  request: Request,
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+): Promise<GetRampOptionsArgs> {
+  const resolvedCustomer = await config.resolveRampCustomer?.(context);
+  return {
+    organizationId:
+      resolvedCustomer?.organizationId ??
+      readRequiredQueryString(request, 'organizationId'),
+    partnerApplicationId:
+      resolvedCustomer?.partnerApplicationId ??
+      readOptionalQueryString(request, 'partnerApplicationId'),
+    countryCode: readOptionalQueryString(request, 'countryCode'),
+    fiatCurrencyCode: readOptionalQueryString(request, 'fiatCurrencyCode'),
+  };
+}
+
+async function bodyWithResolvedRampCustomer(
+  body: Record<string, unknown>,
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+): Promise<Record<string, unknown>> {
+  const resolvedCustomer = await config.resolveRampCustomer?.(context);
+  if (!resolvedCustomer) {
+    return body;
+  }
+
+  return {
+    ...body,
+    customer: {
+      ...(isRecord(body.customer) ? body.customer : {}),
+      ...resolvedCustomer,
+    },
+  };
+}
+
+function readListRampTransactionsArgs(request: Request, walletId: string) {
+  const network = readNetwork(new URL(request.url).searchParams.get('network'));
+  if (!network) {
+    throw new SwigRouteError('network is required');
+  }
+  return {
+    walletId,
+    network,
+    direction: readOptionalQueryString(request, 'direction') as
+      | 'onramp'
+      | 'offramp'
+      | 'transfer'
+      | undefined,
+    status: readOptionalQueryString(request, 'status') as
+      | 'created'
+      | 'pending'
+      | 'settling'
+      | 'settled'
+      | 'failed'
+      | 'declined'
+      | 'cancelled'
+      | 'refunded'
+      | undefined,
+    limit: readOptionalQueryNumber(request, 'limit'),
+  };
 }
 
 async function readJsonObject(
@@ -672,10 +834,20 @@ function readAmount(body: Record<string, unknown>): Amount {
 }
 
 function readNetwork(value: unknown): Network | undefined {
-  if (value === 'devnet' || value === 'mainnet') {
-    return value;
+  switch (value) {
+    case 'devnet':
+    case 'NETWORK_DEVNET':
+    case 1:
+    case '1':
+      return 'devnet';
+    case 'mainnet':
+    case 'NETWORK_MAINNET':
+    case 2:
+    case '2':
+      return 'mainnet';
+    default:
+      return undefined;
   }
-  return undefined;
 }
 
 function readPaymasterBalanceKind(
@@ -743,6 +915,22 @@ function readOptionalQueryNumber(
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readRequiredQueryString(request: Request, key: string): string {
+  const value = readOptionalQueryString(request, key);
+  if (!value) {
+    throw new SwigRouteError(`${key} is required`);
+  }
+  return value;
+}
+
+function readOptionalQueryString(
+  request: Request,
+  key: string,
+): string | undefined {
+  const value = new URL(request.url).searchParams.get(key);
+  return value && value.trim() ? value.trim() : undefined;
 }
 
 function readEnv(...names: string[]): string | undefined {

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -553,7 +553,11 @@ function resolveTransactionApiUrl(config: CreateSwigFetchHandlerConfig) {
   return (
     config.transactionApiUrl ??
     config.baseUrl ??
-    readEnv('SWIG_TRANSACTION_API_URL', 'NEXT_PUBLIC_SWIG_BACKEND_URL')
+    readEnv(
+      'SWIG_TRANSACTION_API_URL',
+      'SWIG_BACKEND_URL',
+      'NEXT_PUBLIC_SWIG_BACKEND_URL',
+    )
   );
 }
 
@@ -663,24 +667,8 @@ async function bodyWithResolvedRampCustomer(
 
   return {
     ...body,
-    customer: {
-      ...rampCustomerBodyWithoutOrganization(body.customer),
-      ...resolvedCustomer,
-    },
+    customer: resolvedCustomer,
   };
-}
-
-function rampCustomerBodyWithoutOrganization(
-  value: unknown,
-): Record<string, unknown> {
-  if (!isRecord(value)) {
-    return {};
-  }
-
-  const customer = { ...value };
-  delete customer.organizationId;
-  delete customer.organization_id;
-  return customer;
 }
 
 function readListRampTransactionsArgs(request: Request, walletId: string) {

--- a/packages/developer-sdk/src/server/fetch/index.ts
+++ b/packages/developer-sdk/src/server/fetch/index.ts
@@ -553,11 +553,7 @@ function resolveTransactionApiUrl(config: CreateSwigFetchHandlerConfig) {
   return (
     config.transactionApiUrl ??
     config.baseUrl ??
-    readEnv(
-      'SWIG_TRANSACTION_API_URL',
-      'SWIG_BACKEND_URL',
-      'NEXT_PUBLIC_SWIG_BACKEND_URL',
-    )
+    readEnv('SWIG_TRANSACTION_API_URL', 'NEXT_PUBLIC_SWIG_BACKEND_URL')
   );
 }
 
@@ -647,9 +643,6 @@ async function readRampOptionsArgs(
 ): Promise<GetRampOptionsArgs> {
   const resolvedCustomer = await config.resolveRampCustomer?.(context);
   return {
-    organizationId:
-      resolvedCustomer?.organizationId ??
-      readRequiredQueryString(request, 'organizationId'),
     partnerApplicationId:
       resolvedCustomer?.partnerApplicationId ??
       readOptionalQueryString(request, 'partnerApplicationId'),
@@ -671,10 +664,23 @@ async function bodyWithResolvedRampCustomer(
   return {
     ...body,
     customer: {
-      ...(isRecord(body.customer) ? body.customer : {}),
+      ...rampCustomerBodyWithoutOrganization(body.customer),
       ...resolvedCustomer,
     },
   };
+}
+
+function rampCustomerBodyWithoutOrganization(
+  value: unknown,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const customer = { ...value };
+  delete customer.organizationId;
+  delete customer.organization_id;
+  return customer;
 }
 
 function readListRampTransactionsArgs(request: Request, walletId: string) {
@@ -915,14 +921,6 @@ function readOptionalQueryNumber(
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function readRequiredQueryString(request: Request, key: string): string {
-  const value = readOptionalQueryString(request, key);
-  if (!value) {
-    throw new SwigRouteError(`${key} is required`);
-  }
-  return value;
 }
 
 function readOptionalQueryString(

--- a/packages/developer-sdk/src/server/index.ts
+++ b/packages/developer-sdk/src/server/index.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_BACKEND_URL, SwigDeveloperSdkError } from '../core/index.js';
+export { RampClient, rampCustomer } from '../ramp/index.js';
 export { TransactionsClient } from '../transactions/index.js';
 export { WalletHandle, WalletsClient } from '../wallets/index.js';
 export {
@@ -11,14 +12,22 @@ export type {
   Amount,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
+  CreateRampSessionArgs,
+  CreateRampSessionResult,
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
   ExecuteArgs,
   ExecuteRecoveryArgs,
+  GetRampOptionsArgs,
+  GetRampOptionsResult,
+  GetRampTransactionArgs,
+  GetRampTransactionResult,
   IdpWalletSession,
   JsonObject,
   JsonValue,
+  ListRampTransactionsArgs,
+  ListRampTransactionsResult,
   Network,
   Policy,
   PolicyAuthority,
@@ -27,6 +36,18 @@ export type {
   PreparedTransaction,
   PreparedTransactionWire,
   PreparedTransactionsResult,
+  QuoteRampArgs,
+  QuoteRampResult,
+  RampCustomerContext,
+  RampCustomerType,
+  RampDirection,
+  RampPaymentMethodType,
+  RampQuote,
+  RampServiceProvider,
+  RampTransaction,
+  RampTransactionStatus,
+  RampTransactionType,
+  RampWalletContext,
   RecoverySetupPlan,
   RetryOptions,
   SponsorSignedTransactionArgs,
@@ -41,3 +62,9 @@ export type {
   WalletHandleOptions,
   WalletReference,
 } from '../types/index.js';
+
+export type {
+  DirectSwigUserRampCustomerArgs,
+  PartnerBusinessRampCustomerArgs,
+  PartnerCustomerRampCustomerArgs,
+} from '../ramp/index.js';

--- a/packages/developer-sdk/src/server/nest/index.test.ts
+++ b/packages/developer-sdk/src/server/nest/index.test.ts
@@ -190,4 +190,60 @@ describe('createSwigNestHandler', () => {
       },
     });
   });
+
+  test('adapts Nest GET requests to the read proxy handler', async () => {
+    const calls: CapturedRequest[] = [];
+    const handler = createSwigNestHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transactions: [
+            {
+              transaction_id: 'txn_123',
+              wallet_id: 'wallet_123',
+              direction: 'RAMP_DIRECTION_ONRAMP',
+              transaction_type: 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE',
+              status: 'RAMP_TRANSACTION_STATUS_PENDING',
+              service_provider: 'RAMP_SERVICE_PROVIDER_OTHER',
+              source_amount: '100.00',
+              source_currency_code: 'USD',
+              destination_currency_code: 'USDC_SOLANA',
+              created_at: '2026-06-06T00:00:00Z',
+              updated_at: '2026-06-06T00:01:00Z',
+            },
+          ],
+        };
+      }),
+    });
+    const response = new TestNestResponse();
+
+    await handler(
+      {
+        headers: {
+          host: 'api.example.com',
+        },
+        method: 'GET',
+        originalUrl:
+          '/swig/ramp/wallets/wallet_123/transactions?network=devnet&direction=onramp',
+        protocol: 'https',
+      },
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body ?? '{}')).toMatchObject({
+      transactions: [
+        {
+          transactionId: 'txn_123',
+          status: 'pending',
+        },
+      ],
+    });
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/wallet/api/ramp/wallets/wallet_123/transactions?network=NETWORK_DEVNET&direction=RAMP_DIRECTION_ONRAMP',
+      method: 'GET',
+    });
+  });
 });

--- a/packages/developer-sdk/src/server/nest/index.ts
+++ b/packages/developer-sdk/src/server/nest/index.ts
@@ -1,5 +1,6 @@
 import {
   createSwigFetchHandler,
+  createSwigGetHandler,
   type CreateSwigFetchHandlerConfig,
 } from '../fetch/index.js';
 
@@ -31,9 +32,11 @@ export type SwigNestHandler = (
 export function createSwigNestHandler(
   config: CreateSwigNestHandlerConfig = {},
 ): SwigNestHandler {
-  const fetchHandler = createSwigFetchHandler(config);
+  const getHandler = createSwigGetHandler(config);
+  const postHandler = createSwigFetchHandler(config);
 
   return async (request, response) => {
+    const fetchHandler = request.method === 'GET' ? getHandler : postHandler;
     const fetchResponse = await fetchHandler(toFetchRequest(request));
     response.status(fetchResponse.status);
     fetchResponse.headers.forEach((value, name) => {

--- a/packages/developer-sdk/src/server/typescript/index.ts
+++ b/packages/developer-sdk/src/server/typescript/index.ts
@@ -4,6 +4,7 @@ import {
   resolveRetryOptions,
 } from '../../core/index.js';
 import { PaymasterClient } from '../../paymaster/index.js';
+import { RampClient } from '../../ramp/index.js';
 import { TransactionsClient } from '../../transactions/index.js';
 import type { SwigClientConfig } from '../../types/index.js';
 import { WalletsClient } from '../../wallets/index.js';
@@ -12,6 +13,7 @@ export class SwigClient {
   readonly #http: HttpClient;
   readonly defaultNetwork: SwigClientConfig['network'];
   readonly paymaster: PaymasterClient;
+  readonly ramp: RampClient;
   readonly transactions: TransactionsClient;
   readonly wallets: WalletsClient;
 
@@ -24,6 +26,7 @@ export class SwigClient {
       retry: resolveRetryOptions(config.retryOptions),
     });
     this.paymaster = new PaymasterClient(this.#http, this.defaultNetwork);
+    this.ramp = new RampClient(this.#http, this.defaultNetwork);
     this.transactions = new TransactionsClient(this.#http, this.defaultNetwork);
     this.wallets = new WalletsClient(this.#http, this.defaultNetwork);
   }

--- a/packages/developer-sdk/src/types/bs58.d.ts
+++ b/packages/developer-sdk/src/types/bs58.d.ts
@@ -1,0 +1,8 @@
+declare module 'bs58' {
+  const bs58: {
+    encode(input: Uint8Array | number[]): string;
+    decode(input: string): Uint8Array;
+  };
+
+  export default bs58;
+}

--- a/packages/developer-sdk/src/types/index.ts
+++ b/packages/developer-sdk/src/types/index.ts
@@ -5,6 +5,7 @@ export type * from './instruction.js';
 export type * from './passkeys.js';
 export type * from './paymaster.js';
 export type * from './policy.js';
+export type * from './ramp.js';
 export type * from './transaction.js';
 export type * from './wallet-actions.js';
 export type * from './wallet.js';

--- a/packages/developer-sdk/src/types/ramp.ts
+++ b/packages/developer-sdk/src/types/ramp.ts
@@ -87,7 +87,6 @@ export type RampPaymentMethodTypeWire =
   | number;
 
 export interface RampCustomerContext {
-  organizationId: string;
   partnerApplicationId?: string;
   swigUserId?: string;
   externalCustomerId?: string;
@@ -125,7 +124,6 @@ export interface RampWalletContextWire {
 }
 
 export interface GetRampOptionsArgs {
-  organizationId: string;
   partnerApplicationId?: string;
   countryCode?: string;
   fiatCurrencyCode?: string;

--- a/packages/developer-sdk/src/types/ramp.ts
+++ b/packages/developer-sdk/src/types/ramp.ts
@@ -1,0 +1,365 @@
+import type { Network } from './common.js';
+import type { NetworkWire } from './transaction.js';
+
+export type RampDirection = 'onramp' | 'offramp' | 'transfer' | 'unspecified';
+export type RampDirectionWire =
+  | RampDirection
+  | 'RAMP_DIRECTION_UNSPECIFIED'
+  | 'RAMP_DIRECTION_ONRAMP'
+  | 'RAMP_DIRECTION_OFFRAMP'
+  | 'RAMP_DIRECTION_TRANSFER'
+  | number;
+
+export type RampCustomerType = 'individual' | 'business' | 'unspecified';
+export type RampCustomerTypeWire =
+  | RampCustomerType
+  | 'RAMP_CUSTOMER_TYPE_UNSPECIFIED'
+  | 'RAMP_CUSTOMER_TYPE_INDIVIDUAL'
+  | 'RAMP_CUSTOMER_TYPE_BUSINESS'
+  | number;
+
+export type RampTransactionType =
+  | 'crypto-purchase'
+  | 'crypto-sell'
+  | 'crypto-purchase-swap'
+  | 'crypto-sell-swap'
+  | 'transfer'
+  | 'unspecified';
+export type RampTransactionTypeWire =
+  | RampTransactionType
+  | 'RAMP_TRANSACTION_TYPE_UNSPECIFIED'
+  | 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE'
+  | 'RAMP_TRANSACTION_TYPE_CRYPTO_SELL'
+  | 'RAMP_TRANSACTION_TYPE_CRYPTO_PURCHASE_SWAP'
+  | 'RAMP_TRANSACTION_TYPE_CRYPTO_SELL_SWAP'
+  | 'RAMP_TRANSACTION_TYPE_TRANSFER'
+  | number;
+
+export type RampTransactionStatus =
+  | 'created'
+  | 'pending'
+  | 'settling'
+  | 'settled'
+  | 'failed'
+  | 'declined'
+  | 'cancelled'
+  | 'refunded'
+  | 'unspecified';
+export type RampTransactionStatusWire =
+  | RampTransactionStatus
+  | 'RAMP_TRANSACTION_STATUS_UNSPECIFIED'
+  | 'RAMP_TRANSACTION_STATUS_CREATED'
+  | 'RAMP_TRANSACTION_STATUS_PENDING'
+  | 'RAMP_TRANSACTION_STATUS_SETTLING'
+  | 'RAMP_TRANSACTION_STATUS_SETTLED'
+  | 'RAMP_TRANSACTION_STATUS_FAILED'
+  | 'RAMP_TRANSACTION_STATUS_DECLINED'
+  | 'RAMP_TRANSACTION_STATUS_CANCELLED'
+  | 'RAMP_TRANSACTION_STATUS_REFUNDED'
+  | number;
+
+export type RampServiceProvider = 'other' | 'unspecified';
+export type RampServiceProviderWire =
+  | RampServiceProvider
+  | 'RAMP_SERVICE_PROVIDER_UNSPECIFIED'
+  | 'RAMP_SERVICE_PROVIDER_OTHER'
+  | number;
+
+export type RampPaymentMethodType =
+  | 'other'
+  | 'credit-debit-card'
+  | 'ach'
+  | 'bank-transfer'
+  | 'apple-pay'
+  | 'google-pay'
+  | 'pix'
+  | 'unspecified';
+export type RampPaymentMethodTypeWire =
+  | RampPaymentMethodType
+  | 'RAMP_PAYMENT_METHOD_TYPE_UNSPECIFIED'
+  | 'RAMP_PAYMENT_METHOD_TYPE_OTHER'
+  | 'RAMP_PAYMENT_METHOD_TYPE_CREDIT_DEBIT_CARD'
+  | 'RAMP_PAYMENT_METHOD_TYPE_ACH'
+  | 'RAMP_PAYMENT_METHOD_TYPE_BANK_TRANSFER'
+  | 'RAMP_PAYMENT_METHOD_TYPE_APPLE_PAY'
+  | 'RAMP_PAYMENT_METHOD_TYPE_GOOGLE_PAY'
+  | 'RAMP_PAYMENT_METHOD_TYPE_PIX'
+  | number;
+
+export interface RampCustomerContext {
+  organizationId: string;
+  partnerApplicationId?: string;
+  swigUserId?: string;
+  externalCustomerId?: string;
+  externalBusinessId?: string;
+  customerType: RampCustomerType;
+}
+
+export interface RampCustomerContextWire {
+  organization_id?: string;
+  organizationId?: string;
+  partner_application_id?: string;
+  partnerApplicationId?: string;
+  swig_user_id?: string;
+  swigUserId?: string;
+  external_customer_id?: string;
+  externalCustomerId?: string;
+  external_business_id?: string;
+  externalBusinessId?: string;
+  customer_type?: RampCustomerTypeWire;
+  customerType?: RampCustomerTypeWire;
+}
+
+export interface RampWalletContext {
+  walletId: string;
+  walletAddress: string;
+  network: Network;
+}
+
+export interface RampWalletContextWire {
+  wallet_id?: string;
+  walletId?: string;
+  wallet_address?: string;
+  walletAddress?: string;
+  network?: NetworkWire;
+}
+
+export interface GetRampOptionsArgs {
+  organizationId: string;
+  partnerApplicationId?: string;
+  countryCode?: string;
+  fiatCurrencyCode?: string;
+}
+
+export interface GetRampOptionsResult {
+  countryCodes: string[];
+  fiatCurrencyCodes: string[];
+  paymentMethodTypes: RampPaymentMethodType[];
+  cryptoCurrencyCodes: string[];
+}
+
+export interface GetRampOptionsResultWire {
+  country_codes?: string[];
+  countryCodes?: string[];
+  fiat_currency_codes?: string[];
+  fiatCurrencyCodes?: string[];
+  payment_method_types?: RampPaymentMethodTypeWire[];
+  paymentMethodTypes?: RampPaymentMethodTypeWire[];
+  crypto_currency_codes?: string[];
+  cryptoCurrencyCodes?: string[];
+}
+
+export interface QuoteRampArgs {
+  customer: RampCustomerContext;
+  wallet: RampWalletContext;
+  direction: Exclude<RampDirection, 'unspecified'>;
+  sourceAmount: string;
+  sourceCurrencyCode: string;
+  destinationCurrencyCode: string;
+  countryCode: string;
+  subdivision?: string;
+  paymentMethodType?: RampPaymentMethodType;
+  serviceProviders?: RampServiceProvider[];
+}
+
+export interface QuoteRampRequestWire {
+  customer?: RampCustomerContextWire;
+  wallet?: RampWalletContextWire;
+  direction?: RampDirectionWire;
+  sourceAmount?: string;
+  source_amount?: string;
+  sourceCurrencyCode?: string;
+  source_currency_code?: string;
+  destinationCurrencyCode?: string;
+  destination_currency_code?: string;
+  countryCode?: string;
+  country_code?: string;
+  subdivision?: string;
+  paymentMethodType?: RampPaymentMethodTypeWire;
+  payment_method_type?: RampPaymentMethodTypeWire;
+  serviceProviders?: RampServiceProviderWire[];
+  service_providers?: RampServiceProviderWire[];
+}
+
+export interface RampQuote {
+  quoteId: string;
+  direction: RampDirection;
+  serviceProvider: RampServiceProvider;
+  paymentMethodType: RampPaymentMethodType;
+  sourceAmount: string;
+  sourceCurrencyCode: string;
+  destinationAmount: string;
+  destinationCurrencyCode: string;
+  exchangeRate: string;
+  totalFee: string;
+  networkFee: string;
+  transactionFee: string;
+  partnerFee: string;
+  rampScore?: string;
+  lowKyc?: boolean;
+}
+
+export interface RampQuoteWire {
+  quote_id?: string;
+  quoteId?: string;
+  direction?: RampDirectionWire;
+  service_provider?: RampServiceProviderWire;
+  serviceProvider?: RampServiceProviderWire;
+  payment_method_type?: RampPaymentMethodTypeWire;
+  paymentMethodType?: RampPaymentMethodTypeWire;
+  source_amount?: string;
+  sourceAmount?: string;
+  source_currency_code?: string;
+  sourceCurrencyCode?: string;
+  destination_amount?: string;
+  destinationAmount?: string;
+  destination_currency_code?: string;
+  destinationCurrencyCode?: string;
+  exchange_rate?: string;
+  exchangeRate?: string;
+  total_fee?: string;
+  totalFee?: string;
+  network_fee?: string;
+  networkFee?: string;
+  transaction_fee?: string;
+  transactionFee?: string;
+  partner_fee?: string;
+  partnerFee?: string;
+  ramp_score?: string;
+  rampScore?: string;
+  low_kyc?: boolean;
+  lowKyc?: boolean;
+}
+
+export interface QuoteRampResult {
+  quotes: RampQuote[];
+}
+
+export interface QuoteRampResultWire {
+  quotes?: RampQuoteWire[];
+}
+
+export interface CreateRampSessionArgs {
+  customer: RampCustomerContext;
+  wallet: RampWalletContext;
+  direction: Exclude<RampDirection, 'unspecified'>;
+  selectedQuoteId: string;
+  sourceAmount: string;
+  sourceCurrencyCode: string;
+  destinationCurrencyCode: string;
+  countryCode: string;
+  subdivision?: string;
+  serviceProvider: RampServiceProvider;
+  paymentMethodType?: RampPaymentMethodType;
+  redirectUrl?: string;
+}
+
+export interface CreateRampSessionRequestWire extends QuoteRampRequestWire {
+  selectedQuoteId?: string;
+  selected_quote_id?: string;
+  serviceProvider?: RampServiceProviderWire;
+  service_provider?: RampServiceProviderWire;
+  redirectUrl?: string;
+  redirect_url?: string;
+}
+
+export interface CreateRampSessionResult {
+  localSessionId: string;
+  meldSessionId: string;
+  externalCustomerId: string;
+  externalSessionId: string;
+  launchUrl: string;
+  fallbackLaunchUrl?: string;
+}
+
+export interface CreateRampSessionResultWire {
+  local_session_id?: string;
+  localSessionId?: string;
+  meld_session_id?: string;
+  meldSessionId?: string;
+  external_customer_id?: string;
+  externalCustomerId?: string;
+  external_session_id?: string;
+  externalSessionId?: string;
+  launch_url?: string;
+  launchUrl?: string;
+  fallback_launch_url?: string;
+  fallbackLaunchUrl?: string;
+}
+
+export interface RampTransaction {
+  transactionId: string;
+  meldTransactionId?: string;
+  meldSessionId?: string;
+  walletId: string;
+  direction: RampDirection;
+  transactionType: RampTransactionType;
+  status: RampTransactionStatus;
+  serviceProvider: RampServiceProvider;
+  paymentMethodType?: RampPaymentMethodType;
+  sourceAmount: string;
+  sourceCurrencyCode: string;
+  destinationAmount?: string;
+  destinationCurrencyCode: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RampTransactionWire {
+  transaction_id?: string;
+  transactionId?: string;
+  meld_transaction_id?: string;
+  meldTransactionId?: string;
+  meld_session_id?: string;
+  meldSessionId?: string;
+  wallet_id?: string;
+  walletId?: string;
+  direction?: RampDirectionWire;
+  transaction_type?: RampTransactionTypeWire;
+  transactionType?: RampTransactionTypeWire;
+  status?: RampTransactionStatusWire;
+  service_provider?: RampServiceProviderWire;
+  serviceProvider?: RampServiceProviderWire;
+  payment_method_type?: RampPaymentMethodTypeWire;
+  paymentMethodType?: RampPaymentMethodTypeWire;
+  source_amount?: string;
+  sourceAmount?: string;
+  source_currency_code?: string;
+  sourceCurrencyCode?: string;
+  destination_amount?: string;
+  destinationAmount?: string;
+  destination_currency_code?: string;
+  destinationCurrencyCode?: string;
+  created_at?: string;
+  createdAt?: string;
+  updated_at?: string;
+  updatedAt?: string;
+}
+
+export interface GetRampTransactionArgs {
+  transactionId: string;
+}
+
+export interface GetRampTransactionResult {
+  transaction?: RampTransaction;
+}
+
+export interface GetRampTransactionResultWire {
+  transaction?: RampTransactionWire;
+}
+
+export interface ListRampTransactionsArgs {
+  walletId: string;
+  network?: Network;
+  direction?: Exclude<RampDirection, 'unspecified'>;
+  status?: Exclude<RampTransactionStatus, 'unspecified'>;
+  limit?: number;
+}
+
+export interface ListRampTransactionsResult {
+  transactions: RampTransaction[];
+}
+
+export interface ListRampTransactionsResultWire {
+  transactions?: RampTransactionWire[];
+}


### PR DESCRIPTION
Adds first-class ramp support to @swig-wallet/developer-sdk, so apps can call Swig ramp APIs through the SDK instead of hand-writing one-wallet-specific proxy routes. The browser client gets a swig.ramp API, while server handlers keep the developer API key server-side.

Changes

- Add RampClient with:getOptions
  - quote
  - createSession
  - getTransaction
  - listTransactions
- Add browser proxy support for ramp routes.
- Extend Next/Nest/server fetch handlers for ramp proxying.
  - Add rampCustomer helpers for:direct Swig users
  - partner customers
  - partner businesses
- Add resolveRampCustomer server hook so apps can inject customer context dynamically.
- Add ramp request/response types, normalization, docs, and tests.