### PR TITLE
Feat(paymaster): Jito bundles SponsorBundle support

### DIFF
--- a/.changeset/quiet-bundles-submit.md
+++ b/.changeset/quiet-bundles-submit.md
@@ -1,0 +1,8 @@
+---
+'@swig-wallet/api': minor
+'@swig-wallet/paymaster-core': minor
+'@swig-wallet/paymaster-classic': minor
+'@swig-wallet/paymaster-kit': minor
+---
+
+Add explicit, ALT-safe Jito bundle preparation and submission support to the paymaster SDK.

--- a/examples/paymaster/.env.example
+++ b/examples/paymaster/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to .env.local and fill in the values before running:
+# bun --filter swig-paymaster-examples jito:classic
+
+PAYMASTER_API_KEY=sk_replace_me
+PAYMASTER_PUBKEY=PaymasterPublicKeyReplaceMe
+PAYMASTER_BASE_URL=http://localhost:8080
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+JITO_TIP_LAMPORTS=10000
+
+# JSON array secret keys for funded test accounts.
+JITO_USER_KEYPAIR_1=[replace,with,64,secret,key,bytes]
+JITO_USER_KEYPAIR_2=[replace,with,64,secret,key,bytes]
+
+# Optional: set this only when you want retries to reuse a specific key.
+# PAYMASTER_IDEMPOTENCY_KEY=jito-mainnet-manual-key
+
+# Optional: useful for local airdrop-capable RPCs only.
+# PAYMASTER_EXAMPLE_AIRDROP=true

--- a/examples/paymaster/jito-classic.ts
+++ b/examples/paymaster/jito-classic.ts
@@ -1,0 +1,229 @@
+/**
+ * Paymaster Jito bundle example (web3.js 1.x)
+ *
+ * Copy .env.example to .env.local, fill in the values, then run:
+ * bun --filter swig-paymaster-examples jito:classic
+ *
+ * Flow:
+ * 1. Create two paymaster-fee-payer memo transactions.
+ * 2. Add a Jito tip instruction before collecting user signatures.
+ * 3. User signs each transaction.
+ * 4. Paymaster signs and submits the bundle through sponsor-bundle.
+ *
+ * Required env:
+ * - PAYMASTER_API_KEY
+ * - PAYMASTER_PUBKEY
+ * - JITO_USER_KEYPAIR_1
+ * - JITO_USER_KEYPAIR_2
+ *
+ * Optional env:
+ * - PAYMASTER_BASE_URL defaults to http://localhost:8080
+ * - SOLANA_RPC_URL defaults to https://api.mainnet-beta.solana.com
+ * - JITO_TIP_LAMPORTS defaults to SDK default
+ * - PAYMASTER_IDEMPOTENCY_KEY defaults to SDK-generated
+ * - PAYMASTER_EXAMPLE_AIRDROP=true requests airdrops for unfunded accounts
+ */
+
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { createPaymasterClient } from '@swig-wallet/paymaster-classic';
+
+const PAYMASTER_API_KEY = requireEnv('PAYMASTER_API_KEY');
+const PAYMASTER_PUBKEY = requireEnv('PAYMASTER_PUBKEY');
+const PAYMASTER_BASE_URL =
+  process.env.PAYMASTER_BASE_URL ?? 'http://localhost:8080';
+const SOLANA_RPC_URL =
+  process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com';
+const JITO_TIP_LAMPORTS = optionalPositiveIntegerEnv('JITO_TIP_LAMPORTS');
+const PAYMASTER_IDEMPOTENCY_KEY = process.env.PAYMASTER_IDEMPOTENCY_KEY;
+const PAYMASTER_EXAMPLE_AIRDROP =
+  process.env.PAYMASTER_EXAMPLE_AIRDROP === 'true';
+
+const MEMO_PROGRAM_ID = new PublicKey(
+  'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
+);
+
+console.log('Paymaster Jito bundle example');
+console.log(`API URL: ${PAYMASTER_BASE_URL}`);
+console.log(`RPC URL: ${SOLANA_RPC_URL}`);
+console.log(`Paymaster: ${PAYMASTER_PUBKEY}`);
+
+const paymaster = createPaymasterClient({
+  apiKey: PAYMASTER_API_KEY,
+  paymasterPubkey: PAYMASTER_PUBKEY,
+  baseUrl: PAYMASTER_BASE_URL,
+  network: 'mainnet',
+  customRpcUrl: SOLANA_RPC_URL,
+  retryOptions: {
+    maxRetries: 0,
+    retryDelay: 1000,
+    backoffMultiplier: 2,
+  },
+});
+
+const connection = new Connection(SOLANA_RPC_URL, 'confirmed');
+const paymasterPubkey = new PublicKey(PAYMASTER_PUBKEY);
+await ensureAccountFunded(connection, paymasterPubkey, 'paymaster');
+
+const users = loadJitoUserKeypairs();
+for (const [index, user] of users.entries()) {
+  console.log(`User ${index + 1}: ${user.publicKey.toBase58()}`);
+}
+await ensureUserAccountsFunded(connection, users);
+
+const transactions = await Promise.all(
+  users.map((user, index) =>
+    paymaster.createLegacyTransaction([
+      createMemoInstruction(`Jito bundle memo ${index + 1}`, user.publicKey),
+    ]),
+  ),
+);
+
+paymaster.prepareJitoBundleTransactions(transactions, {
+  tipLamports: JITO_TIP_LAMPORTS,
+});
+
+for (const [index, transaction] of transactions.entries()) {
+  transaction.partialSign(users[index]!);
+}
+
+const result = await paymaster.signAndSendBundle(transactions, {
+  tipLamports: JITO_TIP_LAMPORTS,
+  idempotencyKey: PAYMASTER_IDEMPOTENCY_KEY,
+});
+
+console.log('Bundle submitted');
+console.log(`Request ID: ${result.requestId}`);
+console.log(`Bundle ID: ${result.bundleId}`);
+console.log(`Spent by paymaster: ${result.spentByPaymaster}`);
+for (const [index, signature] of result.signatures.entries()) {
+  console.log(`Signature ${index + 1}: ${signature}`);
+}
+
+function createMemoInstruction(
+  memo: string,
+  userPublicKey: PublicKey,
+): TransactionInstruction {
+  return new TransactionInstruction({
+    keys: [{ pubkey: userPublicKey, isSigner: true, isWritable: false }],
+    programId: MEMO_PROGRAM_ID,
+    data: Buffer.from(memo),
+  });
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optionalPositiveIntegerEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function loadJitoUserKeypairs(): Keypair[] {
+  return [
+    keypairFromSecretKeyEnv('JITO_USER_KEYPAIR_1'),
+    keypairFromSecretKeyEnv('JITO_USER_KEYPAIR_2'),
+  ];
+}
+
+function keypairFromSecretKeyEnv(name: string): Keypair {
+  const value = requireEnv(name).trim();
+  const json =
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"'))
+      ? value.slice(1, -1)
+      : value;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error(
+      `${name} must be a JSON array secret key: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== 64 ||
+    !parsed.every(
+      (value) =>
+        Number.isInteger(value) && Number(value) >= 0 && Number(value) <= 255,
+    )
+  ) {
+    throw new Error(`${name} must be a JSON array of 64 byte values`);
+  }
+
+  return Keypair.fromSecretKey(Uint8Array.from(parsed));
+}
+
+async function ensureUserAccountsFunded(
+  connection: Connection,
+  users: Keypair[],
+): Promise<void> {
+  for (const user of users) {
+    await ensureAccountFunded(connection, user.publicKey, 'user');
+  }
+}
+
+async function ensureAccountFunded(
+  connection: Connection,
+  account: PublicKey,
+  label: string,
+): Promise<void> {
+  const startingBalance = await connection.getBalance(account);
+  if (startingBalance > 0) {
+    console.log(
+      `${label} funded: ${account.toBase58()} (${startingBalance} lamports)`,
+    );
+    return;
+  }
+
+  if (!PAYMASTER_EXAMPLE_AIRDROP) {
+    throw new Error(
+      `${label} is unfunded: ${account.toBase58()}. Fund it or set PAYMASTER_EXAMPLE_AIRDROP=true for local airdrop testing.`,
+    );
+  }
+
+  console.log(`Funding ${label} by airdrop: ${account.toBase58()}`);
+  const signature = await connection.requestAirdrop(account, LAMPORTS_PER_SOL);
+  await connection.confirmTransaction(signature, 'confirmed');
+  await waitForBalance(connection, account);
+}
+
+async function waitForBalance(
+  connection: Connection,
+  account: PublicKey,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const balance = await connection.getBalance(account);
+    if (balance > 0) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Airdrop did not fund ${account.toBase58()}`);
+}

--- a/examples/paymaster/jito-classic.ts
+++ b/examples/paymaster/jito-classic.ts
@@ -100,7 +100,9 @@ const result = await paymaster.signAndSendBundle(transactions, {
 console.log('Bundle submitted');
 console.log(`Request ID: ${result.requestId}`);
 console.log(`Bundle ID: ${result.bundleId}`);
-console.log(`Spent by paymaster: ${result.spentByPaymaster}`);
+console.log(
+  `Estimated spent by paymaster: ${result.estimatedSpentByPaymaster} lamports`,
+);
 for (const [index, signature] of result.signatures.entries()) {
   console.log(`Signature ${index + 1}: ${signature}`);
 }

--- a/examples/paymaster/jito-classic.ts
+++ b/examples/paymaster/jito-classic.ts
@@ -93,7 +93,6 @@ for (const [index, transaction] of transactions.entries()) {
 }
 
 const result = await paymaster.signAndSendBundle(transactions, {
-  tipLamports: JITO_TIP_LAMPORTS,
   idempotencyKey: PAYMASTER_IDEMPOTENCY_KEY,
 });
 

--- a/examples/paymaster/package.json
+++ b/examples/paymaster/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "classic": "bun run classic.ts",
+    "jito:classic": "set -a; [ ! -f .env.local ] || . ./.env.local; set +a; bun run jito-classic.ts",
     "kit": "bun run kit.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "nx run-many --target=lint --projects='@swig-wallet/api','@swig-wallet/classic','@swig-wallet/coder','@swig-wallet/developer','@swig-wallet/developer-sdk','@swig-wallet/kit','@swig-wallet/lib','@swig-wallet/paymaster-core','@swig-wallet/paymaster-classic','@swig-wallet/paymaster-kit'",
     "lint:fix": "nx run-many --target=lint:fix --projects='@swig-wallet/api','@swig-wallet/classic','@swig-wallet/coder','@swig-wallet/developer','@swig-wallet/developer-sdk','@swig-wallet/kit','@swig-wallet/lib','@swig-wallet/paymaster-core','@swig-wallet/paymaster-classic','@swig-wallet/paymaster-kit'",
     "release": "bun run build:packages && bun update:package-version && changeset publish",
-    "test": "nx run-many --target=test --projects='@swig-wallet/classic','@swig-wallet/coder','@swig-wallet/kit','@swig-wallet/lib'",
+    "test": "nx run-many --target=test --projects='@swig-wallet/classic','@swig-wallet/coder','@swig-wallet/kit','@swig-wallet/lib','@swig-wallet/paymaster-core','@swig-wallet/paymaster-classic','@swig-wallet/paymaster-kit'",
     "test:developer-sdk:python": "cd packages/developer-sdk/python && uv run --frozen pytest",
     "typecheck": "nx run-many --target=typecheck --projects='@swig-wallet/api','@swig-wallet/classic','@swig-wallet/coder','@swig-wallet/developer','@swig-wallet/developer-sdk','@swig-wallet/kit','@swig-wallet/lib','@swig-wallet/paymaster-core','@swig-wallet/paymaster-classic','@swig-wallet/paymaster-kit'",
     "update:package-version": "bun scripts/update-internal-pkg-version.ts",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,6 +26,8 @@ export type {
   ServiceStatus,
   SignRequest,
   SignResponse,
+  SponsorBundleRequest,
+  SponsorBundleResponse,
   SponsorRequest,
   SponsorResponse,
 } from './paymaster/types.js';

--- a/packages/api/src/paymaster/client.ts
+++ b/packages/api/src/paymaster/client.ts
@@ -1,7 +1,12 @@
 import type { SwigApiClient } from '../client.js';
 import { ApiError, type ApiResponse, type Network } from '../types.js';
 import { request } from '../utils/request.js';
-import type { HealthResponse, SignResponse, SponsorResponse } from './types.js';
+import type {
+  HealthResponse,
+  SignResponse,
+  SponsorBundleResponse,
+  SponsorResponse,
+} from './types.js';
 
 export class PaymasterApi {
   constructor(private readonly client: SwigApiClient) {}
@@ -25,6 +30,7 @@ export class PaymasterApi {
   async sponsor(
     transaction: string,
     network: Network,
+    idempotencyKey?: string,
   ): Promise<ApiResponse<SponsorResponse>> {
     const baseUrl = this.#requirePaymasterUrl();
     const url = `${baseUrl}/sponsor`;
@@ -38,6 +44,36 @@ export class PaymasterApi {
         body: JSON.stringify({
           base58_encoded_transaction: transaction,
           network,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        }),
+      },
+      this.client.retry,
+    );
+  }
+
+  /**
+   * Sponsor transactions as a Jito bundle.
+   * @param transactions - Base58-encoded serialized transactions
+   * @param network - Network to use ('mainnet' only)
+   */
+  async sponsorBundle(
+    transactions: string[],
+    network: Network,
+    idempotencyKey?: string,
+  ): Promise<ApiResponse<SponsorBundleResponse>> {
+    const baseUrl = this.#requirePaymasterUrl();
+    const url = `${baseUrl}/paymaster/sponsor/bundle`;
+    return request<SponsorBundleResponse>(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.client.apiKey}`,
+        },
+        body: JSON.stringify({
+          base58_encoded_transactions: transactions,
+          network,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
         }),
       },
       this.client.retry,

--- a/packages/api/src/paymaster/index.ts
+++ b/packages/api/src/paymaster/index.ts
@@ -5,6 +5,8 @@ export type {
   ServiceStatus,
   SignRequest,
   SignResponse,
+  SponsorBundleRequest,
+  SponsorBundleResponse,
   SponsorRequest,
   SponsorResponse,
 } from './types.js';

--- a/packages/api/src/paymaster/types.ts
+++ b/packages/api/src/paymaster/types.ts
@@ -5,6 +5,17 @@ export interface SponsorRequest {
   base58_encoded_transaction: string;
   /** Network to use (defaults to 'mainnet') */
   network?: Network;
+  /** Optional client-supplied idempotency key */
+  idempotencyKey?: string;
+}
+
+export interface SponsorBundleRequest {
+  /** Base58-encoded serialized transactions */
+  base58_encoded_transactions: string[];
+  /** Network to use */
+  network: Network;
+  /** Optional client-supplied idempotency key */
+  idempotencyKey?: string;
 }
 
 export interface SignRequest {
@@ -19,6 +30,17 @@ export interface SponsorResponse {
   request_id: string;
   /** Transaction signature */
   signature: string;
+  /** Amount of lamports spent by the paymaster */
+  spent_by_paymaster: number;
+}
+
+export interface SponsorBundleResponse {
+  /** Unique request ID for tracking */
+  request_id: string;
+  /** Jito bundle ID */
+  bundle_id: string;
+  /** Transaction signatures in bundle order */
+  signatures: string[];
   /** Amount of lamports spent by the paymaster */
   spent_by_paymaster: number;
 }

--- a/packages/api/src/paymaster/types.ts
+++ b/packages/api/src/paymaster/types.ts
@@ -37,12 +37,12 @@ export interface SponsorResponse {
 export interface SponsorBundleResponse {
   /** Unique request ID for tracking */
   request_id: string;
-  /** Jito bundle ID */
+  /** Jito bundle ID accepted by the Block Engine */
   bundle_id: string;
   /** Transaction signatures in bundle order */
   signatures: string[];
-  /** Amount of lamports spent by the paymaster */
-  spent_by_paymaster: number;
+  /** Pre-submission estimate of paymaster-funded fees and Jito tips */
+  estimated_spent_by_paymaster: string;
 }
 
 export interface SignResponse {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -16,25 +16,34 @@ export class ApiError extends Error {
 
   static fromResponse(response: Response, body?: unknown): ApiError {
     const errorBody = body as Record<string, unknown> | undefined;
+    const grpcMessage = response.headers.get('grpc-message');
+    const grpcStatus = response.headers.get('grpc-status');
+    const decodedGrpcMessage = grpcMessage
+      ? decodeURIComponent(grpcMessage)
+      : undefined;
 
     const nestedError = errorBody?.error as
       | { code?: string; message?: string }
       | undefined;
     if (nestedError && typeof nestedError === 'object') {
       const message =
-        nestedError.message ?? `Request failed with status ${response.status}`;
-      const code = nestedError.code ?? `HTTP_${response.status}`;
+        nestedError.message ??
+        decodedGrpcMessage ??
+        `Request failed with status ${response.status}`;
+      const code = nestedError.code ?? grpcStatus ?? `HTTP_${response.status}`;
       return new ApiError(message, code, response.status, errorBody);
     }
 
     const message =
       (errorBody?.message as string) ||
       (errorBody?.error as string) ||
+      decodedGrpcMessage ||
       `Request failed with status ${response.status}`;
 
     const code =
       (errorBody?.error_code as string) ||
       (errorBody?.code as string) ||
+      grpcStatus ||
       `HTTP_${response.status}`;
 
     return new ApiError(message, code, response.status, errorBody?.details);

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -18,9 +18,7 @@ export class ApiError extends Error {
     const errorBody = body as Record<string, unknown> | undefined;
     const grpcMessage = response.headers.get('grpc-message');
     const grpcStatus = response.headers.get('grpc-status');
-    const decodedGrpcMessage = grpcMessage
-      ? decodeURIComponent(grpcMessage)
-      : undefined;
+    const decodedGrpcMessage = safelyDecodeGrpcMessage(grpcMessage);
 
     const nestedError = errorBody?.error as
       | { code?: string; message?: string }
@@ -59,6 +57,18 @@ export class ApiError extends Error {
     }
 
     return new ApiError('An unknown error occurred', 'UNKNOWN_ERROR', 0);
+  }
+}
+
+function safelyDecodeGrpcMessage(message: string | null): string | undefined {
+  if (!message) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(message);
+  } catch {
+    return message;
   }
 }
 

--- a/packages/paymaster/classic/package.json
+++ b/packages/paymaster/classic/package.json
@@ -12,8 +12,8 @@
     "build-pkg": "tsup-node",
     "build": "tsup-node",
     "dev": "tsup-node --watch",
-    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src",
-    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src --fix",
+    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests",
+    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests --fix",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/paymaster/classic/src/index.ts
+++ b/packages/paymaster/classic/src/index.ts
@@ -2,6 +2,7 @@ import { address } from '@solana/kit';
 import {
   Connection,
   PublicKey,
+  SystemProgram,
   Transaction,
   TransactionInstruction,
   TransactionMessage,
@@ -10,11 +11,23 @@ import {
   type TransactionSignature,
 } from '@solana/web3.js';
 import {
+  getJitoTipAccount,
   PaymasterClient as PaymasterClientInternal,
+  PaymasterError,
+  resolveJitoTipLamports,
+  serializedBundleHasJitoTip,
+  type JitoBundleOptions,
   type PaymasterConfig,
+  type PaymasterSubmitOptions,
+  type SponsorBundleResult,
 } from '@swig-wallet/paymaster-core';
 
-export { type PaymasterConfig } from '@swig-wallet/paymaster-core';
+export {
+  type JitoBundleOptions,
+  type PaymasterConfig,
+  type PaymasterSubmitOptions,
+  type SponsorBundleResult,
+} from '@swig-wallet/paymaster-core';
 
 /**
  * Creates a new PaymasterClient instance for use with @solana/web3.js 1.x.
@@ -123,9 +136,33 @@ export class PaymasterClient {
    *
    * @see {@link signAndSend} for signing and sending transaction objects
    */
-  signAndSendSerializedTransaction = (serializedTransaction: Uint8Array) => {
+  signAndSendSerializedTransaction = (
+    serializedTransaction: Uint8Array,
+    options?: PaymasterSubmitOptions,
+  ) => {
     return this.#paymasterClientInternal.signAndSendSerializedTransaction(
       serializedTransaction,
+      options,
+    );
+  };
+
+  /**
+   * Signs and sends serialized transactions as a Jito bundle.
+   *
+   * If no transaction contains a Jito tip, the core client appends a separate
+   * paymaster-only tip transaction when the bundle still has room.
+   *
+   * @param serializedTransactions - Serialized transaction bytes
+   * @param options - Optional Jito bundle settings
+   * @returns Jito bundle submission result
+   */
+  signAndSendBundleSerializedTransactions = (
+    serializedTransactions: Uint8Array[],
+    options?: JitoBundleOptions,
+  ): Promise<SponsorBundleResult> => {
+    return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
+      serializedTransactions,
+      options,
     );
   };
 
@@ -231,6 +268,87 @@ export class PaymasterClient {
   };
 
   /**
+   * Creates a Jito tip instruction funded by the paymaster.
+   *
+   * Use this when constructing a bundle manually before user signatures are
+   * collected.
+   *
+   * @param options - Optional Jito bundle settings
+   * @returns System transfer instruction to a Jito tip account
+   */
+  createJitoTipInstruction = (
+    options?: JitoBundleOptions,
+  ): TransactionInstruction => {
+    return SystemProgram.transfer({
+      fromPubkey: new PublicKey(this.#config.paymasterPubkey),
+      toPubkey: new PublicKey(getJitoTipAccount()),
+      lamports: resolveJitoTipLamports(options),
+    });
+  };
+
+  /**
+   * Adds a Jito tip instruction to the last legacy transaction in a bundle.
+   *
+   * Call this before collecting user signatures. The method will not mutate a
+   * transaction that already has signatures, because changing the message would
+   * invalidate them.
+   *
+   * @param transactions - Unsigned legacy transactions to prepare
+   * @param options - Optional Jito bundle settings
+   * @returns The same transactions, with the tip added when needed
+   */
+  prepareJitoBundleTransactions = <T extends Transaction>(
+    transactions: T[],
+    options?: JitoBundleOptions,
+  ): T[] => {
+    if (transactions.length === 0) {
+      throw new PaymasterError('At least one transaction is required');
+    }
+
+    if (transactions.length > 5) {
+      throw new PaymasterError('Jito bundles support at most 5 transactions');
+    }
+
+    const serializedTransactions = transactions.map((transaction) =>
+      transaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      }),
+    );
+    if (
+      serializedBundleHasJitoTip(
+        serializedTransactions,
+        this.#config.paymasterPubkey,
+      )
+    ) {
+      return transactions;
+    }
+
+    const lastTransaction = transactions[transactions.length - 1]!;
+    if (lastTransaction.signatures.some(({ signature }) => signature)) {
+      throw new PaymasterError(
+        'prepareJitoBundleTransactions must be called before signing transactions',
+      );
+    }
+
+    lastTransaction.add(this.createJitoTipInstruction(options));
+    try {
+      lastTransaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      });
+    } catch (error) {
+      throw new PaymasterError(
+        error instanceof Error
+          ? `Unable to fit Jito tip instruction in the last transaction: ${error.message}`
+          : 'Unable to fit Jito tip instruction in the last transaction',
+      );
+    }
+
+    return transactions;
+  };
+
+  /**
    * Signs a transaction with the paymaster's signature.
    *
    * Takes a transaction (legacy or versioned) that has been signed by the
@@ -291,12 +409,40 @@ export class PaymasterClient {
    */
   signAndSend = <T extends Transaction | VersionedTransaction>(
     transaction: T,
+    options?: PaymasterSubmitOptions,
   ): Promise<TransactionSignature> => {
     return this.#paymasterClientInternal.signAndSendSerializedTransaction(
       transaction.serialize({
         requireAllSignatures: false,
         verifySignatures: false,
       }),
+      options,
+    );
+  };
+
+  /**
+   * Signs transactions with the paymaster and submits them as a Jito bundle.
+   *
+   * Provided transactions are submitted unchanged. If none contains a valid
+   * Jito tip, the SDK appends a separate paymaster-only tip transaction when
+   * the bundle still has room.
+   *
+   * @param transactions - User-signed transactions ready for paymaster signature
+   * @param options - Optional Jito bundle settings
+   * @returns Jito bundle submission result
+   */
+  signAndSendBundle = <T extends Transaction | VersionedTransaction>(
+    transactions: T[],
+    options?: JitoBundleOptions,
+  ): Promise<SponsorBundleResult> => {
+    return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
+      transactions.map((transaction) =>
+        transaction.serialize({
+          requireAllSignatures: false,
+          verifySignatures: false,
+        }),
+      ),
+      options,
     );
   };
 }

--- a/packages/paymaster/classic/src/index.ts
+++ b/packages/paymaster/classic/src/index.ts
@@ -15,7 +15,7 @@ import {
   PaymasterClient as PaymasterClientInternal,
   PaymasterError,
   resolveJitoTipLamports,
-  serializedBundleHasJitoTip,
+  serializedBundleHasSufficientJitoTip,
   type JitoBundleOptions,
   type PaymasterConfig,
   type PaymasterSubmitOptions,
@@ -149,16 +149,13 @@ export class PaymasterClient {
   /**
    * Signs and sends serialized transactions as a Jito bundle.
    *
-   * If no transaction contains a Jito tip, the core client appends a separate
-   * paymaster-only tip transaction when the bundle still has room.
-   *
    * @param serializedTransactions - Serialized transaction bytes
-   * @param options - Optional Jito bundle settings
-   * @returns Jito bundle submission result
+   * @param options - Optional submission settings
+   * @returns Jito Block Engine acceptance result
    */
   signAndSendBundleSerializedTransactions = (
     serializedTransactions: Uint8Array[],
-    options?: JitoBundleOptions,
+    options?: PaymasterSubmitOptions,
   ): Promise<SponsorBundleResult> => {
     return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
       serializedTransactions,
@@ -316,7 +313,7 @@ export class PaymasterClient {
       }),
     );
     if (
-      serializedBundleHasJitoTip(
+      serializedBundleHasSufficientJitoTip(
         serializedTransactions,
         this.#config.paymasterPubkey,
       )
@@ -338,6 +335,7 @@ export class PaymasterClient {
         verifySignatures: false,
       });
     } catch (error) {
+      lastTransaction.instructions.pop();
       throw new PaymasterError(
         error instanceof Error
           ? `Unable to fit Jito tip instruction in the last transaction: ${error.message}`
@@ -423,17 +421,16 @@ export class PaymasterClient {
   /**
    * Signs transactions with the paymaster and submits them as a Jito bundle.
    *
-   * Provided transactions are submitted unchanged. If none contains a valid
-   * Jito tip, the SDK appends a separate paymaster-only tip transaction when
-   * the bundle still has room.
+   * Provided transactions are submitted unchanged and must already contain at
+   * least 1,000 aggregate Jito tip lamports.
    *
    * @param transactions - User-signed transactions ready for paymaster signature
-   * @param options - Optional Jito bundle settings
-   * @returns Jito bundle submission result
+   * @param options - Optional submission settings
+   * @returns Jito Block Engine acceptance result
    */
   signAndSendBundle = <T extends Transaction | VersionedTransaction>(
     transactions: T[],
-    options?: JitoBundleOptions,
+    options?: PaymasterSubmitOptions,
   ): Promise<SponsorBundleResult> => {
     return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
       transactions.map((transaction) =>

--- a/packages/paymaster/classic/tests/jito.test.ts
+++ b/packages/paymaster/classic/tests/jito.test.ts
@@ -1,0 +1,91 @@
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { describe, expect, test } from 'bun:test';
+import { createPaymasterClient } from '../src/index.js';
+
+const PAYMASTER_ADDRESS = 'Ac2z6B25qv5rHprsMi7mcGo1LgkJ5kdxaUejxFcKGxZS';
+const MEMO_PROGRAM_ADDRESS = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+const TEST_BLOCKHASH = '11111111111111111111111111111111';
+
+describe('PaymasterClient.prepareJitoBundleTransactions', () => {
+  test('adds a tip before signing', () => {
+    const client = createClient();
+    const transaction = createTransaction(32);
+
+    const prepared = client.prepareJitoBundleTransactions([transaction], {
+      tipLamports: 1_000,
+    });
+
+    expect(prepared).toBeArrayOfSize(1);
+    expect(prepared[0]).toBe(transaction);
+    expect(transaction.instructions).toBeArrayOfSize(2);
+  });
+
+  test('restores the transaction when the tip does not fit', () => {
+    const client = createClient();
+    const transaction = createTransactionAtTipSizeBoundary(client);
+    const originalInstruction = transaction.instructions[0];
+
+    expect(() =>
+      client.prepareJitoBundleTransactions([transaction], {
+        tipLamports: 1_000,
+      }),
+    ).toThrow('Unable to fit Jito tip instruction in the last transaction');
+
+    expect(transaction.instructions).toEqual([originalInstruction]);
+  });
+});
+
+function createClient() {
+  return createPaymasterClient({
+    apiKey: 'sk_test',
+    paymasterPubkey: PAYMASTER_ADDRESS,
+    baseUrl: 'http://localhost:8080',
+    network: 'mainnet',
+  });
+}
+
+function createTransaction(dataLength: number): Transaction {
+  return new Transaction({
+    feePayer: new PublicKey(PAYMASTER_ADDRESS),
+    recentBlockhash: TEST_BLOCKHASH,
+  }).add(
+    new TransactionInstruction({
+      programId: new PublicKey(MEMO_PROGRAM_ADDRESS),
+      keys: [],
+      data: Buffer.alloc(dataLength, 1),
+    }),
+  );
+}
+
+function createTransactionAtTipSizeBoundary(
+  client: ReturnType<typeof createClient>,
+): Transaction {
+  for (let dataLength = 900; dataLength <= 1_100; dataLength++) {
+    const transaction = createTransaction(dataLength);
+    try {
+      transaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      });
+    } catch {
+      continue;
+    }
+
+    const candidate = createTransaction(dataLength);
+    candidate.add(client.createJitoTipInstruction({ tipLamports: 1_000 }));
+    try {
+      candidate.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      });
+    } catch {
+      return transaction;
+    }
+  }
+
+  throw new Error('Unable to construct a transaction at the tip size boundary');
+}

--- a/packages/paymaster/classic/tsconfig.json
+++ b/packages/paymaster/classic/tsconfig.json
@@ -22,6 +22,10 @@
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  }
+    "noPropertyAccessFromIndexSignature": false,
+
+    // Add this for test globals
+    "types": ["bun", "node"]
+  },
+  "include": ["src", "tests"]
 }

--- a/packages/paymaster/core/package.json
+++ b/packages/paymaster/core/package.json
@@ -12,8 +12,8 @@
     "build-pkg": "tsup-node",
     "build": "tsup-node",
     "dev": "tsup-node --watch",
-    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src",
-    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src --fix",
+    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests",
+    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests --fix",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/paymaster/core/src/client.ts
+++ b/packages/paymaster/core/src/client.ts
@@ -4,28 +4,12 @@
  * @packageDocumentation
  */
 
-import {
-  address,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithinSizeLimit,
-  compileTransaction,
-  createSolanaRpc,
-  createTransactionMessage,
-  getBase58Codec,
-  getTransactionEncoder,
-  pipe,
-  setTransactionMessageFeePayer,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from '@solana/kit';
+import { getBase58Codec } from '@solana/kit';
 import { SwigApiClient } from '@swig-wallet/api';
 import { isPaymasterFeePayer } from './helpers.js';
 import { createIdempotencyKey } from './idempotency.js';
-import {
-  createJitoTipInstruction,
-  serializedBundleHasJitoTip,
-} from './jito.js';
+import { serializedBundleHasSufficientJitoTip } from './jito.js';
 import type {
-  JitoBundleOptions,
   PaymasterConfig,
   PaymasterSubmitOptions,
   SerializedTransaction,
@@ -42,7 +26,6 @@ export class PaymasterClient {
   readonly #api: SwigApiClient;
   readonly #paymasterPubkey: string;
   readonly #network: 'mainnet' | 'devnet';
-  readonly #rpcUrl: string;
 
   /**
    * Creates a new PaymasterClient instance.
@@ -67,11 +50,6 @@ export class PaymasterClient {
     });
     this.#paymasterPubkey = config.paymasterPubkey;
     this.#network = config.network;
-    this.#rpcUrl =
-      config.customRpcUrl ??
-      (config.network === 'devnet'
-        ? 'https://api.devnet.solana.com'
-        : 'https://api.mainnet-beta.solana.com');
   }
 
   /**
@@ -179,17 +157,16 @@ export class PaymasterClient {
    * Signs serialized transactions with the paymaster and submits them as a
    * Jito bundle.
    *
-   * Already-signed user transactions are never mutated. If none of the provided
-   * transactions contains a valid Jito tip transfer, the SDK appends a separate
-   * paymaster-only tip transaction when the bundle still has room.
+   * Already-signed user transactions are never mutated. The submitted bundle
+   * must already contain at least 1,000 aggregate Jito tip lamports.
    *
    * @param serializedTransactions - Serialized transactions with paymaster as fee payer
-   * @param options - Optional Jito bundle settings
+   * @param options - Optional submission settings
    * @returns Jito Block Engine acceptance result. The bundle may still be pending.
    */
   public async signAndSendBundleSerializedTransactions(
     serializedTransactions: SerializedTransaction[],
-    options?: JitoBundleOptions,
+    options?: PaymasterSubmitOptions,
   ): Promise<SponsorBundleResult> {
     if (this.#network !== 'mainnet') {
       throw new PaymasterError('Jito bundles are only supported on mainnet');
@@ -211,18 +188,18 @@ export class PaymasterClient {
       }
     }
 
-    const bundle = [...serializedTransactions];
-    if (!serializedBundleHasJitoTip(bundle, this.#paymasterPubkey)) {
-      if (bundle.length === 5) {
-        throw new PaymasterError(
-          'Jito bundle requires a tip, but no tip was found and the bundle already has 5 transactions',
-        );
-      }
-
-      bundle.push(await this.#createSerializedJitoTipTransaction(options));
+    if (
+      !serializedBundleHasSufficientJitoTip(
+        serializedTransactions,
+        this.#paymasterPubkey,
+      )
+    ) {
+      throw new PaymasterError(
+        'Jito bundle must include at least 1000 lamports in recognized tip instructions',
+      );
     }
 
-    const base58Transactions = bundle.map((transaction) =>
+    const base58Transactions = serializedTransactions.map((transaction) =>
       getBase58Codec().decode(transaction),
     );
     const { data, error } = await this.#api.paymaster.sponsorBundle(
@@ -241,32 +218,5 @@ export class PaymasterClient {
       signatures: data.signatures,
       estimatedSpentByPaymaster: BigInt(data.estimated_spent_by_paymaster),
     };
-  }
-
-  async #createSerializedJitoTipTransaction(
-    options?: JitoBundleOptions,
-  ): Promise<SerializedTransaction> {
-    const { value: latestBlockhash } = await createSolanaRpc(this.#rpcUrl)
-      .getLatestBlockhash()
-      .send();
-    const transactionMessage = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayer(address(this.#paymasterPubkey), tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) =>
-        appendTransactionMessageInstructions(
-          [
-            createJitoTipInstruction({
-              paymasterPubkey: this.#paymasterPubkey,
-              tipLamports: options?.tipLamports,
-            }),
-          ],
-          tx,
-        ),
-    );
-    const transaction = compileTransaction(transactionMessage);
-    assertIsTransactionWithinSizeLimit(transaction);
-
-    return new Uint8Array(getTransactionEncoder().encode(transaction));
   }
 }

--- a/packages/paymaster/core/src/client.ts
+++ b/packages/paymaster/core/src/client.ts
@@ -4,10 +4,33 @@
  * @packageDocumentation
  */
 
-import { getBase58Codec } from '@solana/kit';
+import {
+  address,
+  appendTransactionMessageInstructions,
+  assertIsTransactionWithinSizeLimit,
+  compileTransaction,
+  createSolanaRpc,
+  createTransactionMessage,
+  getBase58Codec,
+  getTransactionEncoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
 import { SwigApiClient } from '@swig-wallet/api';
 import { isPaymasterFeePayer } from './helpers.js';
-import type { PaymasterConfig, SerializedTransaction } from './types.js';
+import { createIdempotencyKey } from './idempotency.js';
+import {
+  createJitoTipInstruction,
+  serializedBundleHasJitoTip,
+} from './jito.js';
+import type {
+  JitoBundleOptions,
+  PaymasterConfig,
+  PaymasterSubmitOptions,
+  SerializedTransaction,
+  SponsorBundleResult,
+} from './types.js';
 import { PaymasterError } from './types.js';
 
 /**
@@ -19,6 +42,7 @@ export class PaymasterClient {
   readonly #api: SwigApiClient;
   readonly #paymasterPubkey: string;
   readonly #network: 'mainnet' | 'devnet';
+  readonly #rpcUrl: string;
 
   /**
    * Creates a new PaymasterClient instance.
@@ -43,6 +67,11 @@ export class PaymasterClient {
     });
     this.#paymasterPubkey = config.paymasterPubkey;
     this.#network = config.network;
+    this.#rpcUrl =
+      config.customRpcUrl ??
+      (config.network === 'devnet'
+        ? 'https://api.devnet.solana.com'
+        : 'https://api.mainnet-beta.solana.com');
   }
 
   /**
@@ -126,6 +155,7 @@ export class PaymasterClient {
    */
   public async signAndSendSerializedTransaction(
     serializedTx: SerializedTransaction,
+    options?: PaymasterSubmitOptions,
   ): Promise<string> {
     if (!this.isPaymasterFeePayer(serializedTx)) {
       throw new PaymasterError('Paymaster public key not set as fee payer');
@@ -135,6 +165,7 @@ export class PaymasterClient {
     const { data, error } = await this.#api.paymaster.sponsor(
       base58Tx,
       this.#network,
+      options?.idempotencyKey ?? createIdempotencyKey(),
     );
 
     if (error || !data) {
@@ -142,5 +173,100 @@ export class PaymasterClient {
     }
 
     return data.signature;
+  }
+
+  /**
+   * Signs serialized transactions with the paymaster and submits them as a
+   * Jito bundle.
+   *
+   * Already-signed user transactions are never mutated. If none of the provided
+   * transactions contains a valid Jito tip transfer, the SDK appends a separate
+   * paymaster-only tip transaction when the bundle still has room.
+   *
+   * @param serializedTransactions - Serialized transactions with paymaster as fee payer
+   * @param options - Optional Jito bundle settings
+   * @returns Jito bundle submission result
+   */
+  public async signAndSendBundleSerializedTransactions(
+    serializedTransactions: SerializedTransaction[],
+    options?: JitoBundleOptions,
+  ): Promise<SponsorBundleResult> {
+    if (this.#network !== 'mainnet') {
+      throw new PaymasterError('Jito bundles are only supported on mainnet');
+    }
+
+    if (serializedTransactions.length === 0) {
+      throw new PaymasterError('At least one transaction is required');
+    }
+
+    if (serializedTransactions.length > 5) {
+      throw new PaymasterError('Jito bundles support at most 5 transactions');
+    }
+
+    for (const [index, transaction] of serializedTransactions.entries()) {
+      if (!this.isPaymasterFeePayer(transaction)) {
+        throw new PaymasterError(
+          `Paymaster public key not set as fee payer for transaction ${index}`,
+        );
+      }
+    }
+
+    const bundle = [...serializedTransactions];
+    if (!serializedBundleHasJitoTip(bundle, this.#paymasterPubkey)) {
+      if (bundle.length === 5) {
+        throw new PaymasterError(
+          'Jito bundle requires a tip, but no tip was found and the bundle already has 5 transactions',
+        );
+      }
+
+      bundle.push(await this.#createSerializedJitoTipTransaction(options));
+    }
+
+    const base58Transactions = bundle.map((transaction) =>
+      getBase58Codec().decode(transaction),
+    );
+    const { data, error } = await this.#api.paymaster.sponsorBundle(
+      base58Transactions,
+      this.#network,
+      options?.idempotencyKey ?? createIdempotencyKey(),
+    );
+
+    if (error || !data) {
+      throw PaymasterError.fromApiError(error!);
+    }
+
+    return {
+      requestId: data.request_id,
+      bundleId: data.bundle_id,
+      signatures: data.signatures,
+      spentByPaymaster: data.spent_by_paymaster,
+    };
+  }
+
+  async #createSerializedJitoTipTransaction(
+    options?: JitoBundleOptions,
+  ): Promise<SerializedTransaction> {
+    const { value: latestBlockhash } = await createSolanaRpc(this.#rpcUrl)
+      .getLatestBlockhash()
+      .send();
+    const transactionMessage = pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayer(address(this.#paymasterPubkey), tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) =>
+        appendTransactionMessageInstructions(
+          [
+            createJitoTipInstruction({
+              paymasterPubkey: this.#paymasterPubkey,
+              tipLamports: options?.tipLamports,
+            }),
+          ],
+          tx,
+        ),
+    );
+    const transaction = compileTransaction(transactionMessage);
+    assertIsTransactionWithinSizeLimit(transaction);
+
+    return new Uint8Array(getTransactionEncoder().encode(transaction));
   }
 }

--- a/packages/paymaster/core/src/client.ts
+++ b/packages/paymaster/core/src/client.ts
@@ -8,7 +8,10 @@ import { getBase58Codec } from '@solana/kit';
 import { SwigApiClient } from '@swig-wallet/api';
 import { isPaymasterFeePayer } from './helpers.js';
 import { createIdempotencyKey } from './idempotency.js';
-import { serializedBundleHasSufficientJitoTip } from './jito.js';
+import {
+  serializedBundleHasSufficientJitoTip,
+  serializedTransactionHasLookupLoadedPaymasterInstruction,
+} from './jito.js';
 import type {
   PaymasterConfig,
   PaymasterSubmitOptions,
@@ -16,6 +19,9 @@ import type {
   SponsorBundleResult,
 } from './types.js';
 import { PaymasterError } from './types.js';
+
+const DECIMAL_U64_PATTERN = /^[0-9]+$/;
+const MAX_U64 = 18_446_744_073_709_551_615n;
 
 /**
  * Client for interacting with the Swig Paymaster service.
@@ -186,6 +192,16 @@ export class PaymasterClient {
           `Paymaster public key not set as fee payer for transaction ${index}`,
         );
       }
+      if (
+        serializedTransactionHasLookupLoadedPaymasterInstruction(
+          transaction,
+          this.#paymasterPubkey,
+        )
+      ) {
+        throw new PaymasterError(
+          `Jito bundle transaction ${index} contains an ALT-loaded instruction that references the paymaster`,
+        );
+      }
     }
 
     if (
@@ -212,11 +228,68 @@ export class PaymasterClient {
       throw PaymasterError.fromApiError(error!);
     }
 
-    return {
-      requestId: data.request_id,
-      bundleId: data.bundle_id,
-      signatures: data.signatures,
-      estimatedSpentByPaymaster: BigInt(data.estimated_spent_by_paymaster),
-    };
+    return parseSponsorBundleResponse(data, serializedTransactions.length);
   }
+}
+
+function parseSponsorBundleResponse(
+  response: unknown,
+  expectedSignatureCount: number,
+): SponsorBundleResult {
+  if (!isRecord(response)) {
+    throw invalidSponsorBundleResponse('expected an object');
+  }
+
+  const requestId = requireNonEmptyString(response.request_id, 'request_id');
+  const bundleId = requireNonEmptyString(response.bundle_id, 'bundle_id');
+  const signatures = response.signatures;
+  if (!Array.isArray(signatures)) {
+    throw invalidSponsorBundleResponse('signatures must be an array');
+  }
+  if (signatures.length !== expectedSignatureCount) {
+    throw invalidSponsorBundleResponse(
+      `expected ${expectedSignatureCount} signatures, received ${signatures.length}`,
+    );
+  }
+  const parsedSignatures = signatures.map((signature, index) =>
+    requireNonEmptyString(signature, `signatures[${index}]`),
+  );
+
+  const estimatedSpend = response.estimated_spent_by_paymaster;
+  if (
+    typeof estimatedSpend !== 'string' ||
+    !DECIMAL_U64_PATTERN.test(estimatedSpend)
+  ) {
+    throw invalidSponsorBundleResponse(
+      'estimated_spent_by_paymaster must be a decimal u64 string',
+    );
+  }
+  const estimatedSpentByPaymaster = BigInt(estimatedSpend);
+  if (estimatedSpentByPaymaster > MAX_U64) {
+    throw invalidSponsorBundleResponse(
+      'estimated_spent_by_paymaster must be a decimal u64 string',
+    );
+  }
+
+  return {
+    requestId,
+    bundleId,
+    signatures: parsedSignatures,
+    estimatedSpentByPaymaster,
+  };
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw invalidSponsorBundleResponse(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function invalidSponsorBundleResponse(reason: string): PaymasterError {
+  return new PaymasterError(`Invalid sponsor bundle response: ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/paymaster/core/src/client.ts
+++ b/packages/paymaster/core/src/client.ts
@@ -185,7 +185,7 @@ export class PaymasterClient {
    *
    * @param serializedTransactions - Serialized transactions with paymaster as fee payer
    * @param options - Optional Jito bundle settings
-   * @returns Jito bundle submission result
+   * @returns Jito Block Engine acceptance result. The bundle may still be pending.
    */
   public async signAndSendBundleSerializedTransactions(
     serializedTransactions: SerializedTransaction[],
@@ -239,7 +239,7 @@ export class PaymasterClient {
       requestId: data.request_id,
       bundleId: data.bundle_id,
       signatures: data.signatures,
-      spentByPaymaster: data.spent_by_paymaster,
+      estimatedSpentByPaymaster: BigInt(data.estimated_spent_by_paymaster),
     };
   }
 

--- a/packages/paymaster/core/src/helpers.ts
+++ b/packages/paymaster/core/src/helpers.ts
@@ -1,5 +1,4 @@
 import {
-  decompileTransactionMessage,
   getCompiledTransactionMessageDecoder,
   getTransactionDecoder,
 } from '@solana/kit';
@@ -27,17 +26,11 @@ export function isPaymasterFeePayer(
   serializedTx: SerializedTransaction,
   paymasterPubkey: string,
 ): boolean {
-  // Decode the transaction from bytes
   const transaction = getTransactionDecoder().decode(serializedTx);
-
   const compiledTransactionMessage =
     getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
 
-  // Decompile the transaction to get the transaction message
-  const transactionMessage = decompileTransactionMessage(
-    compiledTransactionMessage,
+  return (
+    compiledTransactionMessage.staticAccounts[0]?.toString() === paymasterPubkey
   );
-
-  // Check if the fee payer matches the paymaster public key
-  return transactionMessage.feePayer.address.toString() === paymasterPubkey;
 }

--- a/packages/paymaster/core/src/idempotency.ts
+++ b/packages/paymaster/core/src/idempotency.ts
@@ -1,0 +1,17 @@
+export function createIdempotencyKey(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+      '',
+    );
+  }
+
+  return `${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/packages/paymaster/core/src/index.ts
+++ b/packages/paymaster/core/src/index.ts
@@ -12,12 +12,24 @@ export { PaymasterClient } from './client.js';
 
 // Export transaction utilities
 export { isPaymasterFeePayer } from './helpers.js';
+export {
+  createJitoTipInstruction,
+  getJitoTipAccount,
+  isJitoTipAccount,
+  resolveJitoTipLamports,
+  serializedBundleHasJitoTip,
+  serializedTransactionHasJitoTip,
+  transactionMessageHasJitoTip,
+} from './jito.js';
 
 // Export types
 export type {
+  JitoBundleOptions,
   PaymasterConfig,
+  PaymasterSubmitOptions,
   RetryOptions,
   SerializedTransaction,
+  SponsorBundleResult,
 } from './types.js';
 
 export { PaymasterError } from './types.js';

--- a/packages/paymaster/core/src/index.ts
+++ b/packages/paymaster/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   resolveJitoTipLamports,
   serializedBundleHasSufficientJitoTip,
   serializedTransactionJitoTipLamports,
+  transactionMessageHasLookupLoadedPaymasterInstruction,
   transactionMessageJitoTipLamports,
 } from './jito.js';
 

--- a/packages/paymaster/core/src/index.ts
+++ b/packages/paymaster/core/src/index.ts
@@ -16,10 +16,11 @@ export {
   createJitoTipInstruction,
   getJitoTipAccount,
   isJitoTipAccount,
+  isValidJitoTipTotal,
   resolveJitoTipLamports,
-  serializedBundleHasJitoTip,
-  serializedTransactionHasJitoTip,
-  transactionMessageHasJitoTip,
+  serializedBundleHasSufficientJitoTip,
+  serializedTransactionJitoTipLamports,
+  transactionMessageJitoTipLamports,
 } from './jito.js';
 
 // Export types

--- a/packages/paymaster/core/src/jito.ts
+++ b/packages/paymaster/core/src/jito.ts
@@ -1,0 +1,151 @@
+import {
+  AccountRole,
+  address,
+  decompileTransactionMessage,
+  getCompiledTransactionMessageDecoder,
+  getTransactionDecoder,
+  type Instruction,
+} from '@solana/kit';
+import { PaymasterError, type JitoBundleOptions } from './types.js';
+
+const DEFAULT_JITO_TIP_LAMPORTS = 10_000n;
+const MIN_JITO_TIP_LAMPORTS = 1_000n;
+const SYSTEM_PROGRAM_ADDRESS_STRING = '11111111111111111111111111111111';
+const SYSTEM_TRANSFER_DISCRIMINATOR = 2;
+const MAX_U64 = 18_446_744_073_709_551_615n;
+
+const TIP_ACCOUNTS = [
+  '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5',
+  'HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe',
+  'Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY',
+  'ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49',
+  'DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh',
+  'ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt',
+  'DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL',
+  '3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT',
+];
+
+export function getJitoTipAccount(): string {
+  return TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)]!;
+}
+
+export function isJitoTipAccount(pubkey: string): boolean {
+  return TIP_ACCOUNTS.includes(pubkey);
+}
+
+export function resolveJitoTipLamports(options?: JitoBundleOptions): bigint {
+  const tipLamports = options?.tipLamports ?? DEFAULT_JITO_TIP_LAMPORTS;
+
+  if (typeof tipLamports === 'number') {
+    if (
+      !Number.isSafeInteger(tipLamports) ||
+      BigInt(tipLamports) < MIN_JITO_TIP_LAMPORTS
+    ) {
+      throw new PaymasterError('Jito tip lamports must be at least 1000');
+    }
+    return BigInt(tipLamports);
+  }
+
+  if (tipLamports < MIN_JITO_TIP_LAMPORTS || tipLamports > MAX_U64) {
+    throw new PaymasterError('Jito tip lamports must be a u64 value >= 1000');
+  }
+
+  return tipLamports;
+}
+
+export function createJitoTipInstruction(args: {
+  paymasterPubkey: string;
+  tipLamports?: number | bigint;
+}): Instruction {
+  const tipLamports = resolveJitoTipLamports({
+    tipLamports: args.tipLamports,
+  });
+
+  return {
+    programAddress: address(SYSTEM_PROGRAM_ADDRESS_STRING),
+    accounts: [
+      {
+        address: address(args.paymasterPubkey),
+        role: AccountRole.WRITABLE_SIGNER,
+      },
+      {
+        address: address(getJitoTipAccount()),
+        role: AccountRole.WRITABLE,
+      },
+    ],
+    data: encodeSystemTransferInstruction(tipLamports),
+  };
+}
+
+export function serializedTransactionHasJitoTip(
+  serializedTx: Uint8Array,
+  paymasterPubkey: string,
+): boolean {
+  const transaction = getTransactionDecoder().decode(serializedTx);
+  const compiledTransactionMessage =
+    getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+  const transactionMessage = decompileTransactionMessage(
+    compiledTransactionMessage,
+  );
+
+  return transactionMessageHasJitoTip(transactionMessage, paymasterPubkey);
+}
+
+export function serializedBundleHasJitoTip(
+  serializedTransactions: Uint8Array[],
+  paymasterPubkey: string,
+): boolean {
+  return serializedTransactions.some((transaction) =>
+    serializedTransactionHasJitoTip(transaction, paymasterPubkey),
+  );
+}
+
+export function transactionMessageHasJitoTip(
+  transactionMessage: { instructions: readonly Instruction[] },
+  paymasterPubkey: string,
+): boolean {
+  return transactionMessage.instructions.some((instruction) =>
+    instructionIsJitoTip(instruction, paymasterPubkey),
+  );
+}
+
+function instructionIsJitoTip(
+  instruction: Instruction,
+  paymasterPubkey: string,
+): boolean {
+  const accounts = instruction.accounts;
+  if (
+    instruction.programAddress.toString() !== SYSTEM_PROGRAM_ADDRESS_STRING ||
+    !accounts ||
+    accounts.length < 2 ||
+    accounts[0]?.address.toString() !== paymasterPubkey ||
+    !isJitoTipAccount(accounts[1]?.address.toString() ?? '')
+  ) {
+    return false;
+  }
+
+  return decodeSystemTransferLamports(instruction.data) > 0n;
+}
+
+function encodeSystemTransferInstruction(lamports: bigint): Uint8Array {
+  const data = new Uint8Array(12);
+  const view = new DataView(data.buffer);
+  view.setUint32(0, SYSTEM_TRANSFER_DISCRIMINATOR, true);
+  view.setBigUint64(4, lamports, true);
+  return data;
+}
+
+function decodeSystemTransferLamports(
+  data?: Pick<Uint8Array, 'buffer' | 'byteLength' | 'byteOffset'>,
+): bigint {
+  if (!data || data.byteLength < 12) {
+    return 0n;
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  if (view.getUint32(0, true) !== SYSTEM_TRANSFER_DISCRIMINATOR) {
+    return 0n;
+  }
+
+  return view.getBigUint64(4, true);
+}

--- a/packages/paymaster/core/src/jito.ts
+++ b/packages/paymaster/core/src/jito.ts
@@ -122,6 +122,42 @@ export function transactionMessageJitoTipLamports(
   );
 }
 
+export function serializedTransactionHasLookupLoadedPaymasterInstruction(
+  serializedTx: Uint8Array,
+  paymasterPubkey: string,
+): boolean {
+  const transaction = getTransactionDecoder().decode(serializedTx);
+  const message = getCompiledTransactionMessageDecoder().decode(
+    transaction.messageBytes,
+  );
+
+  return message.instructions.some((instruction) => {
+    const accountIndices = instruction.accountIndices;
+    return (
+      accountIndices?.some(
+        (index) =>
+          message.staticAccounts[index]?.toString() === paymasterPubkey,
+      ) === true &&
+      (instruction.programAddressIndex >= message.staticAccounts.length ||
+        accountIndices.some((index) => index >= message.staticAccounts.length))
+    );
+  });
+}
+
+export function transactionMessageHasLookupLoadedPaymasterInstruction(
+  transactionMessage: { instructions: readonly Instruction[] },
+  paymasterPubkey: string,
+): boolean {
+  return transactionMessage.instructions.some((instruction) => {
+    const accounts = instruction.accounts;
+    return (
+      accounts?.some(
+        (account) => account.address.toString() === paymasterPubkey,
+      ) === true && accounts.some((account) => 'lookupTableAddress' in account)
+    );
+  });
+}
+
 export function isValidJitoTipTotal(tipLamports: bigint): boolean {
   return tipLamports >= MIN_JITO_TIP_LAMPORTS && tipLamports <= MAX_U64;
 }

--- a/packages/paymaster/core/src/jito.ts
+++ b/packages/paymaster/core/src/jito.ts
@@ -1,9 +1,9 @@
 import {
   AccountRole,
   address,
-  decompileTransactionMessage,
   getCompiledTransactionMessageDecoder,
   getTransactionDecoder,
+  type CompiledTransactionMessage,
   type Instruction,
 } from '@solana/kit';
 import { PaymasterError, type JitoBundleOptions } from './types.js';
@@ -77,54 +77,96 @@ export function createJitoTipInstruction(args: {
   };
 }
 
-export function serializedTransactionHasJitoTip(
+export function serializedTransactionJitoTipLamports(
   serializedTx: Uint8Array,
   paymasterPubkey: string,
-): boolean {
+): bigint {
   const transaction = getTransactionDecoder().decode(serializedTx);
   const compiledTransactionMessage =
     getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
-  const transactionMessage = decompileTransactionMessage(
-    compiledTransactionMessage,
-  );
 
-  return transactionMessageHasJitoTip(transactionMessage, paymasterPubkey);
+  return compiledTransactionMessage.instructions.reduce(
+    (total, instruction) =>
+      total +
+      compiledInstructionJitoTipLamports(
+        compiledTransactionMessage,
+        instruction,
+        paymasterPubkey,
+      ),
+    0n,
+  );
 }
 
-export function serializedBundleHasJitoTip(
+export function serializedBundleHasSufficientJitoTip(
   serializedTransactions: Uint8Array[],
   paymasterPubkey: string,
 ): boolean {
-  return serializedTransactions.some((transaction) =>
-    serializedTransactionHasJitoTip(transaction, paymasterPubkey),
+  const tipLamports = serializedTransactions.reduce(
+    (total, transaction) =>
+      total +
+      serializedTransactionJitoTipLamports(transaction, paymasterPubkey),
+    0n,
   );
+
+  return isValidJitoTipTotal(tipLamports);
 }
 
-export function transactionMessageHasJitoTip(
+export function transactionMessageJitoTipLamports(
   transactionMessage: { instructions: readonly Instruction[] },
   paymasterPubkey: string,
-): boolean {
-  return transactionMessage.instructions.some((instruction) =>
-    instructionIsJitoTip(instruction, paymasterPubkey),
+): bigint {
+  return transactionMessage.instructions.reduce(
+    (total, instruction) =>
+      total + instructionJitoTipLamports(instruction, paymasterPubkey),
+    0n,
   );
 }
 
-function instructionIsJitoTip(
+export function isValidJitoTipTotal(tipLamports: bigint): boolean {
+  return tipLamports >= MIN_JITO_TIP_LAMPORTS && tipLamports <= MAX_U64;
+}
+
+function instructionJitoTipLamports(
   instruction: Instruction,
   paymasterPubkey: string,
-): boolean {
+): bigint {
   const accounts = instruction.accounts;
   if (
     instruction.programAddress.toString() !== SYSTEM_PROGRAM_ADDRESS_STRING ||
     !accounts ||
     accounts.length < 2 ||
+    accounts.some((account) => 'lookupTableAddress' in account) ||
     accounts[0]?.address.toString() !== paymasterPubkey ||
     !isJitoTipAccount(accounts[1]?.address.toString() ?? '')
   ) {
-    return false;
+    return 0n;
   }
 
-  return decodeSystemTransferLamports(instruction.data) > 0n;
+  return decodeSystemTransferLamports(instruction.data);
+}
+
+function compiledInstructionJitoTipLamports(
+  message: CompiledTransactionMessage,
+  instruction: CompiledTransactionMessage['instructions'][number],
+  paymasterPubkey: string,
+): bigint {
+  const accountIndices = instruction.accountIndices;
+  if (
+    message.staticAccounts[instruction.programAddressIndex]?.toString() !==
+      SYSTEM_PROGRAM_ADDRESS_STRING ||
+    !accountIndices ||
+    accountIndices.length < 2 ||
+    accountIndices.some((index) => index >= message.staticAccounts.length) ||
+    message.staticAccounts[accountIndices[0]!]?.toString() !==
+      paymasterPubkey ||
+    !isJitoTipAccount(
+      message.staticAccounts[accountIndices[1]!]?.toString() ?? '',
+    )
+  ) {
+    return 0n;
+  }
+
+  return decodeSystemTransferLamports(instruction.data);
 }
 
 function encodeSystemTransferInstruction(lamports: bigint): Uint8Array {

--- a/packages/paymaster/core/src/types.ts
+++ b/packages/paymaster/core/src/types.ts
@@ -45,7 +45,7 @@ export interface PaymasterSubmitOptions {
   idempotencyKey?: string;
 }
 
-export interface JitoBundleOptions extends PaymasterSubmitOptions {
+export interface JitoBundleOptions {
   /** Jito tip lamports. Defaults to the SDK's current bundle tip amount. */
   tipLamports?: number | bigint;
 }

--- a/packages/paymaster/core/src/types.ts
+++ b/packages/paymaster/core/src/types.ts
@@ -37,6 +37,30 @@ export interface PaymasterConfig {
  */
 export type SerializedTransaction = Uint8Array;
 
+export interface PaymasterSubmitOptions {
+  /**
+   * Optional opaque idempotency key for submit operations.
+   * If omitted, the SDK generates one per submit call.
+   */
+  idempotencyKey?: string;
+}
+
+export interface JitoBundleOptions extends PaymasterSubmitOptions {
+  /** Jito tip lamports. Defaults to the SDK's current bundle tip amount. */
+  tipLamports?: number | bigint;
+}
+
+export interface SponsorBundleResult {
+  /** Unique request ID for tracking */
+  requestId: string;
+  /** Jito bundle ID */
+  bundleId: string;
+  /** Transaction signatures in submitted bundle order */
+  signatures: string[];
+  /** Amount of lamports spent by the paymaster */
+  spentByPaymaster: number;
+}
+
 /**
  * Error thrown by the PaymasterClient when API requests or operations fail.
  *

--- a/packages/paymaster/core/src/types.ts
+++ b/packages/paymaster/core/src/types.ts
@@ -53,12 +53,15 @@ export interface JitoBundleOptions extends PaymasterSubmitOptions {
 export interface SponsorBundleResult {
   /** Unique request ID for tracking */
   requestId: string;
-  /** Jito bundle ID */
+  /** Jito bundle ID accepted by the Block Engine */
   bundleId: string;
   /** Transaction signatures in submitted bundle order */
   signatures: string[];
-  /** Amount of lamports spent by the paymaster */
-  spentByPaymaster: number;
+  /**
+   * Pre-submission estimate of paymaster-funded transaction fees and Jito tips.
+   * Confirmed fee-payer balance-delta settlement remains authoritative.
+   */
+  estimatedSpentByPaymaster: bigint;
 }
 
 /**

--- a/packages/paymaster/core/tests/client.test.ts
+++ b/packages/paymaster/core/tests/client.test.ts
@@ -6,6 +6,8 @@ import {
   createSerializedTransaction,
   createTipInstruction,
   createUnrelatedLookupInstruction,
+  JITO_TIP_ADDRESS,
+  LOOKUP_TABLE_ADDRESS,
   PAYMASTER_ADDRESS,
 } from './fixtures.js';
 
@@ -16,10 +18,11 @@ afterEach(() => {
 });
 
 describe('PaymasterClient.signAndSendBundleSerializedTransactions', () => {
-  test('submits the prepared bundle unchanged and maps estimated spend', async () => {
-    const transaction = createSerializedTransaction([
-      createTipInstruction(1_000n),
-    ]);
+  test('submits two prepared transactions unchanged and preserves signature order', async () => {
+    const transactions = [
+      createSerializedTransaction([createTipInstruction(400n)]),
+      createSerializedTransaction([createTipInstruction(600n)]),
+    ];
     let capturedBody: unknown;
     globalThis.fetch = (async (input, init) => {
       const request = new Request(input, init);
@@ -28,8 +31,8 @@ describe('PaymasterClient.signAndSendBundleSerializedTransactions', () => {
         JSON.stringify({
           request_id: 'request-1',
           bundle_id: 'bundle-1',
-          signatures: ['signature-1'],
-          estimated_spent_by_paymaster: '6000',
+          signatures: ['signature-1', 'signature-2'],
+          estimated_spent_by_paymaster: '11000',
         }),
         {
           status: 200,
@@ -40,21 +43,106 @@ describe('PaymasterClient.signAndSendBundleSerializedTransactions', () => {
     const client = createClient();
 
     const result = await client.signAndSendBundleSerializedTransactions(
-      [transaction],
+      transactions,
       { idempotencyKey: 'bundle-key' },
     );
 
     expect(capturedBody).toEqual({
-      base58_encoded_transactions: [getBase58Codec().decode(transaction)],
+      base58_encoded_transactions: transactions.map((transaction) =>
+        getBase58Codec().decode(transaction),
+      ),
       network: 'mainnet',
       idempotencyKey: 'bundle-key',
     });
     expect(result).toEqual({
       requestId: 'request-1',
       bundleId: 'bundle-1',
-      signatures: ['signature-1'],
-      estimatedSpentByPaymaster: 6_000n,
+      signatures: ['signature-1', 'signature-2'],
+      estimatedSpentByPaymaster: 11_000n,
     });
+  });
+
+  test('rejects response signature cardinality mismatches', async () => {
+    const transactions = createTwoTransactionBundle();
+    const client = createClient();
+
+    for (const signatures of [
+      ['signature-1'],
+      ['signature-1', 'signature-2', 'signature-3'],
+    ]) {
+      mockSponsorBundleResponse({ signatures });
+      await expect(
+        client.signAndSendBundleSerializedTransactions(transactions),
+      ).rejects.toThrow(
+        `Invalid sponsor bundle response: expected 2 signatures, received ${signatures.length}`,
+      );
+    }
+  });
+
+  test('rejects malformed required response fields', async () => {
+    const transactions = createTwoTransactionBundle();
+    const client = createClient();
+    const cases: Array<{
+      response: Record<string, unknown>;
+      message: string;
+    }> = [
+      {
+        response: { request_id: '' },
+        message:
+          'Invalid sponsor bundle response: request_id must be a non-empty string',
+      },
+      {
+        response: { bundle_id: ' ' },
+        message:
+          'Invalid sponsor bundle response: bundle_id must be a non-empty string',
+      },
+      {
+        response: { signatures: ['signature-1', 2] },
+        message:
+          'Invalid sponsor bundle response: signatures[1] must be a non-empty string',
+      },
+      {
+        response: { estimated_spent_by_paymaster: '-1' },
+        message:
+          'Invalid sponsor bundle response: estimated_spent_by_paymaster must be a decimal u64 string',
+      },
+      {
+        response: {
+          estimated_spent_by_paymaster: '18446744073709551616',
+        },
+        message:
+          'Invalid sponsor bundle response: estimated_spent_by_paymaster must be a decimal u64 string',
+      },
+    ];
+
+    for (const { response, message } of cases) {
+      mockSponsorBundleResponse(response);
+      await expect(
+        client.signAndSendBundleSerializedTransactions(transactions),
+      ).rejects.toThrow(message);
+    }
+  });
+
+  test('rejects an ALT-loaded paymaster instruction before making a request', async () => {
+    const transactions = [
+      createSerializedTransaction([createTipInstruction(1_000n)], {
+        [LOOKUP_TABLE_ADDRESS]: [JITO_TIP_ADDRESS],
+      }),
+      createSerializedTransaction([createTipInstruction(1_000n)]),
+    ];
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+    const client = createClient();
+
+    await expect(
+      client.signAndSendBundleSerializedTransactions(transactions),
+    ).rejects.toThrow(
+      'Jito bundle transaction 0 contains an ALT-loaded instruction that references the paymaster',
+    );
+    expect(fetchCalled).toBe(false);
   });
 
   test('rejects an insufficiently tipped bundle before making a request', async () => {
@@ -89,4 +177,28 @@ function createClient(): PaymasterClient {
       maxRetries: 0,
     },
   });
+}
+
+function createTwoTransactionBundle(): Uint8Array[] {
+  return [
+    createSerializedTransaction([createTipInstruction(400n)]),
+    createSerializedTransaction([createTipInstruction(600n)]),
+  ];
+}
+
+function mockSponsorBundleResponse(overrides: Record<string, unknown>): void {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        request_id: 'request-1',
+        bundle_id: 'bundle-1',
+        signatures: ['signature-1', 'signature-2'],
+        estimated_spent_by_paymaster: '11000',
+        ...overrides,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as unknown as typeof fetch;
 }

--- a/packages/paymaster/core/tests/client.test.ts
+++ b/packages/paymaster/core/tests/client.test.ts
@@ -1,0 +1,92 @@
+import { getBase58Codec } from '@solana/kit';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { PaymasterClient } from '../src/client.js';
+import { PaymasterError } from '../src/types.js';
+import {
+  createSerializedTransaction,
+  createTipInstruction,
+  createUnrelatedLookupInstruction,
+  PAYMASTER_ADDRESS,
+} from './fixtures.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('PaymasterClient.signAndSendBundleSerializedTransactions', () => {
+  test('submits the prepared bundle unchanged and maps estimated spend', async () => {
+    const transaction = createSerializedTransaction([
+      createTipInstruction(1_000n),
+    ]);
+    let capturedBody: unknown;
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init);
+      capturedBody = JSON.parse(await request.text());
+      return new Response(
+        JSON.stringify({
+          request_id: 'request-1',
+          bundle_id: 'bundle-1',
+          signatures: ['signature-1'],
+          estimated_spent_by_paymaster: '6000',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }) as typeof fetch;
+    const client = createClient();
+
+    const result = await client.signAndSendBundleSerializedTransactions(
+      [transaction],
+      { idempotencyKey: 'bundle-key' },
+    );
+
+    expect(capturedBody).toEqual({
+      base58_encoded_transactions: [getBase58Codec().decode(transaction)],
+      network: 'mainnet',
+      idempotencyKey: 'bundle-key',
+    });
+    expect(result).toEqual({
+      requestId: 'request-1',
+      bundleId: 'bundle-1',
+      signatures: ['signature-1'],
+      estimatedSpentByPaymaster: 6_000n,
+    });
+  });
+
+  test('rejects an insufficiently tipped bundle before making a request', async () => {
+    const transaction = createSerializedTransaction([
+      createUnrelatedLookupInstruction(),
+    ]);
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+    const client = createClient();
+
+    expect(
+      client.signAndSendBundleSerializedTransactions([transaction]),
+    ).rejects.toEqual(
+      new PaymasterError(
+        'Jito bundle must include at least 1000 lamports in recognized tip instructions',
+      ),
+    );
+    expect(fetchCalled).toBe(false);
+  });
+});
+
+function createClient(): PaymasterClient {
+  return new PaymasterClient({
+    apiKey: 'sk_test',
+    paymasterPubkey: PAYMASTER_ADDRESS,
+    baseUrl: 'http://localhost:8080',
+    network: 'mainnet',
+    retryOptions: {
+      maxRetries: 0,
+    },
+  });
+}

--- a/packages/paymaster/core/tests/fixtures.ts
+++ b/packages/paymaster/core/tests/fixtures.ts
@@ -1,0 +1,119 @@
+import {
+  AccountRole,
+  address,
+  appendTransactionMessageInstructions,
+  blockhash,
+  compileTransaction,
+  compressTransactionMessageUsingAddressLookupTables,
+  createTransactionMessage,
+  getTransactionEncoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Instruction,
+} from '@solana/kit';
+
+export const PAYMASTER_ADDRESS = 'Ac2z6B25qv5rHprsMi7mcGo1LgkJ5kdxaUejxFcKGxZS';
+export const JITO_TIP_ADDRESS = '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5';
+export const LOOKUP_TABLE_ADDRESS =
+  'Hex8Pe25n1yhMcQGVSfJUUKo2EqRv6MQDMYGZkwQpVpG';
+export const LOOKUP_ACCOUNT_ADDRESS =
+  'EtES4FyCEegf71P6NGFsWTabyJPeaq5kJz7UkJvSD21Z';
+
+const MEMO_PROGRAM_ADDRESS = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111';
+const TEST_BLOCKHASH = blockhash('11111111111111111111111111111111');
+
+export function createSerializedTransaction(
+  instructions: Instruction[],
+  lookupTableAddresses?: Record<string, readonly string[]>,
+): Uint8Array {
+  const transactionMessage = pipe(
+    createTransactionMessage({ version: 0 }),
+    (message) =>
+      setTransactionMessageFeePayer(address(PAYMASTER_ADDRESS), message),
+    (message) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: TEST_BLOCKHASH,
+          lastValidBlockHeight: 1n,
+        },
+        message,
+      ),
+    (message) => appendTransactionMessageInstructions(instructions, message),
+  );
+  const compressedMessage = lookupTableAddresses
+    ? compressTransactionMessageUsingAddressLookupTables(
+        transactionMessage,
+        Object.fromEntries(
+          Object.entries(lookupTableAddresses).map(([table, accounts]) => [
+            address(table),
+            accounts.map((account) => address(account)),
+          ]),
+        ),
+      )
+    : transactionMessage;
+  const transaction = compileTransaction(compressedMessage);
+
+  return new Uint8Array(getTransactionEncoder().encode(transaction));
+}
+
+export function createSerializedLegacyTransaction(
+  instructions: Instruction[],
+): Uint8Array {
+  const transactionMessage = pipe(
+    createTransactionMessage({ version: 'legacy' }),
+    (message) =>
+      setTransactionMessageFeePayer(address(PAYMASTER_ADDRESS), message),
+    (message) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: TEST_BLOCKHASH,
+          lastValidBlockHeight: 1n,
+        },
+        message,
+      ),
+    (message) => appendTransactionMessageInstructions(instructions, message),
+  );
+  const transaction = compileTransaction(transactionMessage);
+
+  return new Uint8Array(getTransactionEncoder().encode(transaction));
+}
+
+export function createTipInstruction(lamports: bigint): Instruction {
+  return {
+    programAddress: address(SYSTEM_PROGRAM_ADDRESS),
+    accounts: [
+      {
+        address: address(PAYMASTER_ADDRESS),
+        role: AccountRole.WRITABLE_SIGNER,
+      },
+      {
+        address: address(JITO_TIP_ADDRESS),
+        role: AccountRole.WRITABLE,
+      },
+    ],
+    data: encodeSystemTransfer(lamports),
+  };
+}
+
+export function createUnrelatedLookupInstruction(): Instruction {
+  return {
+    programAddress: address(MEMO_PROGRAM_ADDRESS),
+    accounts: [
+      {
+        address: address(LOOKUP_ACCOUNT_ADDRESS),
+        role: AccountRole.READONLY,
+      },
+    ],
+    data: new Uint8Array([1]),
+  };
+}
+
+function encodeSystemTransfer(lamports: bigint): Uint8Array {
+  const data = new Uint8Array(12);
+  const view = new DataView(data.buffer);
+  view.setUint32(0, 2, true);
+  view.setBigUint64(4, lamports, true);
+  return data;
+}

--- a/packages/paymaster/core/tests/jito.test.ts
+++ b/packages/paymaster/core/tests/jito.test.ts
@@ -1,0 +1,132 @@
+import {
+  address,
+  appendTransactionMessageInstructions,
+  compressTransactionMessageUsingAddressLookupTables,
+  createTransactionMessage,
+  pipe,
+} from '@solana/kit';
+import { describe, expect, test } from 'bun:test';
+import { isPaymasterFeePayer } from '../src/helpers.js';
+import {
+  serializedBundleHasSufficientJitoTip,
+  serializedTransactionJitoTipLamports,
+  transactionMessageJitoTipLamports,
+} from '../src/jito.js';
+import {
+  createSerializedLegacyTransaction,
+  createSerializedTransaction,
+  createTipInstruction,
+  createUnrelatedLookupInstruction,
+  JITO_TIP_ADDRESS,
+  LOOKUP_ACCOUNT_ADDRESS,
+  LOOKUP_TABLE_ADDRESS,
+  PAYMASTER_ADDRESS,
+} from './fixtures.js';
+
+describe('serialized Jito bundle inspection', () => {
+  test('reads a legacy fee payer from static accounts', () => {
+    const transaction = createSerializedLegacyTransaction([
+      createTipInstruction(1_000n),
+    ]);
+
+    expect(isPaymasterFeePayer(transaction, PAYMASTER_ADDRESS)).toBe(true);
+    expect(isPaymasterFeePayer(transaction, LOOKUP_ACCOUNT_ADDRESS)).toBe(
+      false,
+    );
+  });
+
+  test('reads a v0 fee payer without resolving unrelated lookup accounts', () => {
+    const transaction = createSerializedTransaction(
+      [createUnrelatedLookupInstruction()],
+      {
+        [LOOKUP_TABLE_ADDRESS]: [LOOKUP_ACCOUNT_ADDRESS],
+      },
+    );
+
+    expect(isPaymasterFeePayer(transaction, PAYMASTER_ADDRESS)).toBe(true);
+    expect(
+      serializedTransactionJitoTipLamports(transaction, PAYMASTER_ADDRESS),
+    ).toBe(0n);
+  });
+
+  test('recognizes a static Jito tip', () => {
+    const transaction = createSerializedTransaction([
+      createTipInstruction(1_000n),
+    ]);
+
+    expect(
+      serializedTransactionJitoTipLamports(transaction, PAYMASTER_ADDRESS),
+    ).toBe(1_000n);
+  });
+
+  test('does not recognize an ALT-loaded Jito destination', () => {
+    const transaction = createSerializedTransaction(
+      [createTipInstruction(1_000n)],
+      {
+        [LOOKUP_TABLE_ADDRESS]: [JITO_TIP_ADDRESS],
+      },
+    );
+
+    expect(
+      serializedTransactionJitoTipLamports(transaction, PAYMASTER_ADDRESS),
+    ).toBe(0n);
+  });
+
+  test('recognizes a static tip alongside an unrelated ALT instruction', () => {
+    const transaction = createSerializedTransaction(
+      [createTipInstruction(1_000n), createUnrelatedLookupInstruction()],
+      {
+        [LOOKUP_TABLE_ADDRESS]: [LOOKUP_ACCOUNT_ADDRESS],
+      },
+    );
+
+    expect(isPaymasterFeePayer(transaction, PAYMASTER_ADDRESS)).toBe(true);
+    expect(
+      serializedTransactionJitoTipLamports(transaction, PAYMASTER_ADDRESS),
+    ).toBe(1_000n);
+    expect(
+      serializedBundleHasSufficientJitoTip([transaction], PAYMASTER_ADDRESS),
+    ).toBe(true);
+  });
+
+  test('requires at least 1,000 aggregate tip lamports', () => {
+    const oneLamport = createSerializedTransaction([createTipInstruction(1n)]);
+    const fiveHundredA = createSerializedTransaction([
+      createTipInstruction(500n),
+    ]);
+    const fiveHundredB = createSerializedTransaction([
+      createTipInstruction(500n),
+    ]);
+
+    expect(
+      serializedBundleHasSufficientJitoTip([oneLamport], PAYMASTER_ADDRESS),
+    ).toBe(false);
+    expect(
+      serializedBundleHasSufficientJitoTip(
+        [fiveHundredA, fiveHundredB],
+        PAYMASTER_ADDRESS,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('transaction message Jito tip inspection', () => {
+  test('does not recognize lookup-backed tip accounts before compilation', () => {
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (transactionMessage) =>
+        appendTransactionMessageInstructions(
+          [createTipInstruction(1_000n)],
+          transactionMessage,
+        ),
+      (transactionMessage) =>
+        compressTransactionMessageUsingAddressLookupTables(transactionMessage, {
+          [address(LOOKUP_TABLE_ADDRESS)]: [address(JITO_TIP_ADDRESS)],
+        }),
+    );
+
+    expect(transactionMessageJitoTipLamports(message, PAYMASTER_ADDRESS)).toBe(
+      0n,
+    );
+  });
+});

--- a/packages/paymaster/core/tsconfig.json
+++ b/packages/paymaster/core/tsconfig.json
@@ -25,7 +25,7 @@
     "noPropertyAccessFromIndexSignature": false,
 
     // Add this for test globals
-    "types": ["jest", "node"]
+    "types": ["bun", "node"]
   },
   // Add this to include tests
   "include": ["src", "tests"]

--- a/packages/paymaster/kit/package.json
+++ b/packages/paymaster/kit/package.json
@@ -12,8 +12,8 @@
     "build-pkg": "tsup-node",
     "build": "tsup-node",
     "dev": "tsup-node --watch",
-    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src",
-    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src --fix",
+    "lint": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests",
+    "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src tests --fix",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/paymaster/kit/src/index.ts
+++ b/packages/paymaster/kit/src/index.ts
@@ -23,11 +23,21 @@ import {
   type TransactionWithLifetime,
 } from '@solana/kit';
 import {
+  createJitoTipInstruction as createCoreJitoTipInstruction,
+  type JitoBundleOptions,
   PaymasterClient as PaymasterClientInternal,
   type PaymasterConfig,
+  type PaymasterSubmitOptions,
+  type SponsorBundleResult,
+  transactionMessageHasJitoTip,
 } from '@swig-wallet/paymaster-core';
 
-export { type PaymasterConfig } from '@swig-wallet/paymaster-core';
+export {
+  type JitoBundleOptions,
+  type PaymasterConfig,
+  type PaymasterSubmitOptions,
+  type SponsorBundleResult,
+} from '@swig-wallet/paymaster-core';
 
 /**
  * Creates a new PaymasterClient instance for use with @solana/kit (web3.js 2.0).
@@ -181,10 +191,102 @@ export class PaymasterClient {
    *
    * @see {@link signAndSend} for signing and sending transaction objects
    */
-  signAndSendSerializedTransaction = (serializedTransaction: Uint8Array) => {
+  signAndSendSerializedTransaction = (
+    serializedTransaction: Uint8Array,
+    options?: PaymasterSubmitOptions,
+  ) => {
     return this.#paymasterClientInternal.signAndSendSerializedTransaction(
       serializedTransaction,
+      options,
     );
+  };
+
+  /**
+   * Signs and sends serialized transactions as a Jito bundle.
+   *
+   * If no transaction contains a Jito tip, the core client appends a separate
+   * paymaster-only tip transaction when the bundle still has room.
+   *
+   * @param serializedTransactions - Serialized transaction bytes
+   * @param options - Optional Jito bundle settings
+   * @returns Jito bundle submission result
+   */
+  signAndSendBundleSerializedTransactions = (
+    serializedTransactions: Uint8Array[],
+    options?: JitoBundleOptions,
+  ): Promise<SponsorBundleResult> => {
+    return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
+      serializedTransactions,
+      options,
+    );
+  };
+
+  /**
+   * Creates a Jito tip instruction funded by the paymaster.
+   *
+   * Use this when constructing a bundle manually before user signatures are
+   * collected.
+   *
+   * @param options - Optional Jito bundle settings
+   * @returns System transfer instruction to a Jito tip account
+   */
+  createJitoTipInstruction = (options?: JitoBundleOptions): Instruction => {
+    return createCoreJitoTipInstruction({
+      paymasterPubkey: this.#config.paymasterPubkey,
+      tipLamports: options?.tipLamports,
+    });
+  };
+
+  /**
+   * Adds a Jito tip instruction to the last transaction message in a bundle.
+   *
+   * Call this before collecting user signatures. If a valid Jito tip is already
+   * present, the messages are returned unchanged.
+   *
+   * @param transactionMessages - Transaction messages to prepare
+   * @param options - Optional Jito bundle settings
+   * @returns Transaction messages with the tip added when needed
+   */
+  prepareJitoBundleTransactionMessages = <
+    M extends CompilableTransactionMessage &
+      TransactionMessageWithBlockhashLifetime,
+  >(
+    transactionMessages: M[],
+    options?: JitoBundleOptions,
+  ): M[] => {
+    if (transactionMessages.length === 0) {
+      throw new Error('At least one transaction message is required');
+    }
+
+    if (transactionMessages.length > 5) {
+      throw new Error('Jito bundles support at most 5 transactions');
+    }
+
+    if (
+      transactionMessages.some((transactionMessage) =>
+        transactionMessageHasJitoTip(
+          transactionMessage,
+          this.#config.paymasterPubkey,
+        ),
+      )
+    ) {
+      return transactionMessages;
+    }
+
+    const lastIndex = transactionMessages.length - 1;
+    const preparedMessages = transactionMessages.map(
+      (transactionMessage, index) =>
+        index === lastIndex
+          ? (appendTransactionMessageInstructions(
+              [this.createJitoTipInstruction(options)],
+              transactionMessage,
+            ) as unknown as M)
+          : transactionMessage,
+    );
+    const transaction = compileTransaction(preparedMessages[lastIndex]!);
+    assertIsTransactionWithinSizeLimit(transaction);
+
+    return preparedMessages;
   };
 
   /**
@@ -330,12 +432,39 @@ export class PaymasterClient {
    */
   signAndSend = async <T extends Transaction & TransactionWithLifetime>(
     partiallySignedTransaction: T & TransactionWithinSizeLimit,
+    options?: PaymasterSubmitOptions,
   ): Promise<string> => {
     const serializedTx = new Uint8Array(
       getTransactionCodec().encode(partiallySignedTransaction),
     );
     return this.#paymasterClientInternal.signAndSendSerializedTransaction(
       serializedTx,
+      options,
+    );
+  };
+
+  /**
+   * Signs transactions with the paymaster and submits them as a Jito bundle.
+   *
+   * Provided transactions are submitted unchanged. If none contains a valid
+   * Jito tip, the SDK appends a separate paymaster-only tip transaction when
+   * the bundle still has room.
+   *
+   * @param partiallySignedTransactions - User-signed transactions ready for paymaster signature
+   * @param options - Optional Jito bundle settings
+   * @returns Jito bundle submission result
+   */
+  signAndSendBundle = async <T extends Transaction & TransactionWithLifetime>(
+    partiallySignedTransactions: Array<T & TransactionWithinSizeLimit>,
+    options?: JitoBundleOptions,
+  ): Promise<SponsorBundleResult> => {
+    const serializedTransactions = partiallySignedTransactions.map(
+      (transaction) =>
+        new Uint8Array(getTransactionCodec().encode(transaction)),
+    );
+    return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
+      serializedTransactions,
+      options,
     );
   };
 }

--- a/packages/paymaster/kit/src/index.ts
+++ b/packages/paymaster/kit/src/index.ts
@@ -24,12 +24,13 @@ import {
 } from '@solana/kit';
 import {
   createJitoTipInstruction as createCoreJitoTipInstruction,
+  isValidJitoTipTotal,
   type JitoBundleOptions,
   PaymasterClient as PaymasterClientInternal,
   type PaymasterConfig,
   type PaymasterSubmitOptions,
   type SponsorBundleResult,
-  transactionMessageHasJitoTip,
+  transactionMessageJitoTipLamports,
 } from '@swig-wallet/paymaster-core';
 
 export {
@@ -204,16 +205,13 @@ export class PaymasterClient {
   /**
    * Signs and sends serialized transactions as a Jito bundle.
    *
-   * If no transaction contains a Jito tip, the core client appends a separate
-   * paymaster-only tip transaction when the bundle still has room.
-   *
    * @param serializedTransactions - Serialized transaction bytes
-   * @param options - Optional Jito bundle settings
-   * @returns Jito bundle submission result
+   * @param options - Optional submission settings
+   * @returns Jito Block Engine acceptance result
    */
   signAndSendBundleSerializedTransactions = (
     serializedTransactions: Uint8Array[],
-    options?: JitoBundleOptions,
+    options?: PaymasterSubmitOptions,
   ): Promise<SponsorBundleResult> => {
     return this.#paymasterClientInternal.signAndSendBundleSerializedTransactions(
       serializedTransactions,
@@ -262,14 +260,16 @@ export class PaymasterClient {
       throw new Error('Jito bundles support at most 5 transactions');
     }
 
-    if (
-      transactionMessages.some((transactionMessage) =>
-        transactionMessageHasJitoTip(
+    const tipLamports = transactionMessages.reduce(
+      (total, transactionMessage) =>
+        total +
+        transactionMessageJitoTipLamports(
           transactionMessage,
           this.#config.paymasterPubkey,
         ),
-      )
-    ) {
+      0n,
+    );
+    if (isValidJitoTipTotal(tipLamports)) {
       return transactionMessages;
     }
 
@@ -446,17 +446,16 @@ export class PaymasterClient {
   /**
    * Signs transactions with the paymaster and submits them as a Jito bundle.
    *
-   * Provided transactions are submitted unchanged. If none contains a valid
-   * Jito tip, the SDK appends a separate paymaster-only tip transaction when
-   * the bundle still has room.
+   * Provided transactions are submitted unchanged and must already contain at
+   * least 1,000 aggregate Jito tip lamports.
    *
    * @param partiallySignedTransactions - User-signed transactions ready for paymaster signature
-   * @param options - Optional Jito bundle settings
-   * @returns Jito bundle submission result
+   * @param options - Optional submission settings
+   * @returns Jito Block Engine acceptance result
    */
   signAndSendBundle = async <T extends Transaction & TransactionWithLifetime>(
     partiallySignedTransactions: Array<T & TransactionWithinSizeLimit>,
-    options?: JitoBundleOptions,
+    options?: PaymasterSubmitOptions,
   ): Promise<SponsorBundleResult> => {
     const serializedTransactions = partiallySignedTransactions.map(
       (transaction) =>

--- a/packages/paymaster/kit/src/index.ts
+++ b/packages/paymaster/kit/src/index.ts
@@ -28,8 +28,10 @@ import {
   type JitoBundleOptions,
   PaymasterClient as PaymasterClientInternal,
   type PaymasterConfig,
+  PaymasterError,
   type PaymasterSubmitOptions,
   type SponsorBundleResult,
+  transactionMessageHasLookupLoadedPaymasterInstruction,
   transactionMessageJitoTipLamports,
 } from '@swig-wallet/paymaster-core';
 
@@ -258,6 +260,19 @@ export class PaymasterClient {
 
     if (transactionMessages.length > 5) {
       throw new Error('Jito bundles support at most 5 transactions');
+    }
+
+    if (
+      transactionMessages.some((transactionMessage) =>
+        transactionMessageHasLookupLoadedPaymasterInstruction(
+          transactionMessage,
+          this.#config.paymasterPubkey,
+        ),
+      )
+    ) {
+      throw new PaymasterError(
+        'Jito bundle instructions that reference the paymaster must use static accounts',
+      );
     }
 
     const tipLamports = transactionMessages.reduce(

--- a/packages/paymaster/kit/tests/jito.test.ts
+++ b/packages/paymaster/kit/tests/jito.test.ts
@@ -16,6 +16,8 @@ import { createPaymasterClient } from '../src/index.js';
 const PAYMASTER_ADDRESS = 'Ac2z6B25qv5rHprsMi7mcGo1LgkJ5kdxaUejxFcKGxZS';
 const JITO_TIP_ADDRESS = '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5';
 const LOOKUP_TABLE_ADDRESS = 'Hex8Pe25n1yhMcQGVSfJUUKo2EqRv6MQDMYGZkwQpVpG';
+const LOOKUP_ACCOUNT_ADDRESS = 'EtES4FyCEegf71P6NGFsWTabyJPeaq5kJz7UkJvSD21Z';
+const MEMO_PROGRAM_ADDRESS = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111';
 const TEST_BLOCKHASH = blockhash('11111111111111111111111111111111');
 
@@ -34,7 +36,7 @@ describe('PaymasterClient.prepareJitoBundleTransactionMessages', () => {
     expect(prepared[1]?.instructions).toBeArrayOfSize(1);
   });
 
-  test('does not count an ALT-loaded tip destination as a static tip', () => {
+  test('rejects a paymaster tip whose destination is ALT-loaded', () => {
     const client = createClient();
     const message = compressTransactionMessageUsingAddressLookupTables(
       createMessage(createTipInstruction(1_000n)),
@@ -44,9 +46,28 @@ describe('PaymasterClient.prepareJitoBundleTransactionMessages', () => {
     );
     const messages = [message];
 
+    expect(() => client.prepareJitoBundleTransactionMessages(messages)).toThrow(
+      'Jito bundle instructions that reference the paymaster must use static accounts',
+    );
+    expect(message.instructions).toBeArrayOfSize(1);
+  });
+
+  test('allows unrelated ALT-loaded accounts alongside a static tip', () => {
+    const client = createClient();
+    const message = compressTransactionMessageUsingAddressLookupTables(
+      createMessage(
+        createTipInstruction(1_000n),
+        createUnrelatedLookupInstruction(),
+      ),
+      {
+        [address(LOOKUP_TABLE_ADDRESS)]: [address(LOOKUP_ACCOUNT_ADDRESS)],
+      },
+    );
+    const messages = [message];
+
     const prepared = client.prepareJitoBundleTransactionMessages(messages);
 
-    expect(prepared).not.toBe(messages);
+    expect(prepared).toBe(messages);
     expect(prepared[0]?.instructions).toBeArrayOfSize(2);
   });
 });
@@ -60,7 +81,7 @@ function createClient() {
   });
 }
 
-function createMessage(instruction: Instruction) {
+function createMessage(...instructions: Instruction[]) {
   return pipe(
     createTransactionMessage({ version: 0 }),
     (message) =>
@@ -73,7 +94,7 @@ function createMessage(instruction: Instruction) {
         },
         message,
       ),
-    (message) => appendTransactionMessageInstructions([instruction], message),
+    (message) => appendTransactionMessageInstructions(instructions, message),
   );
 }
 
@@ -91,6 +112,19 @@ function createTipInstruction(lamports: bigint): Instruction {
       },
     ],
     data: encodeSystemTransfer(lamports),
+  };
+}
+
+function createUnrelatedLookupInstruction(): Instruction {
+  return {
+    programAddress: address(MEMO_PROGRAM_ADDRESS),
+    accounts: [
+      {
+        address: address(LOOKUP_ACCOUNT_ADDRESS),
+        role: AccountRole.READONLY,
+      },
+    ],
+    data: new Uint8Array([1]),
   };
 }
 

--- a/packages/paymaster/kit/tests/jito.test.ts
+++ b/packages/paymaster/kit/tests/jito.test.ts
@@ -1,0 +1,103 @@
+import {
+  AccountRole,
+  address,
+  appendTransactionMessageInstructions,
+  blockhash,
+  compressTransactionMessageUsingAddressLookupTables,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Instruction,
+} from '@solana/kit';
+import { describe, expect, test } from 'bun:test';
+import { createPaymasterClient } from '../src/index.js';
+
+const PAYMASTER_ADDRESS = 'Ac2z6B25qv5rHprsMi7mcGo1LgkJ5kdxaUejxFcKGxZS';
+const JITO_TIP_ADDRESS = '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5';
+const LOOKUP_TABLE_ADDRESS = 'Hex8Pe25n1yhMcQGVSfJUUKo2EqRv6MQDMYGZkwQpVpG';
+const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111';
+const TEST_BLOCKHASH = blockhash('11111111111111111111111111111111');
+
+describe('PaymasterClient.prepareJitoBundleTransactionMessages', () => {
+  test('accepts split tips that satisfy the aggregate minimum', () => {
+    const client = createClient();
+    const messages = [
+      createMessage(createTipInstruction(500n)),
+      createMessage(createTipInstruction(500n)),
+    ];
+
+    const prepared = client.prepareJitoBundleTransactionMessages(messages);
+
+    expect(prepared).toBe(messages);
+    expect(prepared[0]?.instructions).toBeArrayOfSize(1);
+    expect(prepared[1]?.instructions).toBeArrayOfSize(1);
+  });
+
+  test('does not count an ALT-loaded tip destination as a static tip', () => {
+    const client = createClient();
+    const message = compressTransactionMessageUsingAddressLookupTables(
+      createMessage(createTipInstruction(1_000n)),
+      {
+        [address(LOOKUP_TABLE_ADDRESS)]: [address(JITO_TIP_ADDRESS)],
+      },
+    );
+    const messages = [message];
+
+    const prepared = client.prepareJitoBundleTransactionMessages(messages);
+
+    expect(prepared).not.toBe(messages);
+    expect(prepared[0]?.instructions).toBeArrayOfSize(2);
+  });
+});
+
+function createClient() {
+  return createPaymasterClient({
+    apiKey: 'sk_test',
+    paymasterPubkey: PAYMASTER_ADDRESS,
+    baseUrl: 'http://localhost:8080',
+    network: 'mainnet',
+  });
+}
+
+function createMessage(instruction: Instruction) {
+  return pipe(
+    createTransactionMessage({ version: 0 }),
+    (message) =>
+      setTransactionMessageFeePayer(address(PAYMASTER_ADDRESS), message),
+    (message) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: TEST_BLOCKHASH,
+          lastValidBlockHeight: 1n,
+        },
+        message,
+      ),
+    (message) => appendTransactionMessageInstructions([instruction], message),
+  );
+}
+
+function createTipInstruction(lamports: bigint): Instruction {
+  return {
+    programAddress: address(SYSTEM_PROGRAM_ADDRESS),
+    accounts: [
+      {
+        address: address(PAYMASTER_ADDRESS),
+        role: AccountRole.WRITABLE_SIGNER,
+      },
+      {
+        address: address(JITO_TIP_ADDRESS),
+        role: AccountRole.WRITABLE,
+      },
+    ],
+    data: encodeSystemTransfer(lamports),
+  };
+}
+
+function encodeSystemTransfer(lamports: bigint): Uint8Array {
+  const data = new Uint8Array(12);
+  const view = new DataView(data.buffer);
+  view.setUint32(0, 2, true);
+  view.setBigUint64(4, lamports, true);
+  return data;
+}

--- a/packages/paymaster/kit/tsconfig.json
+++ b/packages/paymaster/kit/tsconfig.json
@@ -25,7 +25,7 @@
     "noPropertyAccessFromIndexSignature": false,
 
     // Add this for test globals
-    "types": ["jest", "node"]
+    "types": ["bun", "node"]
   },
   // Add this to include tests
   "include": ["src", "tests"]


### PR DESCRIPTION
## Summary

Adds Paymaster SDK support for sponsoring Jito bundles through the new `/paymaster/sponsor/bundle` endpoint.

## Changes

- Add sponsor-bundle API client/types.
- Add SDK idempotency key support for submit operations.
- Add Jito bundle helpers for:
  - creating paymaster-funded tip instructions
  - detecting existing Jito tips
  - validating minimum tip amounts
- Add `signAndSendBundle` APIs for classic and kit clients.
- Add serialized bundle submit helpers.
- Add a `jito-classic` paymaster example.
- Add `.env.example` for the Jito bundle example.
- Improve API error handling for gRPC-transcoded responses.

## Test Notes

- `bun --filter '@swig-wallet/paymaster-core' typecheck`
- `bun --filter '@swig-wallet/paymaster-classic' typecheck`
- `bun --filter '@swig-wallet/paymaster-kit' typecheck`
- `bun --filter '@swig-wallet/paymaster-core' build`
- `bun --filter '@swig-wallet/paymaster-classic' build`
- `bun --filter '@swig-wallet/paymaster-kit' build`

Manual E2E against local backend with Jito bundle flow completed successfully.