### PR TITLE
Build custom transactions through the Developer API

### DIFF
--- a/.changeset/custom-transaction-preparation.md
+++ b/.changeset/custom-transaction-preparation.md
@@ -1,0 +1,5 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Use the batch and custom transaction preparation endpoints, replacing generic wallet execution with `wallet.buildTransaction`.

--- a/packages/developer-sdk/PARITY.md
+++ b/packages/developer-sdk/PARITY.md
@@ -12,7 +12,7 @@ uses snake_case names while TypeScript uses camelCase.
 | Transfers           | `wallet.transfer.sol/token/splToken`             | `wallet.transfer.sol/token/spl_token`               | same endpoints and prepared transaction output          |
 | Jupiter swap        | `wallet.swap.jupiter`                            | `wallet.swap.jupiter`                               | same optional swap controls                             |
 | Recovery            | `wallet.recovery.*`                              | `wallet.recovery.*`                                 | same prepare, start, cancel, and execute behavior       |
-| Generic execution   | `wallet.execute`                                 | `wallet.execute`                                    | same instruction normalization                          |
+| Custom transaction  | `wallet.buildTransaction`                        | `wallet.build_transaction`                          | same custom preparation request and instruction shape   |
 | Wallet reads        | balance, token balances, transactions            | balance, token balances, transactions               | same required-field validation                          |
 | Paymaster           | balance and IDP balance                          | balance and IDP balance                             | same query and normalization                            |
 | Sponsorship         | `transactions.sponsor`                           | `transactions.sponsor`                              | same base58 conversion and idempotency-key forwarding   |

--- a/packages/developer-sdk/python/README.md
+++ b/packages/developer-sdk/python/README.md
@@ -26,6 +26,10 @@ prepared = await wallet.transfer.sol(
 )
 ```
 
+Use `wallet.build_transaction(...)` to supply raw Solana instructions for the
+backend to wrap in the Swig signing flow. The returned transaction is still
+signed and submitted client-side.
+
 `wallet.transfer(...)` and `wallet.swap(...)` are callable like their
 TypeScript counterparts. Their explicit `sol`, `token`, `spl_token`, and
 `jupiter` methods are available as well.

--- a/packages/developer-sdk/python/src/swig_developer_sdk/wallets.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/wallets.py
@@ -295,7 +295,7 @@ class WalletsClient:
     ) -> PreparedTransactionsResult:
         authority = _requester_authority(wallet, requester_authority)
         response = await self._http.post(
-            "/transaction/prepare",
+            "/transaction/prepare/batch",
             {
                 **_base_write_request(
                     wallet, fee_payer, network, self._default_network
@@ -575,26 +575,29 @@ class WalletsClient:
             )
         )
 
-    async def execute(
+    async def build_transaction(
         self,
         wallet: WalletHandle,
         *,
+        fee_payer: str,
         instructions: Sequence[SolanaInstructionInput],
+        requester_authority: WalletAuthority | None = None,
         address_lookup_table_accounts: Sequence[str] | None = None,
         network: Network | None = None,
-        idempotency_key: str | None = None,
     ) -> PreparedTransaction:
+        authority = _requester_authority(wallet, requester_authority)
         return normalize_prepared_transaction(
             await self._http.post(
-                f"/v1/wallets/{quote(wallet.swig_config_address, safe='')}/execute",
+                "/transaction/prepare/custom",
                 {
-                    "wallet": wallet.swig_config_address,
-                    "network": network or wallet.network or self._default_network,
+                    **_base_write_request(
+                        wallet, fee_payer, network, self._default_network
+                    ),
+                    "requesterAuthority": wallet_authority_to_wire(authority),
                     "instructions": [
                         _instruction_to_wire(item) for item in instructions
                     ],
                     "addressLookupTableAccounts": address_lookup_table_accounts,
-                    "idempotencyKey": idempotency_key,
                 },
             )
         )
@@ -679,20 +682,22 @@ class WalletHandle:
             idempotency_key=idempotency_key,
         )
 
-    async def execute(
+    async def build_transaction(
         self,
         *,
+        fee_payer: str,
         instructions: Sequence[SolanaInstructionInput],
+        requester_authority: WalletAuthority | None = None,
         address_lookup_table_accounts: Sequence[str] | None = None,
         network: Network | None = None,
-        idempotency_key: str | None = None,
     ) -> PreparedTransaction:
-        return await self._wallets.execute(
+        return await self._wallets.build_transaction(
             self,
+            fee_payer=fee_payer,
             instructions=instructions,
+            requester_authority=requester_authority,
             address_lookup_table_accounts=address_lookup_table_accounts,
             network=network,
-            idempotency_key=idempotency_key,
         )
 
     async def get_usd_balance(

--- a/packages/developer-sdk/python/tests/test_client.py
+++ b/packages/developer-sdk/python/tests/test_client.py
@@ -5,7 +5,14 @@ import json
 import httpx
 import pytest
 
-from swig_developer_sdk import RetryOptions, SwigClient, SwigDeveloperSdkError
+from swig_developer_sdk import (
+    RetryOptions,
+    SolanaAccountMeta,
+    SolanaInstructionInput,
+    SwigClient,
+    SwigDeveloperSdkError,
+    TransferSolOperation,
+)
 
 
 async def test_wallet_transfer_matches_typescript_wire_contract() -> None:
@@ -62,6 +69,111 @@ async def test_wallet_transfer_matches_typescript_wire_contract() -> None:
         "requesterAuthority": {"ed25519": {"publicKey": "requester"}},
         "destination": "destination",
         "lamports": "123",
+    }
+
+
+async def test_wallet_prepare_uses_batch_preparation_endpoint() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"data": {"transactions": [], "network": "NETWORK_DEVNET"}},
+        )
+
+    swig = SwigClient(
+        api_key="secret",
+        base_url="https://example.test",
+        network="devnet",
+        transport=httpx.MockTransport(handler),
+    )
+    wallet = swig.wallets.use(
+        "swig-address",
+        requester_authority={"ed25519": {"publicKey": "requester"}},
+    )
+
+    await wallet.prepare(
+        fee_payer="payer",
+        operations=(TransferSolOperation(destination="destination", amount=123),),
+    )
+
+    assert requests[0].url.path == "/transaction/prepare/batch"
+    assert json.loads(requests[0].content) == {
+        "network": "NETWORK_DEVNET",
+        "feePayer": "payer",
+        "swigAddress": "swig-address",
+        "requesterAuthority": {"ed25519": {"publicKey": "requester"}},
+        "operations": [
+            {"transferSol": {"destination": "destination", "lamports": "123"}}
+        ],
+    }
+
+
+async def test_wallet_build_transaction_matches_custom_preparation_contract() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "transaction": "prepared-custom-base64",
+                    "transactionEncoding": "TRANSACTION_ENCODING_BASE64",
+                    "network": "NETWORK_DEVNET",
+                }
+            },
+        )
+
+    swig = SwigClient(
+        api_key="secret",
+        base_url="https://example.test",
+        network="devnet",
+        transport=httpx.MockTransport(handler),
+    )
+    wallet = swig.wallets.use(
+        "swig-address",
+        requester_authority={"ed25519": {"publicKey": "requester"}},
+    )
+
+    prepared = await wallet.build_transaction(
+        fee_payer="payer",
+        instructions=(
+            SolanaInstructionInput(
+                program_id="program",
+                accounts=(
+                    SolanaAccountMeta(
+                        pubkey="account", is_signer=True, is_writable=True
+                    ),
+                ),
+                data=b"\x01\x02\x03",
+            ),
+        ),
+        address_lookup_table_accounts=("lookup-table",),
+    )
+
+    assert prepared.transaction == "prepared-custom-base64"
+    assert requests[0].url.path == "/transaction/prepare/custom"
+    assert json.loads(requests[0].content) == {
+        "network": "NETWORK_DEVNET",
+        "feePayer": "payer",
+        "swigAddress": "swig-address",
+        "requesterAuthority": {"ed25519": {"publicKey": "requester"}},
+        "instructions": [
+            {
+                "programId": "program",
+                "accounts": [
+                    {
+                        "pubkey": "account",
+                        "isSigner": True,
+                        "isWritable": True,
+                    }
+                ],
+                "data": "AQID",
+            }
+        ],
+        "addressLookupTableAccounts": ["lookup-table"],
     }
 
 

--- a/packages/developer-sdk/typescript/README.md
+++ b/packages/developer-sdk/typescript/README.md
@@ -132,6 +132,26 @@ return {
 };
 ```
 
+### Build a Custom Transaction
+
+Use `wallet.buildTransaction` when the application supplies the raw Solana
+instructions. The backend wraps them in the Swig signing flow and returns an
+unsigned transaction; signing and submission remain client-side.
+
+```typescript
+const prepared = await wallet.buildTransaction({
+  feePayer,
+  instructions: [
+    {
+      programId,
+      accounts: [{ pubkey: destination, isWritable: true }],
+      data: instructionData,
+    },
+  ],
+  addressLookupTableAccounts,
+});
+```
+
 ### Prepare SOL Transfer
 
 ```typescript

--- a/packages/developer-sdk/typescript/src/index.ts
+++ b/packages/developer-sdk/typescript/src/index.ts
@@ -22,6 +22,7 @@ export type {
 export type {
   AddRecoveryAuthorityArgs,
   Amount,
+  BuildTransactionArgs,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
   CreateRampSessionArgs,
@@ -29,7 +30,6 @@ export type {
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
-  ExecuteArgs,
   ExecuteRecoveryArgs,
   GetRampOptionsArgs,
   GetRampOptionsResult,

--- a/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
@@ -541,7 +541,7 @@ describe('createSwigFetchHandler', () => {
       },
     });
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/transaction/prepare',
+      url: 'http://localhost:8080/transaction/prepare/batch',
       body: {
         network: 'NETWORK_DEVNET',
         feePayer: 'payer_123',

--- a/packages/developer-sdk/typescript/src/server/index.ts
+++ b/packages/developer-sdk/typescript/src/server/index.ts
@@ -10,6 +10,7 @@ export {
 export type {
   AddRecoveryAuthorityArgs,
   Amount,
+  BuildTransactionArgs,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
   CreateRampSessionArgs,
@@ -17,7 +18,6 @@ export type {
   CreateWalletArgs,
   CreateWalletResponse,
   CreateWalletResult,
-  ExecuteArgs,
   ExecuteRecoveryArgs,
   GetRampOptionsArgs,
   GetRampOptionsResult,

--- a/packages/developer-sdk/typescript/src/types/wallet-actions.ts
+++ b/packages/developer-sdk/typescript/src/types/wallet-actions.ts
@@ -114,9 +114,10 @@ export interface ExecuteRecoveryArgs extends BaseRecoveryArgs {
   newAuthority: string;
 }
 
-export interface ExecuteArgs {
+export interface BuildTransactionArgs {
+  feePayer: string;
+  requesterAuthority?: WalletAuthority;
   instructions: SolanaInstructionInput[];
   addressLookupTableAccounts?: string[];
   network?: Network;
-  idempotencyKey?: string;
 }

--- a/packages/developer-sdk/typescript/src/wallets/client.test.ts
+++ b/packages/developer-sdk/typescript/src/wallets/client.test.ts
@@ -700,7 +700,7 @@ describe('WalletsClient', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      url: 'http://localhost:8080/transaction/prepare',
+      url: 'http://localhost:8080/transaction/prepare/batch',
       method: 'POST',
       body: {
         network: 'NETWORK_DEVNET',
@@ -738,6 +738,78 @@ describe('WalletsClient', () => {
     });
     expect(prepared.feePayerOnlyTransactions).toHaveLength(1);
     expect(prepared.clientAuthorityTransactions).toEqual([]);
+  });
+
+  test('builds custom transactions through the custom preparation endpoint', async () => {
+    const calls: CapturedRequest[] = [];
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          transaction: 'base64-custom-tx',
+          transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+          network: 'NETWORK_DEVNET',
+          recentBlockhash: 'blockhash_custom',
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.buildTransaction({
+      feePayer: 'payer_123',
+      instructions: [
+        {
+          programId: 'program_123',
+          accounts: [
+            {
+              pubkey: 'account_123',
+              isSigner: true,
+              isWritable: true,
+            },
+          ],
+          data: new Uint8Array([1, 2, 3]),
+        },
+      ],
+      addressLookupTableAccounts: ['lookup_table_123'],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/prepare/custom',
+      method: 'POST',
+      body: {
+        network: 'NETWORK_DEVNET',
+        feePayer: 'payer_123',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+        instructions: [
+          {
+            programId: 'program_123',
+            accounts: [
+              {
+                pubkey: 'account_123',
+                isSigner: true,
+                isWritable: true,
+              },
+            ],
+            data: 'AQID',
+          },
+        ],
+        addressLookupTableAccounts: ['lookup_table_123'],
+      },
+    });
+    expect(prepared).toMatchObject({
+      transaction: 'base64-custom-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+      recentBlockhash: 'blockhash_custom',
+    });
   });
 
   test('prepares Jupiter swaps through the local transaction endpoint', async () => {

--- a/packages/developer-sdk/typescript/src/wallets/client.ts
+++ b/packages/developer-sdk/typescript/src/wallets/client.ts
@@ -1,12 +1,12 @@
 import type { HttpClient } from '../core/index.js';
 import type {
   AddRecoveryAuthorityArgs,
+  BuildTransactionArgs,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
   CreateWalletArgs,
   CreateWalletResponseWire,
   CreateWalletResult,
-  ExecuteArgs,
   ExecuteRecoveryArgs,
   IdpWalletSession,
   ListSwigTokenBalancesResult,
@@ -45,11 +45,11 @@ import {
 } from './normalizers.js';
 import {
   addRecoveryAuthorityRequest,
+  buildTransactionRequest,
   cancelRecoveryRequest,
   configureRecoveryRequest,
   createWalletRequest,
   executeRecoveryRequest,
-  executeRequest,
   isTokenTransfer,
   prepareRequest,
   startRecoveryRequest,
@@ -181,7 +181,7 @@ export class WalletsClient {
     args: PrepareArgs,
   ): Promise<PreparedTransactionsResult> => {
     const response = await this.http.post<PrepareTransactionsResponseWire>(
-      '/transaction/prepare',
+      '/transaction/prepare/batch',
       prepareRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePrepareTransactionsResponse(response);
@@ -301,13 +301,13 @@ export class WalletsClient {
     return normalizePreparedTransaction(response);
   };
 
-  execute = async (
+  buildTransaction = async (
     wallet: WalletHandle,
-    args: ExecuteArgs,
+    args: BuildTransactionArgs,
   ): Promise<PreparedTransaction> => {
     const response = await this.http.post<PreparedTransactionWire>(
-      `/v1/wallets/${encodeURIComponent(wallet.swigConfigAddress)}/execute`,
-      executeRequest(wallet, args, this.defaultNetwork),
+      '/transaction/prepare/custom',
+      buildTransactionRequest(wallet, args, this.defaultNetwork),
     );
     return normalizePreparedTransaction(response);
   };

--- a/packages/developer-sdk/typescript/src/wallets/handle.ts
+++ b/packages/developer-sdk/typescript/src/wallets/handle.ts
@@ -1,6 +1,6 @@
 import type {
+  BuildTransactionArgs,
   CancelRecoveryArgs,
-  ExecuteArgs,
   ExecuteRecoveryArgs,
   ListSwigTokenBalancesResult,
   ListSwigTokenTransactionsArgs,
@@ -70,7 +70,9 @@ export class WalletHandle {
   prepare = (args: PrepareArgs): Promise<PreparedTransactionsResult> =>
     this.wallets.prepare(this, args);
 
-  execute = (args: ExecuteArgs) => this.wallets.execute(this, args);
+  buildTransaction = (
+    args: BuildTransactionArgs,
+  ): Promise<PreparedTransaction> => this.wallets.buildTransaction(this, args);
 
   getUsdBalance = (args?: WalletReadArgs): Promise<SwigUsdBalance> =>
     this.wallets.getUsdBalance(this, args);

--- a/packages/developer-sdk/typescript/src/wallets/requests.ts
+++ b/packages/developer-sdk/typescript/src/wallets/requests.ts
@@ -1,9 +1,9 @@
 import type {
   AddRecoveryAuthorityArgs,
+  BuildTransactionArgs,
   CancelRecoveryArgs,
   ConfigureRecoveryArgs,
   CreateWalletArgs,
-  ExecuteArgs,
   ExecuteRecoveryArgs,
   Network,
   PrepareArgs,
@@ -191,17 +191,20 @@ export function executeRecoveryRequest(
   };
 }
 
-export function executeRequest(
+export function buildTransactionRequest(
   wallet: WalletHandle,
-  args: ExecuteArgs,
+  args: BuildTransactionArgs,
   defaultNetwork?: Network,
 ) {
   return {
-    wallet: wallet.swigConfigAddress,
-    network: args.network ?? wallet.network ?? defaultNetwork,
+    network: toProtoNetwork(
+      resolveNetwork(args.network, wallet.network, defaultNetwork),
+    ),
+    feePayer: args.feePayer,
+    swigAddress: wallet.swigConfigAddress,
+    requesterAuthority: resolveRequesterAuthority(wallet, args),
     instructions: args.instructions.map(normalizeInstruction),
     addressLookupTableAccounts: args.addressLookupTableAccounts,
-    idempotencyKey: args.idempotencyKey,
   };
 }
 
@@ -245,12 +248,14 @@ function resolveRequesterAuthority(
     | TransferArgs
     | SwapArgs
     | PrepareArgs
+    | BuildTransactionArgs
     | CancelRecoveryArgs
     | AddRecoveryAuthorityArgs,
 ): NonNullable<
   | TransferArgs['requesterAuthority']
   | SwapArgs['requesterAuthority']
   | PrepareArgs['requesterAuthority']
+  | BuildTransactionArgs['requesterAuthority']
   | CancelRecoveryArgs['requesterAuthority']
   | AddRecoveryAuthorityArgs['requesterAuthority']
 > {


### PR DESCRIPTION
## Summary

- route grouped preparation through `POST /transaction/prepare/batch`
- replace generic `wallet.execute` with `wallet.buildTransaction` in TypeScript and `wallet.build_transaction` in Python
- send the typed custom preparation contract to `POST /transaction/prepare/custom`, including fee payer, Swig address, requester authority, raw instructions, and optional lookup tables
- remove the obsolete custom-execution idempotency field and compatibility surface
- document and test TypeScript/Python parity

Backend dependency: [swig-dev-portal 0.5.25](https://github.com/anagrambuild/swig-dev-portal/releases/tag/0.5.25)

## Validation

- `bun --filter @swig-wallet/developer-sdk test` (80 passed)
- `bun --filter @swig-wallet/developer-sdk typecheck`
- `bun --filter @swig-wallet/developer-sdk lint`
- `bun --filter @swig-wallet/developer-sdk build`
- `uv run --frozen ruff format --check src tests scripts`
- `uv run --frozen ruff check src tests scripts`
- `uv run --frozen mypy src scripts`
- `uv run --frozen pytest` (21 passed)
- `uv build`