### PR TITLE
Publish Python SDK with PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,114 @@
+name: Publish Python SDK
+
+on:
+  push:
+    tags:
+      - 'swig-developer-sdk@*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-python-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Python package
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/developer-sdk/python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: '3.10'
+          working-directory: packages/developer-sdk/python
+          enable-cache: true
+
+      - name: Verify release tag
+        shell: bash
+        run: |
+          package_version="$(uv version --short --locked)"
+          expected_tag="swig-developer-sdk@${package_version}"
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Expected tag ${expected_tag}, got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          git fetch origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "Release tag must point to a commit on main" >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-groups
+
+      - name: Check formatting
+        run: uv run --frozen ruff format --check src tests scripts
+
+      - name: Check linting
+        run: uv run --frozen ruff check src tests scripts
+
+      - name: Check types
+        run: uv run --frozen mypy src scripts
+
+      - name: Run tests
+        run: uv run --frozen pytest
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload package distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: packages/developer-sdk/python/dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish package to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/swig-developer-sdk
+    permissions:
+      id-token: write
+    steps:
+      - name: Download package distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download package distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}" dist/*
+          --repo "${GITHUB_REPOSITORY}"
+          --title "${GITHUB_REF_NAME}"
+          --generate-notes

--- a/packages/developer-sdk/python/pyproject.toml
+++ b/packages/developer-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "swig-developer-sdk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for preparing and locally signing Swig wallet transactions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/developer-sdk/python/uv.lock
+++ b/packages/developer-sdk/python/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "swig-developer-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary

- bump `swig-developer-sdk` to `0.7.0`
- add the trusted-publisher workflow PyPI is configured to accept: `.github/workflows/publish-python.yml`
- build, lint, type-check, and test without OIDC permissions
- publish from a separate least-privilege job using `pypa/gh-action-pypi-publish@release/v1`
- require release tags to match the locked package version and point to a commit on `main`
- create a GitHub release with the wheel and source distribution after PyPI succeeds

After merge, publishing is triggered by the `swig-developer-sdk@0.7.0` tag. No PyPI token or repository secret is used.

## Validation

- `actionlint .github/workflows/publish-python.yml`
- `bunx prettier --check .github/workflows/publish-python.yml`
- `uv version --short --locked` (`0.7.0`)
- `uv sync --frozen --all-groups`
- `uv run --frozen ruff format --check src tests scripts`
- `uv run --frozen ruff check src tests scripts`
- `uv run --frozen mypy src scripts`
- `uv run --frozen pytest` (21 passed)
- `uv build`