### PR TITLE
Align sponsor idempotency across Developer SDKs

### DIFF
--- a/.changeset/sponsor-idempotency.md
+++ b/.changeset/sponsor-idempotency.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Remove unsupported sponsor metadata and retain optional idempotency keys for backend-enforced retries.

--- a/packages/developer-sdk/PARITY.md
+++ b/packages/developer-sdk/PARITY.md
@@ -15,7 +15,7 @@ uses snake_case names while TypeScript uses camelCase.
 | Generic execution   | `wallet.execute`                                 | `wallet.execute`                                    | same instruction normalization                          |
 | Wallet reads        | balance, token balances, transactions            | balance, token balances, transactions               | same required-field validation                          |
 | Paymaster           | balance and IDP balance                          | balance and IDP balance                             | same query and normalization                            |
-| Sponsorship         | `transactions.sponsor`                           | `transactions.sponsor`                              | base64 input converted to base58 for the sponsor API    |
+| Sponsorship         | `transactions.sponsor`                           | `transactions.sponsor`                              | same base58 conversion and idempotency-key forwarding   |
 | Ramp                | options, quote, session, transaction reads       | same                                                | same enum conversion and required-field validation      |
 | One Business        | grant URL, redirect, and callback parsing        | same                                                | same query contract and errors                          |
 | Generic signing     | callback and signer object                       | callback and signer protocol                        | same metadata preservation                              |

--- a/packages/developer-sdk/python/README.md
+++ b/packages/developer-sdk/python/README.md
@@ -56,7 +56,8 @@ local API key and exercises wallet creation, real P-256 signing, direct and
 grouped SOL transfers, an SPL-token transfer, and the Python proxy through the
 Developer API. It also verifies the live paymaster balance endpoint and a
 sponsored transfer where the user pays no network fee. Every transaction is
-submitted to Surfpool and verified on-chain.
+submitted to Surfpool and verified on-chain; the paymaster flow also retries
+with the same idempotency key and verifies that no balance changes repeat.
 
 ```bash
 bun run e2e:developer-sdk:python

--- a/packages/developer-sdk/python/scripts/local_transaction_e2e.py
+++ b/packages/developer-sdk/python/scripts/local_transaction_e2e.py
@@ -468,11 +468,13 @@ async def run_paymaster_e2e(
     destination_before = await rpc.balance(str(destination.pubkey()))
     user_before = await rpc.balance(str(user.pubkey()))
     paymaster_before = await rpc.balance(paymaster.address)
+    idempotency_key = f"python-local-e2e-{uuid4()}"
+    sponsor_args = SponsorSignedTransactionArgs(
+        transaction=transaction,
+        idempotency_key=idempotency_key,
+    )
     submitted = await swig.transactions.sponsor(
-        SponsorSignedTransactionArgs(
-            transaction=transaction,
-            metadata={"source": "python-local-e2e"},
-        )
+        sponsor_args
     )
     await rpc.confirm(submitted.signature)
     destination_after = await rpc.balance(str(destination.pubkey()))
@@ -488,8 +490,20 @@ async def run_paymaster_e2e(
         raise RuntimeError("Sponsored transfer charged the user a transaction fee")
     if paymaster_fee <= 0:
         raise RuntimeError("Sponsored transfer did not charge the paymaster")
+
+    replayed = await swig.transactions.sponsor(sponsor_args)
+    if replayed != submitted:
+        raise RuntimeError("Idempotent sponsor retry changed the response")
+    if await rpc.balance(str(destination.pubkey())) != destination_after:
+        raise RuntimeError("Idempotent sponsor retry repeated the transfer")
+    if await rpc.balance(str(user.pubkey())) != user_after:
+        raise RuntimeError("Idempotent sponsor retry charged the user again")
+    if await rpc.balance(paymaster.address) != paymaster_after:
+        raise RuntimeError("Idempotent sponsor retry charged the paymaster again")
+
     return {
         "paymaster_configured": True,
+        "paymaster_idempotency_replayed": True,
         "paymaster_destination_delta_lamports": destination_delta,
         "paymaster_user_delta_lamports": user_delta,
         "paymaster_fee_lamports": paymaster_fee,

--- a/packages/developer-sdk/python/scripts/local_transaction_e2e.py
+++ b/packages/developer-sdk/python/scripts/local_transaction_e2e.py
@@ -473,9 +473,7 @@ async def run_paymaster_e2e(
         transaction=transaction,
         idempotency_key=idempotency_key,
     )
-    submitted = await swig.transactions.sponsor(
-        sponsor_args
-    )
+    submitted = await swig.transactions.sponsor(sponsor_args)
     await rpc.confirm(submitted.signature)
     destination_after = await rpc.balance(str(destination.pubkey()))
     user_after = await rpc.balance(str(user.pubkey()))

--- a/packages/developer-sdk/python/src/swig_developer_sdk/transactions.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/transactions.py
@@ -8,7 +8,6 @@ from typing import Literal
 import base58
 
 from .common import (
-    JsonObject,
     Network,
     WalletAddressInfo,
     normalize_network,
@@ -62,7 +61,6 @@ class SponsorSignedTransactionArgs:
     transaction: str
     transaction_encoding: TransactionEncoding | None = None
     network: Network | None = None
-    metadata: JsonObject | None = None
     idempotency_key: str | None = None
 
 
@@ -96,7 +94,6 @@ class TransactionsClient:
                     transaction_bytes
                 ).decode("ascii"),
                 "network": args.network or self._default_network,
-                "metadata": args.metadata,
                 "idempotencyKey": args.idempotency_key,
             },
         )

--- a/packages/developer-sdk/python/tests/test_resource_clients.py
+++ b/packages/developer-sdk/python/tests/test_resource_clients.py
@@ -35,14 +35,14 @@ async def test_sponsor_converts_base64_transaction_to_base58() -> None:
     submitted = await swig.transactions.sponsor(
         SponsorSignedTransactionArgs(
             transaction=base64.b64encode(transaction).decode("ascii"),
-            metadata={"source": "test"},
+            idempotency_key="sponsor-request-123",
         )
     )
     assert submitted.signature == "chain-signature"
     assert json.loads(requests[0].content) == {
         "base58_encoded_transaction": base58.b58encode(transaction).decode("ascii"),
         "network": "devnet",
-        "metadata": {"source": "test"},
+        "idempotencyKey": "sponsor-request-123",
     }
 
 

--- a/packages/developer-sdk/typescript/README.md
+++ b/packages/developer-sdk/typescript/README.md
@@ -386,7 +386,9 @@ const signed = await signPreparedSwigTransaction(prepared, {
 
 After signing, pass `signed` to your app-owned send or sponsor flow. On your
 server, `swig.transactions.sponsor(signed)` handles the deployed paymaster route
-and base58 payload encoding expected by the backend.
+and base58 payload encoding expected by the backend. Pass `idempotencyKey` when
+the application may retry sponsorship; a matching retry returns the original
+paymaster response.
 
 For wallet creation, sign only `created.clientAuthorityTransactions` on the
 client. Do not authority-sign `created.operatorSignedTransactions`; those

--- a/packages/developer-sdk/typescript/src/transactions/client.test.ts
+++ b/packages/developer-sdk/typescript/src/transactions/client.test.ts
@@ -20,6 +20,7 @@ describe('TransactionsClient', () => {
     await expect(
       transactions.sponsor({
         transaction: bytesToBase64(transactionBytes),
+        idempotencyKey: 'sponsor-request-123',
       }),
     ).resolves.toEqual({
       signature: 'sponsored_signature_123',
@@ -31,8 +32,7 @@ describe('TransactionsClient', () => {
         body: {
           base58_encoded_transaction: bs58.encode(transactionBytes),
           network: 'devnet',
-          metadata: undefined,
-          idempotencyKey: undefined,
+          idempotencyKey: 'sponsor-request-123',
         },
       },
     ]);

--- a/packages/developer-sdk/typescript/src/transactions/client.ts
+++ b/packages/developer-sdk/typescript/src/transactions/client.ts
@@ -24,7 +24,6 @@ export class TransactionsClient {
           base64ToBytes(args.transaction),
         ),
         network: args.network ?? this.defaultNetwork,
-        metadata: args.metadata,
         idempotencyKey: args.idempotencyKey,
       },
     );

--- a/packages/developer-sdk/typescript/src/types/transaction.ts
+++ b/packages/developer-sdk/typescript/src/types/transaction.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, Network } from './common.js';
+import type { Network } from './common.js';
 import type { WalletAuthority } from './wallet-actions.js';
 import type { WalletAddressInfo } from './wallet.js';
 
@@ -133,7 +133,6 @@ export interface SponsorSignedTransactionArgs {
   transaction: string;
   transactionEncoding?: TransactionEncoding;
   network?: Network;
-  metadata?: JsonObject;
   idempotencyKey?: string;
 }
 


### PR DESCRIPTION
## Summary

- remove unsupported sponsor metadata from the TypeScript and Python public contracts
- retain optional idempotency keys and forward the same wire field in both SDKs
- extend the Python local E2E to retry a real sponsored Surfpool transaction and verify no balance change repeats
- add a minor changeset for `@swig-wallet/developer-sdk`

Backend enforcement is merged in [swig-dev-portal#674](https://github.com/anagrambuild/swig-dev-portal/pull/674).

## Verification

- TypeScript: 79 tests, typecheck, lint, package build
- Python: 19 tests, Ruff, Mypy, sdist and wheel build
- local Python E2E against Tilt + Surfpool + paymaster + Redis: `status: ok`, `paymaster_idempotency_replayed: true`
- live paymaster logs confirmed the second call replayed the original request ID
- `git diff --check`
