### PR TITLE
Feat(developer-sdk:typescript): x402 Swig Transaction Preparation

### DIFF
--- a/.changeset/bright-x402-prepare.md
+++ b/.changeset/bright-x402-prepare.md
@@ -1,0 +1,7 @@
+---
+'@swig-wallet/developer-sdk': minor
+---
+
+Add x402 exact-Solana payment preparation through server and browser wallet
+handles, plus generic signed-payment payload and `PAYMENT-SIGNATURE` header
+assembly.

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
       "dependencies": {
         "@solana/web3.js": "^1.98.0",
         "@swig-wallet/lib": "workspace:*",
+        "@x402/core": "2.21.0",
         "bs58": "^6.0.0",
       },
       "devDependencies": {
@@ -1272,6 +1273,8 @@
     "@walletconnect/window-getters": ["@walletconnect/window-getters@1.0.1", "", { "dependencies": { "tslib": "1.14.1" } }, "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q=="],
 
     "@walletconnect/window-metadata": ["@walletconnect/window-metadata@1.0.1", "", { "dependencies": { "@walletconnect/window-getters": "^1.0.1", "tslib": "1.14.1" } }, "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA=="],
+
+    "@x402/core": ["@x402/core@2.21.0", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-0djKE7V5/JKDMrjRe5he3DoMFzlbVnUcvMmLAb2j6OoAJDamupkFh6fFrXeoHwjkBIxOFUzjGI4FVixz2dMxSA=="],
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 

--- a/packages/developer-sdk/typescript/README.md
+++ b/packages/developer-sdk/typescript/README.md
@@ -240,8 +240,9 @@ Use `signPreparedTransaction` for Ed25519 authorities. For
 Secp256r1/passkey authorities, use `signPreparedSwigTransaction` to fulfill
 the prepared transaction's signature requests.
 
-Browser integrations require the merchant to expose `PAYMENT-REQUIRED`
-through CORS.
+Browser integrations require the resource server to expose
+`PAYMENT-REQUIRED` through `Access-Control-Expose-Headers` and allow
+`PAYMENT-SIGNATURE` through `Access-Control-Allow-Headers` for paid requests.
 
 ### Prepare Swap
 

--- a/packages/developer-sdk/typescript/README.md
+++ b/packages/developer-sdk/typescript/README.md
@@ -208,6 +208,11 @@ const wallet = swig.wallets.use({
   swigConfigAddress,
   walletAddress,
   roleId,
+  requesterAuthority: {
+    ed25519: {
+      publicKey: userPublicKey,
+    },
+  },
 });
 
 const challenge = await fetch(resourceUrl);

--- a/packages/developer-sdk/typescript/README.md
+++ b/packages/developer-sdk/typescript/README.md
@@ -190,6 +190,54 @@ const preparedTokenTransfer = await wallet.transfer.token({
 return preparedTokenTransfer;
 ```
 
+### Prepare an x402 Payment
+
+Pass the merchant's `402 Payment Required` response directly to the wallet.
+When `acceptedIndex` is omitted, Swig selects the first eligible exact Solana
+requirement and returns its original array index.
+
+```typescript
+import { SwigBrowserClient } from '@swig-wallet/developer-sdk/browser';
+import {
+  createX402Payment,
+  signPreparedTransaction,
+} from '@swig-wallet/developer-sdk/client';
+
+const swig = new SwigBrowserClient({ network: 'devnet' });
+const wallet = swig.wallets.use({
+  swigConfigAddress,
+  walletAddress,
+  roleId,
+});
+
+const challenge = await fetch(resourceUrl);
+const prepared = await wallet.x402.prepareFromResponse(challenge);
+const signed = await signPreparedTransaction(prepared.preparedTransaction, {
+  signTransaction,
+});
+const payment = createX402Payment(prepared, signed);
+
+const paidResponse = await fetch(resourceUrl, {
+  headers: payment.paymentSignatureHeaders,
+});
+```
+
+To select a specific merchant offer, pass its index from the original
+`accepts` array:
+
+```typescript
+const prepared = await wallet.x402.prepareFromResponse(challenge, {
+  acceptedIndex,
+});
+```
+
+Use `signPreparedTransaction` for Ed25519 authorities. For
+Secp256r1/passkey authorities, use `signPreparedSwigTransaction` to fulfill
+the prepared transaction's signature requests.
+
+Browser integrations require the merchant to expose `PAYMENT-REQUIRED`
+through CORS.
+
 ### Prepare Swap
 
 ```typescript

--- a/packages/developer-sdk/typescript/nest/README.md
+++ b/packages/developer-sdk/typescript/nest/README.md
@@ -32,6 +32,7 @@ The handler expects routes like:
 
 ```text
 POST /swig/wallet/create
+POST /swig/x402/prepare
 POST /swig/prepare
 POST /swig/transfer/sol
 POST /swig/transfer/spl-token

--- a/packages/developer-sdk/typescript/next/README.md
+++ b/packages/developer-sdk/typescript/next/README.md
@@ -23,6 +23,7 @@ The helper handles:
 
 ```text
 POST /api/swig/wallet/create
+POST /api/swig/x402/prepare
 POST /api/swig/prepare
 POST /api/swig/transfer/sol
 POST /api/swig/transfer/spl-token

--- a/packages/developer-sdk/typescript/package.json
+++ b/packages/developer-sdk/typescript/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@solana/web3.js": "^1.98.0",
     "@swig-wallet/lib": "workspace:*",
+    "@x402/core": "2.21.0",
     "bs58": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/developer-sdk/typescript/package.json
+++ b/packages/developer-sdk/typescript/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint --config ../../../eslint.config.mjs --ext js,ts,tsx src --fix",
     "smoke:local": "bun run scripts/local-transaction-smoke.ts",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.x402.json"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/developer-sdk/typescript/src/browser-proxy.test.ts
+++ b/packages/developer-sdk/typescript/src/browser-proxy.test.ts
@@ -1,3 +1,6 @@
+import { encodePaymentRequiredHeader } from '@x402/core/http';
+import type { PaymentRequiredV2 } from '@x402/core/schemas';
+import type { PaymentRequired } from '@x402/core/types';
 import { describe, expect, test } from 'bun:test';
 
 import { SwigBrowserClient, SwigBrowserProxyError } from './browser.js';
@@ -145,6 +148,108 @@ describe('SwigBrowserClient', () => {
       },
     });
     expect(prepared.transaction).toBe('base64-token-transfer-tx');
+  });
+
+  test('prepares x402 payments through the local proxy without an API key', async () => {
+    const calls: CapturedRequest[] = [];
+    const paymentRequired = x402PaymentRequired();
+    paymentRequired.accepts.reverse();
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          prepared: {
+            preparedTransaction: {
+              transaction: 'base64-x402-tx',
+              transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+              network: 'NETWORK_DEVNET',
+              kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+              wallet: {
+                swigConfigAddress: 'swig_config_123',
+                walletAddress: 'wallet_123',
+              },
+              signatureRequests: [
+                {
+                  scheme: 'secp256r1',
+                  signer: 'requester_123',
+                  messageHash: 'message_hash_123',
+                  slot: 42,
+                  counter: 7,
+                },
+              ],
+            },
+            acceptedIndex: 0,
+          },
+        };
+      }),
+    });
+    const wallet = swig.wallets.fromIdpSession({
+      configAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      roleId: 2,
+      authFlow: 'role',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.x402.prepareFromResponse(
+      x402Response(paymentRequired),
+      {
+        acceptedIndex: 0,
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://app.example/api/swig/x402/prepare',
+      method: 'POST',
+      body: {
+        wallet: {
+          swigConfigAddress: 'swig_config_123',
+          walletAddress: 'wallet_123',
+          roleId: 2,
+          network: 'devnet',
+          requesterAuthority: {
+            ed25519: { publicKey: 'requester_123' },
+          },
+        },
+        network: 'devnet',
+        requesterAuthority: {
+          ed25519: { publicKey: 'requester_123' },
+        },
+        paymentRequired,
+        acceptedIndex: 0,
+      },
+    });
+    expect(calls[0]?.headers.has('authorization')).toBe(false);
+    expect(prepared.acceptedIndex).toBe(0);
+    expect(prepared.preparedTransaction.signatureRequests).toEqual([
+      {
+        scheme: 'secp256r1',
+        signer: 'requester_123',
+        messageHash: 'message_hash_123',
+        slot: 42,
+        counter: 7,
+      },
+    ]);
+    expect(prepared.paymentRequired).toEqual(paymentRequired);
+  });
+
+  test('rejects malformed x402 responses before calling the local proxy', async () => {
+    let proxyCalls = 0;
+    const swig = new SwigBrowserClient({
+      network: 'devnet',
+      fetch: (async () => {
+        proxyCalls += 1;
+        return new Response();
+      }) as unknown as typeof fetch,
+    });
+    const wallet = swig.wallets.use('swig_config_123');
+
+    await expect(
+      wallet.x402.prepareFromResponse(new Response(null, { status: 402 })),
+    ).rejects.toThrow('missing PAYMENT-REQUIRED');
+    expect(proxyCalls).toBe(0);
   });
 
   test('prepares grouped wallet operations through the proxy route', async () => {
@@ -534,6 +639,52 @@ function absoluteUrl(input: RequestInfo | URL): RequestInfo | URL {
     return `https://app.example${input}`;
   }
   return input;
+}
+
+function x402Response(paymentRequired: PaymentRequiredV2): Response {
+  return new Response(null, {
+    status: 402,
+    headers: {
+      'PAYMENT-REQUIRED': encodePaymentRequiredHeader(
+        paymentRequired as unknown as PaymentRequired,
+      ),
+    },
+  });
+}
+
+function x402PaymentRequired(): PaymentRequiredV2 {
+  return {
+    x402Version: 2,
+    resource: {
+      url: 'https://merchant.example/protected',
+      description: 'Protected resource',
+    },
+    accepts: [
+      {
+        scheme: 'exact',
+        network: 'eip155:8453',
+        amount: '1000',
+        asset: '0xasset',
+        payTo: '0xmerchant',
+        maxTimeoutSeconds: 300,
+        extra: {
+          assetTransferMethod: 'eip3009',
+        },
+      },
+      {
+        scheme: 'exact',
+        network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+        amount: '42',
+        asset: 'mint_123',
+        payTo: 'merchant_123',
+        maxTimeoutSeconds: 300,
+        extra: {
+          feePayer: 'payer_123',
+          memo: 'merchant-reference',
+        },
+      },
+    ],
+  };
 }
 
 function isJsonFetchResponse(

--- a/packages/developer-sdk/typescript/src/browser-proxy.ts
+++ b/packages/developer-sdk/typescript/src/browser-proxy.ts
@@ -31,6 +31,7 @@ import type {
   PreparedTransactionWire,
   PrepareOperation,
   PrepareTransactionsResponseWire,
+  PrepareX402PaymentOptions,
   QuoteRampArgs,
   QuoteRampResult,
   QuoteRampResultWire,
@@ -42,12 +43,20 @@ import type {
   WalletHandleOptions,
   WalletReadArgs,
   WalletReference,
+  WalletX402Client,
+  X402PreparationResult,
 } from './types/index.js';
 import {
   normalizeAmount,
   normalizePreparedTransaction,
   normalizePrepareTransactionsResponse,
 } from './wallets/normalizers.js';
+import type { PrepareX402PaymentResponseWire } from './x402/index.js';
+import {
+  normalizeX402PreparationResponse,
+  parsePaymentRequiredFromResponse,
+  validateRequestedAcceptedIndex,
+} from './x402/index.js';
 
 export interface SwigBrowserClientConfig {
   /**
@@ -92,6 +101,7 @@ type WithoutFeePayer<TArgs extends { feePayer: string }> = Omit<
 };
 
 type SwigBrowserProxyRoute =
+  | 'x402/prepare'
   | 'prepare'
   | 'transfer/sol'
   | 'transfer/spl-token'
@@ -295,6 +305,38 @@ export class BrowserWalletsClient {
         network: args.network ?? wallet.network ?? this.defaultNetwork,
         limit: args.limit,
       },
+    );
+  };
+
+  prepareX402PaymentFromResponse = async (
+    wallet: BrowserWalletHandle,
+    response: Response,
+    options: PrepareX402PaymentOptions = {},
+  ): Promise<X402PreparationResult> => {
+    const paymentRequired = parsePaymentRequiredFromResponse(response);
+    const network = wallet.network ?? this.defaultNetwork;
+    if (!network) {
+      throw new Error('network is required');
+    }
+    const acceptedIndex = validateRequestedAcceptedIndex(
+      options.acceptedIndex,
+      paymentRequired,
+    );
+    const prepared = await this.http.post<PrepareX402PaymentResponseWire>(
+      'x402/prepare',
+      {
+        ...baseRequest(wallet, {}, this.defaultNetwork),
+        paymentRequired,
+        ...(acceptedIndex === undefined ? {} : { acceptedIndex }),
+      },
+    );
+
+    return normalizeX402PreparationResponse(
+      prepared,
+      paymentRequired,
+      acceptedIndex,
+      network,
+      wallet.swigConfigAddress,
     );
   };
 }
@@ -504,6 +546,7 @@ export class BrowserWalletHandle {
   readonly requesterAuthority?: WalletAuthority;
   readonly transfer: BrowserWalletTransferClient;
   readonly swap: BrowserWalletSwapClient;
+  readonly x402: WalletX402Client;
 
   constructor(
     private readonly wallets: BrowserWalletsClient,
@@ -517,6 +560,7 @@ export class BrowserWalletHandle {
     this.requesterAuthority = init.requesterAuthority;
     this.transfer = createBrowserWalletTransferClient(wallets, this);
     this.swap = createBrowserWalletSwapClient(wallets, this);
+    this.x402 = createBrowserWalletX402Client(wallets, this);
   }
 
   prepare = (args: BrowserPrepareArgs): Promise<PreparedTransactionsResult> =>
@@ -541,6 +585,16 @@ function walletReadRoute(
   route: 'balance/usd' | 'token-balances' | 'token-transactions',
 ): string {
   return `wallet/${encodeURIComponent(wallet.swigConfigAddress)}/${route}`;
+}
+
+function createBrowserWalletX402Client(
+  wallets: BrowserWalletsClient,
+  wallet: BrowserWalletHandle,
+): WalletX402Client {
+  return {
+    prepareFromResponse: (response, options) =>
+      wallets.prepareX402PaymentFromResponse(wallet, response, options),
+  };
 }
 
 function createBrowserWalletTransferClient(

--- a/packages/developer-sdk/typescript/src/client/index.ts
+++ b/packages/developer-sdk/typescript/src/client/index.ts
@@ -7,11 +7,18 @@ export type {
   Eip1193Provider,
   PasskeySigningFn,
   PasskeySigningResult,
+  PaymentPayloadV2,
+  PaymentRequiredV2,
   PreparedTransaction,
+  PrepareX402PaymentOptions,
   Secp256k1SigningFn,
   Secp256k1SigningResult,
   TransactionEncoding,
+  WalletX402Client,
+  X402PaymentSubmission,
+  X402PreparationResult,
 } from '../types/index.js';
+export { createX402Payment } from '../x402/index.js';
 export {
   signPreparedSwigTransaction,
   signPreparedSwigTransactions,

--- a/packages/developer-sdk/typescript/src/index.ts
+++ b/packages/developer-sdk/typescript/src/index.ts
@@ -11,6 +11,7 @@ export { RampClient, rampCustomer } from './ramp/index.js';
 export { SwigClient } from './server/typescript/index.js';
 export { TransactionsClient } from './transactions/index.js';
 export { WalletHandle, WalletsClient } from './wallets/index.js';
+export { createX402Payment } from './x402/index.js';
 
 export type {
   BuildOneBusinessGrantAccessUrlArgs,
@@ -41,9 +42,12 @@ export type {
   ListRampTransactionsArgs,
   ListRampTransactionsResult,
   Network,
+  PaymentPayloadV2,
+  PaymentRequiredV2,
   Policy,
   PolicyAuthority,
   PrepareRecoverySetupArgs,
+  PrepareX402PaymentOptions,
   PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionWire,
@@ -78,6 +82,9 @@ export type {
   WalletAddressInfo,
   WalletHandleOptions,
   WalletReference,
+  WalletX402Client,
+  X402PaymentSubmission,
+  X402PreparationResult,
 } from './types/index.js';
 
 export type {

--- a/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
@@ -1,3 +1,4 @@
+import { PaymentRequiredV2Schema } from '@x402/core/schemas';
 import { describe, expect, test } from 'bun:test';
 
 import { createSwigFetchHandler, createSwigGetHandler } from './index.js';
@@ -34,6 +35,183 @@ function jsonFetch(
 }
 
 describe('createSwigFetchHandler', () => {
+  test('prepares typed x402 challenges through the dedicated route', async () => {
+    const calls: CapturedRequest[] = [];
+    let feePayerResolverCalls = 0;
+    let requesterAuthorityResolverCalls = 0;
+    const browserPaymentRequired = {
+      x402Version: 2,
+      resource: {
+        url: 'https://merchant.example/resource',
+        description: 'Test resource',
+        merchantResourceData: { correlation: 'resource-1' },
+      },
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+          amount: '1000',
+          asset: 'mint_123',
+          payTo: 'merchant_123',
+          maxTimeoutSeconds: 300,
+          extra: {
+            feePayer: 'x402_sponsor_123',
+            memo: 'order_123',
+          },
+          merchantRequirementData: { keep: true },
+        },
+      ],
+      extensions: { merchantExtension: { enabled: true } },
+      merchantEnvelopeData: { keep: true },
+    };
+    const paymentRequired = PaymentRequiredV2Schema.parse(
+      browserPaymentRequired,
+    );
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      feePayer: () => {
+        feePayerResolverCalls += 1;
+        return 'configured_fee_payer_123';
+      },
+      resolveRequesterAuthority: ({ route, wallet, body }) => {
+        requesterAuthorityResolverCalls += 1;
+        expect(route).toBe('x402/prepare');
+        expect(wallet?.swigConfigAddress).toBe('swig_config_123');
+        expect(body.paymentRequired).toEqual(browserPaymentRequired);
+        return {
+          ed25519: { publicKey: 'requester_123' },
+        };
+      },
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          preparedTransaction: {
+            wallet: {
+              swigConfigAddress: 'swig_config_123',
+              walletAddress: 'wallet_123',
+            },
+            transaction: 'base64-x402-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            recentBlockhash: 'blockhash_123',
+            kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+            signatureRequests: [
+              {
+                scheme: 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1',
+                signer: 'requester_123',
+                messageHash: 'message_hash_123',
+                slot: 42,
+                counter: 7,
+              },
+            ],
+          },
+          acceptedIndex: 0,
+        };
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/x402/prepare', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          network: 'devnet',
+          paymentRequired: browserPaymentRequired,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      prepared: {
+        preparedTransaction: {
+          wallet: {
+            swigConfigAddress: 'swig_config_123',
+            walletAddress: 'wallet_123',
+          },
+          transaction: 'base64-x402-tx',
+          transactionEncoding: 'base64',
+          network: 'devnet',
+          recentBlockhash: 'blockhash_123',
+          kind: 'x402-payment',
+          signatureRequests: [
+            {
+              scheme: 'secp256r1',
+              signer: 'requester_123',
+              messageHash: 'message_hash_123',
+              slot: 42,
+              counter: 7,
+            },
+          ],
+        },
+        acceptedIndex: 0,
+      },
+    });
+    expect(requesterAuthorityResolverCalls).toBe(1);
+    expect(feePayerResolverCalls).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/payment/x402/prepare',
+      method: 'POST',
+    });
+    expect(calls[0]?.body).toEqual({
+      paymentRequired,
+      network: 'NETWORK_DEVNET',
+      swigAddress: 'swig_config_123',
+      requesterAuthority: {
+        ed25519: { publicKey: 'requester_123' },
+      },
+    });
+    expect(
+      Object.hasOwn(calls[0]?.body as Record<string, unknown>, 'feePayer'),
+    ).toBe(false);
+  });
+
+  test('rejects malformed browser x402 JSON before calling transaction-service', async () => {
+    let transactionApiCalls = 0;
+    let requesterAuthorityResolverCalls = 0;
+    const handler = createSwigFetchHandler({
+      apiKey: 'sk_test',
+      transactionApiUrl: 'http://localhost:8080',
+      resolveRequesterAuthority: () => {
+        requesterAuthorityResolverCalls += 1;
+        return {
+          ed25519: { publicKey: 'requester_123' },
+        };
+      },
+      fetch: jsonFetch(() => {
+        transactionApiCalls += 1;
+        return {};
+      }),
+    });
+
+    const response = await handler(
+      new Request('https://app.example/api/swig/x402/prepare', {
+        method: 'POST',
+        body: JSON.stringify({
+          wallet: { swigConfigAddress: 'swig_config_123' },
+          network: 'devnet',
+          paymentRequired: {
+            x402Version: 2,
+            resource: { url: 'https://merchant.example/resource' },
+            accepts: [],
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'PAYMENT-REQUIRED does not match the x402 v2 schema',
+    });
+    expect(requesterAuthorityResolverCalls).toBe(0);
+    expect(transactionApiCalls).toBe(0);
+  });
+
   test('prepares wallet creation with the multi-transaction create response', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({

--- a/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
+++ b/packages/developer-sdk/typescript/src/server/fetch/index.test.ts
@@ -212,6 +212,61 @@ describe('createSwigFetchHandler', () => {
     expect(transactionApiCalls).toBe(0);
   });
 
+  test.each([null, '0', {}, -1, 1.5, 0x1_0000_0000])(
+    'rejects a present invalid x402 acceptedIndex %p',
+    async (acceptedIndex) => {
+      let transactionApiCalls = 0;
+      let requesterAuthorityResolverCalls = 0;
+      const handler = createSwigFetchHandler({
+        apiKey: 'sk_test',
+        transactionApiUrl: 'http://localhost:8080',
+        resolveRequesterAuthority: () => {
+          requesterAuthorityResolverCalls += 1;
+          return {
+            ed25519: { publicKey: 'requester_123' },
+          };
+        },
+        fetch: jsonFetch(() => {
+          transactionApiCalls += 1;
+          return {};
+        }),
+      });
+
+      const response = await handler(
+        new Request('https://app.example/api/swig/x402/prepare', {
+          method: 'POST',
+          body: JSON.stringify({
+            wallet: { swigConfigAddress: 'swig_config_123' },
+            network: 'devnet',
+            acceptedIndex,
+            paymentRequired: {
+              x402Version: 2,
+              resource: { url: 'https://merchant.example/resource' },
+              accepts: [
+                {
+                  scheme: 'exact',
+                  network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+                  amount: '1000',
+                  asset: 'mint_123',
+                  payTo: 'merchant_123',
+                  maxTimeoutSeconds: 300,
+                  extra: { feePayer: 'x402_sponsor_123' },
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: 'acceptedIndex must be a non-negative uint32',
+      });
+      expect(requesterAuthorityResolverCalls).toBe(0);
+      expect(transactionApiCalls).toBe(0);
+    },
+  );
+
   test('prepares wallet creation with the multi-transaction create response', async () => {
     const calls: CapturedRequest[] = [];
     const handler = createSwigFetchHandler({

--- a/packages/developer-sdk/typescript/src/server/fetch/index.ts
+++ b/packages/developer-sdk/typescript/src/server/fetch/index.ts
@@ -202,7 +202,19 @@ async function prepareX402Payment(
     throw new SwigRouteError('paymentRequired is required');
   }
   const paymentRequired = validatePaymentRequiredV2(body.paymentRequired);
-  const acceptedIndex = readOptionalNumber(body, 'acceptedIndex');
+  let acceptedIndex: number | undefined;
+  if (Object.hasOwn(body, 'acceptedIndex')) {
+    const value = body.acceptedIndex;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 0 ||
+      value > 0xffff_ffff
+    ) {
+      throw new SwigRouteError('acceptedIndex must be a non-negative uint32');
+    }
+    acceptedIndex = value;
+  }
   const requesterAuthority = await resolveRequesterAuthority(context, config);
   const handle = swig.wallets.use(
     {

--- a/packages/developer-sdk/typescript/src/server/fetch/index.ts
+++ b/packages/developer-sdk/typescript/src/server/fetch/index.ts
@@ -14,10 +14,12 @@ import type {
   WalletAuthority,
   WalletReference,
 } from '../../types/index.js';
+import { validatePaymentRequiredV2 } from '../../x402/index.js';
 import { SwigClient } from '../typescript/index.js';
 
 export type SwigPostProxyRoute =
   | 'wallet/create'
+  | 'x402/prepare'
   | 'prepare'
   | 'transfer/sol'
   | 'transfer/spl-token'
@@ -85,6 +87,7 @@ class SwigRouteError extends Error {
 
 const swigPostProxyRoutes: SwigPostProxyRoute[] = [
   'wallet/create',
+  'x402/prepare',
   'prepare',
   'transfer/sol',
   'transfer/spl-token',
@@ -139,6 +142,10 @@ async function handlePost(
         return json({
           prepared: await prepareWalletCreation(swig, body, context, config),
         });
+      case 'x402/prepare':
+        return json({
+          prepared: await prepareX402Payment(swig, body, context, config),
+        });
       case 'prepare':
         return json({
           prepared: await prepareGroupedOperations(swig, body, context, config),
@@ -182,6 +189,38 @@ async function handlePost(
     const status = error instanceof SwigRouteError ? error.status : 400;
     return json({ error: message }, status);
   }
+}
+
+async function prepareX402Payment(
+  swig: SwigClient,
+  body: Record<string, unknown>,
+  context: SwigRouteContext,
+  config: CreateSwigFetchHandlerConfig,
+) {
+  const wallet = requireWallet(context.wallet);
+  if (!Object.hasOwn(body, 'paymentRequired')) {
+    throw new SwigRouteError('paymentRequired is required');
+  }
+  const paymentRequired = validatePaymentRequiredV2(body.paymentRequired);
+  const acceptedIndex = readOptionalNumber(body, 'acceptedIndex');
+  const requesterAuthority = await resolveRequesterAuthority(context, config);
+  const handle = swig.wallets.use(
+    {
+      ...wallet,
+      requesterAuthority,
+    },
+    { network: context.network },
+  );
+  const result = await swig.wallets.prepareX402Payment(
+    handle,
+    paymentRequired,
+    acceptedIndex,
+  );
+
+  return {
+    preparedTransaction: result.preparedTransaction,
+    acceptedIndex: result.acceptedIndex,
+  };
 }
 
 async function handleGet(

--- a/packages/developer-sdk/typescript/src/server/index.ts
+++ b/packages/developer-sdk/typescript/src/server/index.ts
@@ -2,6 +2,7 @@ export { DEFAULT_BACKEND_URL, SwigDeveloperSdkError } from '../core/index.js';
 export { RampClient, rampCustomer } from '../ramp/index.js';
 export { TransactionsClient } from '../transactions/index.js';
 export { WalletHandle, WalletsClient } from '../wallets/index.js';
+export { createX402Payment } from '../x402/index.js';
 export {
   SwigClient,
   SwigClient as SwigServerClient,
@@ -29,9 +30,12 @@ export type {
   ListRampTransactionsArgs,
   ListRampTransactionsResult,
   Network,
+  PaymentPayloadV2,
+  PaymentRequiredV2,
   Policy,
   PolicyAuthority,
   PrepareRecoverySetupArgs,
+  PrepareX402PaymentOptions,
   PreparedRecoverySetupResult,
   PreparedTransaction,
   PreparedTransactionWire,
@@ -63,6 +67,9 @@ export type {
   WalletAddressInfo,
   WalletHandleOptions,
   WalletReference,
+  WalletX402Client,
+  X402PaymentSubmission,
+  X402PreparationResult,
 } from '../types/index.js';
 
 export type {

--- a/packages/developer-sdk/typescript/src/types/index.ts
+++ b/packages/developer-sdk/typescript/src/types/index.ts
@@ -9,3 +9,4 @@ export type * from './ramp.js';
 export type * from './transaction.js';
 export type * from './wallet-actions.js';
 export type * from './wallet.js';
+export type * from './x402.js';

--- a/packages/developer-sdk/typescript/src/types/transaction.ts
+++ b/packages/developer-sdk/typescript/src/types/transaction.ts
@@ -20,12 +20,14 @@ export type NetworkWire = Network | ProtoNetwork | number;
 export type PreparedTransactionKind =
   | 'create-swig-wallet'
   | 'add-authority'
-  | 'configure-recovery';
+  | 'configure-recovery'
+  | 'x402-payment';
 export type ProtoPreparedTransactionKind =
   | 'PREPARED_TRANSACTION_KIND_UNSPECIFIED'
   | 'PREPARED_TRANSACTION_KIND_CREATE_SWIG_WALLET'
   | 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY'
-  | 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY';
+  | 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY'
+  | 'PREPARED_TRANSACTION_KIND_X402_PAYMENT';
 export type PreparedTransactionKindWire =
   | PreparedTransactionKind
   | ProtoPreparedTransactionKind
@@ -69,6 +71,7 @@ export interface ClientSignatureRequest {
 
 export interface ClientSignatureRequestWire {
   scheme?:
+    | ClientSignatureRequest['scheme']
     | 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1'
     | 'AUTHORITY_SIGNATURE_SCHEME_SECP256K1'
     | number;

--- a/packages/developer-sdk/typescript/src/types/x402.ts
+++ b/packages/developer-sdk/typescript/src/types/x402.ts
@@ -1,0 +1,26 @@
+import type { PaymentPayloadV2, PaymentRequiredV2 } from '@x402/core/schemas';
+import type { PreparedTransaction } from './transaction.js';
+
+export type { PaymentPayloadV2, PaymentRequiredV2 } from '@x402/core/schemas';
+
+export interface PrepareX402PaymentOptions {
+  acceptedIndex?: number;
+}
+
+export interface X402PreparationResult {
+  preparedTransaction: PreparedTransaction;
+  paymentRequired: PaymentRequiredV2;
+  acceptedIndex: number;
+}
+
+export interface X402PaymentSubmission {
+  paymentPayload: PaymentPayloadV2;
+  paymentSignatureHeaders: Record<'PAYMENT-SIGNATURE', string>;
+}
+
+export interface WalletX402Client {
+  prepareFromResponse(
+    response: Response,
+    options?: PrepareX402PaymentOptions,
+  ): Promise<X402PreparationResult>;
+}

--- a/packages/developer-sdk/typescript/src/types/x402.ts
+++ b/packages/developer-sdk/typescript/src/types/x402.ts
@@ -1,7 +1,39 @@
-import type { PaymentPayloadV2, PaymentRequiredV2 } from '@x402/core/schemas';
 import type { PreparedTransaction } from './transaction.js';
 
-export type { PaymentPayloadV2, PaymentRequiredV2 } from '@x402/core/schemas';
+export interface X402ResourceInfoV2 {
+  url: string;
+  description?: string | undefined;
+  mimeType?: string | undefined;
+  serviceName?: string | undefined;
+  tags?: string[] | undefined;
+  iconUrl?: string | undefined;
+}
+
+export interface X402PaymentRequirementV2 {
+  scheme: string;
+  network: string;
+  amount: string;
+  asset: string;
+  payTo: string;
+  maxTimeoutSeconds: number;
+  extra?: Record<string, unknown> | null | undefined;
+}
+
+export interface PaymentRequiredV2 {
+  x402Version: 2;
+  error?: string | undefined;
+  resource: X402ResourceInfoV2;
+  accepts: X402PaymentRequirementV2[];
+  extensions?: Record<string, unknown> | null | undefined;
+}
+
+export interface PaymentPayloadV2 {
+  x402Version: 2;
+  resource?: X402ResourceInfoV2 | undefined;
+  accepted: X402PaymentRequirementV2;
+  payload: Record<string, unknown>;
+  extensions?: Record<string, unknown> | null | undefined;
+}
 
 export interface PrepareX402PaymentOptions {
   acceptedIndex?: number;

--- a/packages/developer-sdk/typescript/src/types/x402.typecheck.ts
+++ b/packages/developer-sdk/typescript/src/types/x402.typecheck.ts
@@ -1,0 +1,25 @@
+import type {
+  PaymentPayloadV2 as CorePaymentPayloadV2,
+  PaymentRequiredV2 as CorePaymentRequiredV2,
+} from '@x402/core/schemas';
+
+import type { PaymentPayloadV2, PaymentRequiredV2 } from './x402.js';
+
+declare const corePaymentRequired: CorePaymentRequiredV2;
+declare const sdkPaymentRequired: PaymentRequiredV2;
+
+const sdkPaymentRequiredFromCore: PaymentRequiredV2 = corePaymentRequired;
+const corePaymentRequiredFromSdk: CorePaymentRequiredV2 = sdkPaymentRequired;
+
+declare const corePaymentPayload: CorePaymentPayloadV2;
+declare const sdkPaymentPayload: PaymentPayloadV2;
+
+const sdkPaymentPayloadFromCore: PaymentPayloadV2 = corePaymentPayload;
+const corePaymentPayloadFromSdk: CorePaymentPayloadV2 = sdkPaymentPayload;
+
+void [
+  sdkPaymentRequiredFromCore,
+  corePaymentRequiredFromSdk,
+  sdkPaymentPayloadFromCore,
+  corePaymentPayloadFromSdk,
+];

--- a/packages/developer-sdk/typescript/src/wallets/client.test.ts
+++ b/packages/developer-sdk/typescript/src/wallets/client.test.ts
@@ -1,3 +1,9 @@
+import { encodePaymentRequiredHeader } from '@x402/core/http';
+import {
+  PaymentRequiredV2Schema,
+  type PaymentRequiredV2,
+} from '@x402/core/schemas';
+import type { PaymentRequired } from '@x402/core/types';
 import { describe, expect, test } from 'bun:test';
 
 import { SwigClient } from '../server/typescript/index.js';
@@ -42,6 +48,54 @@ function jsonFetch(
       },
     );
   }) as typeof fetch;
+}
+
+function x402Response(paymentRequired: unknown): Response {
+  return new Response(null, {
+    status: 402,
+    headers: {
+      'PAYMENT-REQUIRED': encodePaymentRequiredHeader(
+        paymentRequired as unknown as PaymentRequired,
+      ),
+    },
+  });
+}
+
+function x402PaymentRequired(
+  options: { svmFirst?: boolean } = {},
+): PaymentRequiredV2 {
+  const svm = {
+    scheme: 'exact',
+    network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+    amount: '42',
+    asset: 'mint_123',
+    payTo: 'merchant_123',
+    maxTimeoutSeconds: 300,
+    extra: {
+      feePayer: 'payer_123',
+      memo: 'merchant-reference',
+    },
+  } satisfies PaymentRequiredV2['accepts'][number];
+  const evm = {
+    scheme: 'exact',
+    network: 'eip155:8453',
+    amount: '1000',
+    asset: '0xasset',
+    payTo: '0xmerchant',
+    maxTimeoutSeconds: 300,
+    extra: {
+      assetTransferMethod: 'eip3009',
+    },
+  } satisfies PaymentRequiredV2['accepts'][number];
+
+  return {
+    x402Version: 2,
+    resource: {
+      url: 'https://merchant.example/protected',
+      description: 'Protected resource',
+    },
+    accepts: options.svmFirst ? [svm, evm] : [evm, svm],
+  };
 }
 
 describe('WalletsClient', () => {
@@ -601,6 +655,166 @@ describe('WalletsClient', () => {
       network: 'devnet',
       recentBlockhash: 'blockhash_456',
     });
+  });
+
+  test('prepares an x402 payment and retains the backend-selected index', async () => {
+    const calls: CapturedRequest[] = [];
+    const paymentRequired = x402PaymentRequired();
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          preparedTransaction: {
+            transaction: 'base64-x402-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+            wallet: {
+              swigConfigAddress: 'swig_config_123',
+              walletAddress: 'wallet_123',
+            },
+          },
+          acceptedIndex: 1,
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.x402.prepareFromResponse(
+      x402Response(paymentRequired),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'http://localhost:8080/transaction/payment/x402/prepare',
+      method: 'POST',
+      body: {
+        paymentRequired,
+        network: 'NETWORK_DEVNET',
+        swigAddress: 'swig_config_123',
+        requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+      },
+    });
+    expect(
+      (calls[0]?.body as Record<string, unknown>).acceptedIndex,
+    ).toBeUndefined();
+    expect(prepared.acceptedIndex).toBe(1);
+    expect(prepared.preparedTransaction).toMatchObject({
+      transaction: 'base64-x402-tx',
+      transactionEncoding: 'base64',
+      network: 'devnet',
+      kind: 'x402-payment',
+    });
+    expect(prepared.paymentRequired).toEqual(paymentRequired);
+  });
+
+  test('forwards an explicit x402 accepted index of zero', async () => {
+    const calls: CapturedRequest[] = [];
+    const paymentRequired = x402PaymentRequired({ svmFirst: true });
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          preparedTransaction: {
+            transaction: 'base64-x402-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+            wallet: {
+              swigConfigAddress: 'swig_config_123',
+              walletAddress: 'wallet_123',
+            },
+          },
+          acceptedIndex: 0,
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.x402.prepareFromResponse(
+      x402Response(paymentRequired),
+      {
+        acceptedIndex: 0,
+      },
+    );
+
+    expect(calls[0]).toMatchObject({
+      body: {
+        paymentRequired,
+        acceptedIndex: 0,
+      },
+    });
+    expect(prepared.acceptedIndex).toBe(0);
+  });
+
+  test('sends the official x402 schema output directly to the backend', async () => {
+    const calls: CapturedRequest[] = [];
+    const base = x402PaymentRequired({ svmFirst: true });
+    const paymentRequiredInput = {
+      ...base,
+      resource: {
+        ...base.resource,
+        merchantResourceData: { correlation: 'resource-1' },
+      },
+      accepts: base.accepts.map((requirement) => ({
+        ...requirement,
+        extra: {
+          ...(requirement.extra ?? {}),
+          merchantExtraData: { correlation: 'requirement-1' },
+        },
+        merchantRequirementData: { keep: true },
+      })),
+      extensions: { merchantExtension: { enabled: true } },
+      merchantEnvelopeData: { keep: true },
+    };
+    const paymentRequired = PaymentRequiredV2Schema.parse(paymentRequiredInput);
+    const swig = new SwigClient({
+      apiKey: 'sk_test',
+      baseUrl: 'http://localhost:8080',
+      network: 'devnet',
+      fetch: jsonFetch((request) => {
+        calls.push(request);
+        return {
+          preparedTransaction: {
+            transaction: 'base64-x402-tx',
+            transactionEncoding: 'TRANSACTION_ENCODING_BASE64',
+            network: 'NETWORK_DEVNET',
+            kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+            wallet: { swigConfigAddress: 'swig_config_123' },
+          },
+          acceptedIndex: 0,
+        };
+      }),
+    });
+    const wallet = swig.wallets.use({
+      swigConfigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+
+    const prepared = await wallet.x402.prepareFromResponse(
+      x402Response(paymentRequiredInput),
+    );
+
+    expect(calls[0]?.body).toEqual({
+      paymentRequired,
+      network: 'NETWORK_DEVNET',
+      swigAddress: 'swig_config_123',
+      requesterAuthority: { ed25519: { publicKey: 'requester_123' } },
+    });
+    expect(prepared.paymentRequired).toEqual(paymentRequired);
   });
 
   test('prepares token transfers through the opinionated wallet API', async () => {

--- a/packages/developer-sdk/typescript/src/wallets/client.ts
+++ b/packages/developer-sdk/typescript/src/wallets/client.ts
@@ -1,4 +1,3 @@
-import type { PaymentRequiredV2 } from '@x402/core/schemas';
 import type { HttpClient } from '../core/index.js';
 import type {
   AddRecoveryAuthorityArgs,
@@ -16,6 +15,7 @@ import type {
   ListSwigTokenTransactionsResult,
   ListSwigTokenTransactionsWire,
   Network,
+  PaymentRequiredV2,
   Policy,
   PrepareArgs,
   PreparedRecoverySetupResult,

--- a/packages/developer-sdk/typescript/src/wallets/client.ts
+++ b/packages/developer-sdk/typescript/src/wallets/client.ts
@@ -1,3 +1,4 @@
+import type { PaymentRequiredV2 } from '@x402/core/schemas';
 import type { HttpClient } from '../core/index.js';
 import type {
   AddRecoveryAuthorityArgs,
@@ -23,6 +24,7 @@ import type {
   PreparedTransactionWire,
   PrepareRecoverySetupArgs,
   PrepareTransactionsResponseWire,
+  PrepareX402PaymentOptions,
   RecoverySetupPlan,
   StartRecoveryArgs,
   SwapArgs,
@@ -33,7 +35,12 @@ import type {
   WalletHandleOptions,
   WalletReadArgs,
   WalletReference,
+  X402PreparationResult,
 } from '../types/index.js';
+import {
+  prepareX402Payment,
+  prepareX402PaymentFromResponse,
+} from '../x402/index.js';
 import { WalletHandle } from './handle.js';
 import {
   normalizeCreateWalletResponse,
@@ -186,6 +193,32 @@ export class WalletsClient {
     );
     return normalizePrepareTransactionsResponse(response);
   };
+
+  prepareX402PaymentFromResponse = (
+    wallet: WalletHandle,
+    response: Response,
+    options: PrepareX402PaymentOptions = {},
+  ): Promise<X402PreparationResult> =>
+    prepareX402PaymentFromResponse(
+      this.http,
+      wallet,
+      this.defaultNetwork,
+      response,
+      options,
+    );
+
+  prepareX402Payment = (
+    wallet: WalletHandle,
+    paymentRequired: PaymentRequiredV2,
+    acceptedIndex?: number,
+  ): Promise<X402PreparationResult> =>
+    prepareX402Payment(
+      this.http,
+      wallet,
+      this.defaultNetwork,
+      paymentRequired,
+      acceptedIndex,
+    );
 
   transferSol = async (
     wallet: WalletHandle,

--- a/packages/developer-sdk/typescript/src/wallets/handle.ts
+++ b/packages/developer-sdk/typescript/src/wallets/handle.ts
@@ -19,6 +19,7 @@ import type {
   TransferTokenArgs,
   WalletReadArgs,
   WalletReference,
+  WalletX402Client,
 } from '../types/index.js';
 import type { WalletsClient } from './client.js';
 
@@ -53,6 +54,7 @@ export class WalletHandle {
   readonly transfer: WalletTransferClient;
   readonly swap: WalletSwapClient;
   readonly recovery: WalletRecoveryClient;
+  readonly x402: WalletX402Client;
 
   constructor(
     private readonly wallets: WalletsClient,
@@ -65,6 +67,7 @@ export class WalletHandle {
     this.transfer = createWalletTransferClient(wallets, this);
     this.swap = createWalletSwapClient(wallets, this);
     this.recovery = createWalletRecoveryClient(wallets, this);
+    this.x402 = createWalletX402Client(wallets, this);
   }
 
   prepare = (args: PrepareArgs): Promise<PreparedTransactionsResult> =>
@@ -101,6 +104,16 @@ function createWalletTransferClient(
   transfer.splToken = transfer.token;
 
   return transfer;
+}
+
+function createWalletX402Client(
+  wallets: WalletsClient,
+  wallet: WalletHandle,
+): WalletX402Client {
+  return {
+    prepareFromResponse: (response, options) =>
+      wallets.prepareX402PaymentFromResponse(wallet, response, options),
+  };
 }
 
 function createWalletSwapClient(

--- a/packages/developer-sdk/typescript/src/wallets/normalizers.test.ts
+++ b/packages/developer-sdk/typescript/src/wallets/normalizers.test.ts
@@ -27,6 +27,49 @@ describe('wallet normalizers', () => {
     });
   });
 
+  test('normalizes the x402 prepared-transaction kind string', () => {
+    expect(
+      normalizePreparedTransaction({
+        transaction: 'base64-x402-tx',
+        kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT',
+      }).kind,
+    ).toBe('x402-payment');
+  });
+
+  test('normalizes the numeric x402 prepared-transaction kind', () => {
+    expect(
+      normalizePreparedTransaction({
+        transaction: 'base64-x402-tx',
+        kind: 4,
+      }).kind,
+    ).toBe('x402-payment');
+  });
+
+  test('accepts already-normalized signature requests from the local proxy', () => {
+    expect(
+      normalizePreparedTransaction({
+        transaction: 'base64-x402-tx',
+        signatureRequests: [
+          {
+            scheme: 'secp256r1',
+            signer: 'requester_123',
+            messageHash: 'hash_123',
+            slot: 42,
+            counter: 7,
+          },
+        ],
+      }).signatureRequests,
+    ).toEqual([
+      {
+        scheme: 'secp256r1',
+        signer: 'requester_123',
+        messageHash: 'hash_123',
+        slot: 42,
+        counter: 7,
+      },
+    ]);
+  });
+
   test('normalizes create wallet responses with multiple prepared transactions', () => {
     expect(
       normalizeCreateWalletResponse({

--- a/packages/developer-sdk/typescript/src/wallets/normalizers.ts
+++ b/packages/developer-sdk/typescript/src/wallets/normalizers.ts
@@ -367,6 +367,10 @@ function normalizePreparedTransactionKind(
     case 'PREPARED_TRANSACTION_KIND_CONFIGURE_RECOVERY':
     case 3:
       return 'configure-recovery';
+    case 'x402-payment':
+    case 'PREPARED_TRANSACTION_KIND_X402_PAYMENT':
+    case 4:
+      return 'x402-payment';
     default:
       return undefined;
   }
@@ -454,9 +458,11 @@ function normalizeAuthoritySignatureScheme(
   scheme: ClientSignatureRequestWire['scheme'],
 ): ClientSignatureRequest['scheme'] | undefined {
   switch (scheme) {
+    case 'secp256r1':
     case 'AUTHORITY_SIGNATURE_SCHEME_SECP256R1':
     case 1:
       return 'secp256r1';
+    case 'secp256k1':
     case 'AUTHORITY_SIGNATURE_SCHEME_SECP256K1':
     case 2:
       return 'secp256k1';

--- a/packages/developer-sdk/typescript/src/x402/index.test.ts
+++ b/packages/developer-sdk/typescript/src/x402/index.test.ts
@@ -1,0 +1,468 @@
+import {
+  decodePaymentSignatureHeader,
+  encodePaymentRequiredHeader,
+} from '@x402/core/http';
+import {
+  PaymentPayloadV2Schema,
+  PaymentRequiredV2Schema,
+  type PaymentRequiredV2,
+} from '@x402/core/schemas';
+import type { PaymentRequired } from '@x402/core/types';
+import { describe, expect, test } from 'bun:test';
+
+import { signPreparedTransaction } from '../client/index.js';
+import type {
+  PreparedTransaction,
+  X402PreparationResult,
+} from '../types/index.js';
+import {
+  createX402Payment,
+  normalizeX402PreparationResponse,
+  parsePaymentRequiredFromResponse,
+} from './index.js';
+
+const DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+
+describe('parsePaymentRequiredFromResponse', () => {
+  test('requires a 402 response with a PAYMENT-REQUIRED header', () => {
+    expect(() => parsePaymentRequiredFromResponse(new Response(null))).toThrow(
+      'status 402',
+    );
+    expect(() =>
+      parsePaymentRequiredFromResponse(new Response(null, { status: 402 })),
+    ).toThrow('missing PAYMENT-REQUIRED');
+    expect(() =>
+      parsePaymentRequiredFromResponse(
+        new Response(null, {
+          status: 402,
+          headers: { 'PAYMENT-REQUIRED': 'not-base64' },
+        }),
+      ),
+    ).toThrow('not valid x402 data');
+  });
+
+  test('decodes and validates an official PAYMENT-REQUIRED header', () => {
+    const paymentRequired = paymentRequiredFixture();
+    const response = paymentRequiredResponse(paymentRequired);
+
+    expect(parsePaymentRequiredFromResponse(response)).toEqual(
+      PaymentRequiredV2Schema.parse(paymentRequired),
+    );
+  });
+
+  test('rejects decoded data that does not match the x402 V2 schema', () => {
+    const response = paymentRequiredResponse({
+      ...paymentRequiredFixture(),
+      resource: { description: 'missing required URL' },
+    });
+
+    expect(() => parsePaymentRequiredFromResponse(response)).toThrow(
+      'PAYMENT-REQUIRED does not match the x402 v2 schema',
+    );
+  });
+
+  test('returns schema-normalized data while preserving nested extra and extensions values', () => {
+    const input = {
+      ...paymentRequiredFixture(),
+      error: null,
+      resource: {
+        url: 'https://merchant.example/resource',
+        description: null,
+        tags: null,
+        unknownResourceField: { correlation: 'resource-1' },
+      },
+      accepts: [
+        {
+          ...paymentRequiredFixture().accepts[0],
+          extra: {
+            feePayer: '11111111111111111111111111111111',
+            merchantExtraData: { correlation: 'requirement-1' },
+          },
+          unknownRequirementField: { keep: true },
+        },
+      ],
+      extensions: {
+        merchantExtension: { enabled: true },
+      },
+      unknownEnvelopeField: { keep: true },
+    };
+    const parsed = parsePaymentRequiredFromResponse(
+      paymentRequiredResponse(input),
+    );
+
+    expect(parsed).toEqual(PaymentRequiredV2Schema.parse(input));
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.resource.description).toBeUndefined();
+    expect(parsed.resource.tags).toBeUndefined();
+    expect(Object.hasOwn(parsed.resource, 'unknownResourceField')).toBe(false);
+    expect(Object.hasOwn(parsed.accepts[0]!, 'unknownRequirementField')).toBe(
+      false,
+    );
+    expect(Object.hasOwn(parsed, 'unknownEnvelopeField')).toBe(false);
+    expect(parsed.accepts[0]?.extra).toEqual({
+      feePayer: '11111111111111111111111111111111',
+      merchantExtraData: { correlation: 'requirement-1' },
+    });
+    expect(parsed.extensions).toEqual({
+      merchantExtension: { enabled: true },
+    });
+  });
+
+  test.each([
+    { label: 'omitted', present: false, value: undefined },
+    { label: 'null', present: true, value: null },
+    { label: 'empty object', present: true, value: {} },
+    {
+      label: 'populated object',
+      present: true,
+      value: { merchantData: { correlation: 'merchant-1' } },
+    },
+  ] as const)(
+    'preserves $label extra and extensions presence',
+    ({ present, value }) => {
+      const paymentRequired: PaymentRequiredV2 = {
+        x402Version: 2,
+        resource: paymentRequiredFixture().resource,
+        accepts: [
+          {
+            ...paymentRequirementFixture(),
+            ...(present ? { extra: value } : {}),
+          },
+        ],
+        ...(present ? { extensions: value } : {}),
+      };
+      const parsed = parsePaymentRequiredFromResponse(
+        paymentRequiredResponse(paymentRequired),
+      );
+
+      expect(Object.hasOwn(parsed.accepts[0]!, 'extra')).toBe(present);
+      expect(Object.hasOwn(parsed, 'extensions')).toBe(present);
+      if (present) {
+        expect(parsed.accepts[0]?.extra).toEqual(value);
+        expect(parsed.extensions).toEqual(value);
+      }
+    },
+  );
+});
+
+describe('createX402Payment', () => {
+  test('accepts output from the existing generic transaction signer', async () => {
+    const prepared = preparationFixture(paymentRequiredFixture());
+    const signedTransaction = bytesToBase64(Uint8Array.of(1, 2, 3));
+    const signed = await signPreparedTransaction(prepared.preparedTransaction, {
+      signTransaction: async () => signedTransaction,
+    });
+
+    expect(
+      createX402Payment(prepared, signed).paymentPayload.payload.transaction,
+    ).toBe(signedTransaction);
+  });
+
+  test('returns a payload and an official PAYMENT-SIGNATURE header round-trip', () => {
+    const paymentRequiredInput = {
+      ...paymentRequiredFixture(),
+      resource: {
+        ...paymentRequiredFixture().resource,
+        description: null,
+        unknownResourceField: { strip: true },
+      },
+      accepts: [
+        {
+          ...paymentRequiredFixture().accepts[0]!,
+          unknownRequirementField: { strip: true },
+        },
+      ],
+      unknownEnvelopeField: { strip: true },
+    };
+    const prepared = preparationFixture(paymentRequiredInput);
+    const signedTransaction = bytesToBase64(Uint8Array.of(1, 2, 3, 4));
+
+    const submission = createX402Payment(prepared, {
+      transaction: signedTransaction,
+      transactionEncoding: 'base64',
+      network: 'devnet',
+    });
+    const normalizedPaymentRequired =
+      PaymentRequiredV2Schema.parse(paymentRequiredInput);
+    const expectedPayload = PaymentPayloadV2Schema.parse({
+      x402Version: 2,
+      resource: normalizedPaymentRequired.resource,
+      accepted: normalizedPaymentRequired.accepts[0],
+      payload: { transaction: signedTransaction },
+    });
+
+    expect(submission.paymentPayload).toEqual(expectedPayload);
+    expect(submission.paymentPayload.resource?.description).toBeUndefined();
+    expect(
+      Object.hasOwn(
+        submission.paymentPayload.resource ?? {},
+        'unknownResourceField',
+      ),
+    ).toBe(false);
+    expect(
+      Object.hasOwn(
+        submission.paymentPayload.accepted,
+        'unknownRequirementField',
+      ),
+    ).toBe(false);
+    expect(Object.hasOwn(submission.paymentPayload, 'extensions')).toBe(false);
+    expect(
+      decodePaymentSignatureHeader(
+        submission.paymentSignatureHeaders['PAYMENT-SIGNATURE'],
+      ) as unknown,
+    ).toEqual(JSON.parse(JSON.stringify(submission.paymentPayload)));
+  });
+
+  test.each([
+    { label: 'null', value: null },
+    { label: 'empty object', value: {} },
+    {
+      label: 'populated object',
+      value: { merchantExtension: { enabled: true } },
+    },
+  ] as const)(
+    'preserves $label extensions in the payload and header',
+    ({ value }) => {
+      const paymentRequired = {
+        ...paymentRequiredFixture(),
+        extensions: value,
+      };
+      const submission = createX402Payment(
+        preparationFixture(paymentRequired),
+        {
+          transaction: bytesToBase64(Uint8Array.of(1)),
+          transactionEncoding: 'base64',
+          network: 'devnet',
+        },
+      );
+      const normalizedPaymentRequired =
+        PaymentRequiredV2Schema.parse(paymentRequired);
+      const expectedPayload = PaymentPayloadV2Schema.parse({
+        x402Version: 2,
+        resource: normalizedPaymentRequired.resource,
+        accepted: normalizedPaymentRequired.accepts[0],
+        payload: { transaction: bytesToBase64(Uint8Array.of(1)) },
+        extensions: value,
+      });
+
+      expect(submission.paymentPayload).toEqual(expectedPayload);
+      expect(Object.hasOwn(submission.paymentPayload, 'extensions')).toBe(true);
+      expect(submission.paymentPayload.extensions).toEqual(value);
+      expect(
+        decodePaymentSignatureHeader(
+          submission.paymentSignatureHeaders['PAYMENT-SIGNATURE'],
+        ) as unknown,
+      ).toEqual(submission.paymentPayload);
+    },
+  );
+
+  test.each(['AQ', 'AQ==\n', 'AQ-_'])(
+    'rejects non-canonical Base64 transaction %s',
+    (transaction) => {
+      expect(() =>
+        createX402Payment(preparationFixture(paymentRequiredFixture()), {
+          transaction,
+          transactionEncoding: 'base64',
+          network: 'devnet',
+        }),
+      ).toThrow('signed x402 transaction is not canonical base64');
+    },
+  );
+
+  test('rejects a signed transaction for a different network', () => {
+    expect(() =>
+      createX402Payment(preparationFixture(paymentRequiredFixture()), {
+        transaction: bytesToBase64(Uint8Array.of(1)),
+        transactionEncoding: 'base64',
+        network: 'mainnet',
+      }),
+    ).toThrow('signed x402 transaction has a different network');
+  });
+
+  test('accepts 1,232 transaction bytes and rejects 1,233 bytes', () => {
+    const prepared = preparationFixture(paymentRequiredFixture());
+
+    expect(() =>
+      createX402Payment(prepared, {
+        transaction: bytesToBase64(new Uint8Array(1_232).fill(1)),
+        transactionEncoding: 'base64',
+        network: 'devnet',
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      createX402Payment(prepared, {
+        transaction: bytesToBase64(new Uint8Array(1_233).fill(1)),
+        transactionEncoding: 'base64',
+        network: 'devnet',
+      }),
+    ).toThrow('signed x402 transaction exceeds the Solana wire limit');
+  });
+
+  test('rejects an encoded PAYMENT-SIGNATURE value over 8,000 bytes', () => {
+    const paymentRequired = {
+      ...paymentRequiredFixture(),
+      extensions: {
+        merchantMetadata: 'x'.repeat(7_000),
+      },
+    };
+
+    expect(() =>
+      createX402Payment(preparationFixture(paymentRequired), {
+        transaction: bytesToBase64(Uint8Array.of(1)),
+        transactionEncoding: 'base64',
+        network: 'devnet',
+      }),
+    ).toThrow('PAYMENT-SIGNATURE exceeds the supported header size');
+  });
+});
+
+describe('normalizeX402PreparationResponse', () => {
+  test('requires the backend-selected index, including explicit zero presence', () => {
+    const paymentRequired = parsePaymentRequiredFromResponse(
+      paymentRequiredResponse(paymentRequiredFixture()),
+    );
+
+    expect(() =>
+      normalizeX402PreparationResponse(
+        { preparedTransaction: preparedTransactionWire() },
+        paymentRequired,
+        undefined,
+        'devnet',
+        'swig_config_123',
+      ),
+    ).toThrow('invalid acceptedIndex');
+
+    expect(
+      normalizeX402PreparationResponse(
+        {
+          preparedTransaction: preparedTransactionWire(),
+          acceptedIndex: 0,
+        },
+        paymentRequired,
+        undefined,
+        'devnet',
+        'swig_config_123',
+      ).acceptedIndex,
+    ).toBe(0);
+  });
+
+  test('rejects mismatched transaction metadata', () => {
+    const paymentRequired = parsePaymentRequiredFromResponse(
+      paymentRequiredResponse(paymentRequiredFixture()),
+    );
+
+    expect(() =>
+      normalizeX402PreparationResponse(
+        {
+          preparedTransaction: {
+            ...preparedTransactionWire(),
+            kind: 'PREPARED_TRANSACTION_KIND_ADD_AUTHORITY',
+          },
+          acceptedIndex: 0,
+        },
+        paymentRequired,
+        undefined,
+        'devnet',
+        'swig_config_123',
+      ),
+    ).toThrow('invalid transaction kind');
+
+    expect(() =>
+      normalizeX402PreparationResponse(
+        {
+          preparedTransaction: {
+            ...preparedTransactionWire(),
+            network: 'NETWORK_MAINNET',
+          },
+          acceptedIndex: 0,
+        },
+        paymentRequired,
+        undefined,
+        'devnet',
+        'swig_config_123',
+      ),
+    ).toThrow('different network');
+  });
+});
+
+function paymentRequiredFixture(): PaymentRequiredV2 {
+  return {
+    x402Version: 2,
+    resource: {
+      url: 'https://merchant.example/resource',
+      description: 'A protected resource',
+      mimeType: 'application/json',
+    },
+    accepts: [
+      {
+        ...paymentRequirementFixture(),
+        extra: {
+          feePayer: '11111111111111111111111111111111',
+        },
+      },
+    ],
+  };
+}
+
+function paymentRequirementFixture(): PaymentRequiredV2['accepts'][number] {
+  return {
+    scheme: 'exact',
+    network: DEVNET,
+    amount: '1000',
+    asset: 'So11111111111111111111111111111111111111112',
+    payTo: '11111111111111111111111111111111',
+    maxTimeoutSeconds: 300,
+  };
+}
+
+function paymentRequiredResponse(value: unknown): Response {
+  return new Response(null, {
+    status: 402,
+    headers: {
+      'PAYMENT-REQUIRED': encodePaymentRequiredHeader(
+        value as unknown as PaymentRequired,
+      ),
+    },
+  });
+}
+
+function preparationFixture(
+  paymentRequired: PaymentRequiredV2 | unknown,
+): X402PreparationResult {
+  const preparedTransaction: PreparedTransaction = {
+    transaction: bytesToBase64(Uint8Array.of(0)),
+    transactionEncoding: 'base64',
+    network: 'devnet',
+    kind: 'x402-payment',
+    signatureRequests: [],
+  };
+
+  return {
+    preparedTransaction,
+    paymentRequired:
+      paymentRequired as X402PreparationResult['paymentRequired'],
+    acceptedIndex: 0,
+  };
+}
+
+function preparedTransactionWire() {
+  return {
+    transaction: 'AQ==',
+    transactionEncoding: 'TRANSACTION_ENCODING_BASE64' as const,
+    network: 'NETWORK_DEVNET' as const,
+    kind: 'PREPARED_TRANSACTION_KIND_X402_PAYMENT' as const,
+    wallet: {
+      swigConfigAddress: 'swig_config_123',
+      walletAddress: 'wallet_123',
+    },
+  };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}

--- a/packages/developer-sdk/typescript/src/x402/index.test.ts
+++ b/packages/developer-sdk/typescript/src/x402/index.test.ts
@@ -5,13 +5,16 @@ import {
 import {
   PaymentPayloadV2Schema,
   PaymentRequiredV2Schema,
-  type PaymentRequiredV2,
+  type PaymentPayloadV2 as CorePaymentPayloadV2,
+  type PaymentRequiredV2 as CorePaymentRequiredV2,
 } from '@x402/core/schemas';
 import type { PaymentRequired } from '@x402/core/types';
 import { describe, expect, test } from 'bun:test';
 
 import { signPreparedTransaction } from '../client/index.js';
 import type {
+  PaymentPayloadV2,
+  PaymentRequiredV2,
   PreparedTransaction,
   X402PreparationResult,
 } from '../types/index.js';
@@ -22,6 +25,28 @@ import {
 } from './index.js';
 
 const DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+
+describe('public x402 types', () => {
+  test('remain compatible with the pinned official schema output', () => {
+    const corePaymentRequired: CorePaymentRequiredV2 =
+      PaymentRequiredV2Schema.parse(paymentRequiredFixture());
+    const sdkPaymentRequired: PaymentRequiredV2 = corePaymentRequired;
+    const corePaymentRequiredAgain: CorePaymentRequiredV2 = sdkPaymentRequired;
+
+    const corePaymentPayload: CorePaymentPayloadV2 =
+      PaymentPayloadV2Schema.parse({
+        x402Version: 2,
+        resource: sdkPaymentRequired.resource,
+        accepted: sdkPaymentRequired.accepts[0],
+        payload: { transaction: bytesToBase64(Uint8Array.of(1)) },
+      });
+    const sdkPaymentPayload: PaymentPayloadV2 = corePaymentPayload;
+    const corePaymentPayloadAgain: CorePaymentPayloadV2 = sdkPaymentPayload;
+
+    expect(corePaymentRequiredAgain).toEqual(corePaymentRequired);
+    expect(corePaymentPayloadAgain).toEqual(corePaymentPayload);
+  });
+});
 
 describe('parsePaymentRequiredFromResponse', () => {
   test('requires a 402 response with a PAYMENT-REQUIRED header', () => {

--- a/packages/developer-sdk/typescript/src/x402/index.ts
+++ b/packages/developer-sdk/typescript/src/x402/index.ts
@@ -5,7 +5,6 @@ import {
 import {
   PaymentPayloadV2Schema,
   PaymentRequiredV2Schema,
-  type PaymentRequiredV2,
 } from '@x402/core/schemas';
 import type { PaymentPayload } from '@x402/core/types';
 
@@ -13,6 +12,7 @@ import type { SignedPreparedTransaction } from '../client/index.js';
 import type { HttpClient } from '../core/index.js';
 import type {
   Network,
+  PaymentRequiredV2,
   PrepareX402PaymentOptions,
   PreparedTransactionWire,
   WalletReference,

--- a/packages/developer-sdk/typescript/src/x402/index.ts
+++ b/packages/developer-sdk/typescript/src/x402/index.ts
@@ -1,0 +1,351 @@
+import {
+  decodePaymentRequiredHeader,
+  encodePaymentSignatureHeader,
+} from '@x402/core/http';
+import {
+  PaymentPayloadV2Schema,
+  PaymentRequiredV2Schema,
+  type PaymentRequiredV2,
+} from '@x402/core/schemas';
+import type { PaymentPayload } from '@x402/core/types';
+
+import type { SignedPreparedTransaction } from '../client/index.js';
+import type { HttpClient } from '../core/index.js';
+import type {
+  Network,
+  PrepareX402PaymentOptions,
+  PreparedTransactionWire,
+  WalletReference,
+  X402PaymentSubmission,
+  X402PreparationResult,
+} from '../types/index.js';
+import {
+  normalizePreparedTransaction,
+  toProtoNetwork,
+} from '../wallets/normalizers.js';
+
+const MAX_SOLANA_TRANSACTION_BYTES = 1_232;
+const MAX_PAYMENT_SIGNATURE_HEADER_BYTES = 8_000;
+const PAYMENT_REQUIRED_HEADER = 'PAYMENT-REQUIRED';
+
+const X402_SOLANA_NETWORKS: Record<Network, string> = {
+  devnet: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+  mainnet: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+};
+
+export interface PrepareX402PaymentResponseWire {
+  preparedTransaction?: PreparedTransactionWire;
+  prepared_transaction?: PreparedTransactionWire;
+  acceptedIndex?: unknown;
+  accepted_index?: unknown;
+}
+
+export async function prepareX402PaymentFromResponse(
+  http: HttpClient,
+  wallet: WalletReference,
+  defaultNetwork: Network | undefined,
+  response: Response,
+  options: PrepareX402PaymentOptions = {},
+): Promise<X402PreparationResult> {
+  const paymentRequired = parsePaymentRequiredFromResponse(response);
+
+  return prepareX402Payment(
+    http,
+    wallet,
+    defaultNetwork,
+    paymentRequired,
+    options.acceptedIndex,
+  );
+}
+
+export async function prepareX402Payment(
+  http: HttpClient,
+  wallet: WalletReference,
+  defaultNetwork: Network | undefined,
+  paymentRequired: PaymentRequiredV2,
+  requestedAcceptedIndex?: number,
+): Promise<X402PreparationResult> {
+  const validatedPaymentRequired = validatePaymentRequiredV2(paymentRequired);
+  const network = resolveNetwork(wallet.network, defaultNetwork);
+  const requesterAuthority = wallet.requesterAuthority;
+
+  if (!requesterAuthority) {
+    throw new Error('requesterAuthority is required');
+  }
+
+  const acceptedIndex = validateRequestedAcceptedIndex(
+    requestedAcceptedIndex,
+    validatedPaymentRequired,
+  );
+  const prepared = await http.post<PrepareX402PaymentResponseWire>(
+    '/transaction/payment/x402/prepare',
+    {
+      paymentRequired: validatedPaymentRequired,
+      ...(acceptedIndex === undefined ? {} : { acceptedIndex }),
+      network: toProtoNetwork(network),
+      swigAddress: wallet.swigConfigAddress,
+      requesterAuthority,
+    },
+  );
+
+  return normalizeX402PreparationResponse(
+    prepared,
+    validatedPaymentRequired,
+    acceptedIndex,
+    network,
+    wallet.swigConfigAddress,
+  );
+}
+
+export function parsePaymentRequiredFromResponse(
+  response: Response,
+): PaymentRequiredV2 {
+  if (response.status !== 402) {
+    throw new Error('x402 response must have status 402');
+  }
+
+  const header = response.headers.get(PAYMENT_REQUIRED_HEADER);
+  if (!header) {
+    throw new Error('x402 response is missing PAYMENT-REQUIRED');
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = decodePaymentRequiredHeader(header);
+  } catch {
+    throw new Error('PAYMENT-REQUIRED is not valid x402 data');
+  }
+
+  return validatePaymentRequiredV2(decoded);
+}
+
+export function validatePaymentRequiredV2(value: unknown): PaymentRequiredV2 {
+  const result = PaymentRequiredV2Schema.safeParse(value);
+  if (!result.success) {
+    throw new Error('PAYMENT-REQUIRED does not match the x402 v2 schema');
+  }
+  return result.data;
+}
+
+export function validateRequestedAcceptedIndex(
+  acceptedIndex: number | undefined,
+  paymentRequired: PaymentRequiredV2,
+): number | undefined {
+  if (acceptedIndex === undefined) {
+    return undefined;
+  }
+  if (
+    !Number.isInteger(acceptedIndex) ||
+    acceptedIndex < 0 ||
+    acceptedIndex > 0xffff_ffff
+  ) {
+    throw new Error('acceptedIndex must be a non-negative uint32');
+  }
+  if (acceptedIndex >= paymentRequired.accepts.length) {
+    throw new Error('acceptedIndex is out of range');
+  }
+  return acceptedIndex;
+}
+
+export function normalizeX402PreparationResponse(
+  response: PrepareX402PaymentResponseWire,
+  paymentRequired: PaymentRequiredV2,
+  requestedAcceptedIndex: number | undefined,
+  network: Network,
+  swigConfigAddress: string,
+): X402PreparationResult {
+  const preparedWire =
+    response.preparedTransaction ?? response.prepared_transaction;
+  if (!preparedWire) {
+    throw new Error('x402 preparation response is missing preparedTransaction');
+  }
+
+  const acceptedIndex = readResponseAcceptedIndex(
+    response.acceptedIndex ?? response.accepted_index,
+  );
+  if (acceptedIndex >= paymentRequired.accepts.length) {
+    throw new Error('x402 preparation response acceptedIndex is out of range');
+  }
+  if (
+    requestedAcceptedIndex !== undefined &&
+    acceptedIndex !== requestedAcceptedIndex
+  ) {
+    throw new Error(
+      'x402 preparation response selected a different requirement',
+    );
+  }
+
+  const accepted = paymentRequired.accepts[acceptedIndex];
+  if (
+    accepted?.scheme !== 'exact' ||
+    accepted.network !== X402_SOLANA_NETWORKS[network]
+  ) {
+    throw new Error(
+      'x402 preparation response selected an unsupported requirement',
+    );
+  }
+
+  const preparedTransaction = normalizePreparedTransaction(preparedWire);
+  if (preparedTransaction.kind !== 'x402-payment') {
+    throw new Error(
+      'x402 preparation response has an invalid transaction kind',
+    );
+  }
+  if (preparedTransaction.network !== network) {
+    throw new Error('x402 preparation response has a different network');
+  }
+  if (preparedTransaction.transactionEncoding !== 'base64') {
+    throw new Error('x402 preparation response must use base64');
+  }
+  if (preparedTransaction.wallet?.swigConfigAddress !== swigConfigAddress) {
+    throw new Error('x402 preparation response has a different Swig wallet');
+  }
+
+  return {
+    preparedTransaction,
+    paymentRequired,
+    acceptedIndex,
+  };
+}
+
+export function createX402Payment(
+  prepared: X402PreparationResult,
+  signed: SignedPreparedTransaction,
+): X402PaymentSubmission {
+  const paymentRequired = validatePaymentRequiredV2(prepared.paymentRequired);
+  const acceptedIndex = validateRequiredAcceptedIndex(
+    prepared.acceptedIndex,
+    paymentRequired,
+  );
+
+  if (prepared.preparedTransaction.kind !== 'x402-payment') {
+    throw new Error('prepared transaction is not an x402 payment');
+  }
+  const network = prepared.preparedTransaction.network;
+  if (!network) {
+    throw new Error('prepared x402 transaction is missing network');
+  }
+  const accepted = paymentRequired.accepts[acceptedIndex];
+  if (
+    accepted?.scheme !== 'exact' ||
+    accepted.network !== X402_SOLANA_NETWORKS[network]
+  ) {
+    throw new Error('prepared x402 requirement does not match its network');
+  }
+  if (signed.transactionEncoding !== 'base64') {
+    throw new Error('signed x402 transaction must use base64');
+  }
+  if (signed.network !== undefined && signed.network !== network) {
+    throw new Error('signed x402 transaction has a different network');
+  }
+
+  const transactionBytes = decodeCanonicalBase64(signed.transaction);
+  if (transactionBytes.length === 0) {
+    throw new Error('signed x402 transaction is empty');
+  }
+  if (transactionBytes.length > MAX_SOLANA_TRANSACTION_BYTES) {
+    throw new Error('signed x402 transaction exceeds the Solana wire limit');
+  }
+
+  const candidate = {
+    x402Version: paymentRequired.x402Version,
+    resource: paymentRequired.resource,
+    accepted,
+    payload: { transaction: signed.transaction },
+    ...(Object.hasOwn(paymentRequired, 'extensions')
+      ? { extensions: paymentRequired.extensions }
+      : {}),
+  };
+  const parsedPayload = PaymentPayloadV2Schema.safeParse(candidate);
+  if (!parsedPayload.success) {
+    throw new Error('x402 payment payload is invalid');
+  }
+
+  const paymentPayload = parsedPayload.data;
+  const paymentSignature = encodePaymentSignatureHeader(
+    paymentPayload as PaymentPayload,
+  );
+  if (
+    new TextEncoder().encode(paymentSignature).length >
+    MAX_PAYMENT_SIGNATURE_HEADER_BYTES
+  ) {
+    throw new Error('PAYMENT-SIGNATURE exceeds the supported header size');
+  }
+
+  return {
+    paymentPayload,
+    paymentSignatureHeaders: {
+      'PAYMENT-SIGNATURE': paymentSignature,
+    },
+  };
+}
+
+function validateRequiredAcceptedIndex(
+  acceptedIndex: number,
+  paymentRequired: PaymentRequiredV2,
+): number {
+  const validated = validateRequestedAcceptedIndex(
+    acceptedIndex,
+    paymentRequired,
+  );
+  if (validated === undefined) {
+    throw new Error('acceptedIndex is required');
+  }
+  return validated;
+}
+
+function readResponseAcceptedIndex(value: unknown): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > 0xffff_ffff
+  ) {
+    throw new Error('x402 preparation response has an invalid acceptedIndex');
+  }
+  return value;
+}
+
+function resolveNetwork(
+  walletNetwork: Network | undefined,
+  defaultNetwork: Network | undefined,
+): Network {
+  const network = walletNetwork ?? defaultNetwork;
+  if (!network) {
+    throw new Error('network is required');
+  }
+  return network;
+}
+
+function decodeCanonicalBase64(value: string): Uint8Array {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      value,
+    )
+  ) {
+    throw new Error('signed x402 transaction is not canonical base64');
+  }
+
+  try {
+    const decoded = atob(value);
+    const bytes = Uint8Array.from(decoded, (character) =>
+      character.charCodeAt(0),
+    );
+    if (encodeBase64(bytes) !== value) {
+      throw new Error('non-canonical');
+    }
+    return bytes;
+  } catch {
+    throw new Error('signed x402 transaction is not canonical base64');
+  }
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}

--- a/packages/developer-sdk/typescript/tsconfig.x402.json
+++ b/packages/developer-sdk/typescript/tsconfig.x402.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src/types/x402.typecheck.ts"]
+}


### PR DESCRIPTION
## Summary

Adds x402 exact-Solana payment preparation to the TypeScript Developer SDK.

Developers can pass a resource server’s `402 Payment Required` response directly to a Swig wallet:

```ts
const prepared = await wallet.x402.prepareFromResponse(response, {
  acceptedIndex,
});
```

When `acceptedIndex` is omitted, transaction-service selects the first eligible requirement and returns its original index.

## Changes

- Validate `PAYMENT-REQUIRED` using the pinned `@x402/core` V2 schema.
- Add x402 preparation to server and browser wallet handles.
- Add the `/x402/prepare` browser-proxy route.
- Use the existing requester-authority resolution behavior.
- Normalize the x402 prepared-transaction kind and signature requests.
- Reuse the generic prepared-transaction signing helpers.
- Add `createX402Payment` to assemble:
  - The x402 `PaymentPayload`
  - A `Record<"PAYMENT-SIGNATURE", string>` header
- Preserve supported x402 extension values and property presence.
- Validate transaction encoding, network, wire size, and outbound header size.
- Add SDK documentation and a minor-version changeset.
- Pin `@x402/core` to `2.21.0`.

## Validation

- 116 Developer SDK tests passed.
- TypeScript typecheck passed.
- ESLint passed.
- Package build passed.
- Prettier and `git diff --check` passed.

## Scope

This PR contains only TypeScript Developer SDK changes. 