### PR TITLE
Feat(developer-sdk:python): x402 Swig Transaction

### DIFF
--- a/packages/developer-sdk/PARITY.md
+++ b/packages/developer-sdk/PARITY.md
@@ -13,6 +13,7 @@ uses snake_case names while TypeScript uses camelCase.
 | Jupiter swap        | `wallet.swap.jupiter`                            | `wallet.swap.jupiter`                               | same optional swap controls                             |
 | Recovery            | `wallet.recovery.*`                              | `wallet.recovery.*`                                 | same prepare, start, cancel, and execute behavior       |
 | Custom transaction  | `wallet.buildTransaction`                        | `wallet.build_transaction`                          | same custom preparation request and instruction shape   |
+| x402 payments       | `wallet.x402.prepareFromResponse`                | `wallet.x402.prepare_from_response`                  | same selection, preparation, and payment-header assembly |
 | Wallet reads        | balance, token balances, transactions            | balance, token balances, transactions               | same required-field validation                          |
 | Paymaster           | balance and IDP balance                          | balance and IDP balance                             | same query and normalization                            |
 | Sponsorship         | `transactions.sponsor`                           | `transactions.sponsor`                              | same base58 conversion and idempotency-key forwarding   |

--- a/packages/developer-sdk/python/README.md
+++ b/packages/developer-sdk/python/README.md
@@ -34,6 +34,46 @@ signed and submitted client-side.
 TypeScript counterparts. Their explicit `sol`, `token`, `spl_token`, and
 `jupiter` methods are available as well.
 
+## Prepare an x402 payment
+
+Pass the resource server's `402 Payment Required` response directly to the
+wallet. When `accepted_index` is omitted, Swig selects the first eligible exact
+Solana requirement and returns its original array index.
+
+```python
+import httpx
+
+from swig_developer_sdk import (
+    create_x402_payment,
+    sign_prepared_transaction,
+)
+
+async with httpx.AsyncClient() as http:
+    challenge = await http.get(resource_url)
+    prepared = await wallet.x402.prepare_from_response(challenge)
+    signed = await sign_prepared_transaction(
+        prepared.prepared_transaction,
+        sign_transaction=sign_transaction,
+    )
+    payment = create_x402_payment(prepared, signed)
+    response = await http.get(
+        resource_url,
+        headers=payment.payment_signature_headers,
+    )
+```
+
+To choose a specific offer from the original `accepts` array:
+
+```python
+prepared = await wallet.x402.prepare_from_response(
+    challenge,
+    accepted_index=accepted_index,
+)
+```
+
+Use `sign_prepared_transaction` for Ed25519 authorities and
+`sign_prepared_swig_transaction` for Secp256r1/passkey authorities.
+
 ## Sign locally
 
 The generic signer helper works with an application-owned Ed25519 signer. The

--- a/packages/developer-sdk/python/pyproject.toml
+++ b/packages/developer-sdk/python/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "base58>=2.1,<3",
   "httpx>=0.28,<1",
   "solders>=0.28,<0.29",
+  "x402==2.18.0",
 ]
 
 [project.urls]

--- a/packages/developer-sdk/python/src/swig_developer_sdk/__init__.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/__init__.py
@@ -95,6 +95,12 @@ from .wallets import (
     WalletReference,
     WalletsClient,
 )
+from .x402 import (
+    WalletX402Client,
+    X402PaymentSubmission,
+    X402PreparationResult,
+    create_x402_payment,
+)
 
 __all__ = [
     "DEFAULT_BACKEND_URL",
@@ -167,13 +173,17 @@ __all__ = [
     "WalletAuthority",
     "WalletHandle",
     "WalletReference",
+    "WalletX402Client",
     "WalletsClient",
     "WebAuthnAssertion",
+    "X402PaymentSubmission",
+    "X402PreparationResult",
     "build_one_business_grant_access_url",
     "complete_one_business_grant_access",
     "create_secp256k1_evm_signing_fn",
     "create_secp256r1_passkey_signing_fn",
     "create_swig_proxy_handler",
+    "create_x402_payment",
     "ramp_customer",
     "redirect_to_one_business_grant_access",
     "secp256r1_der_to_raw_signature",

--- a/packages/developer-sdk/python/src/swig_developer_sdk/proxy.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/proxy.py
@@ -9,6 +9,7 @@ from typing import Literal, TypeAlias, TypeVar, cast
 from urllib.parse import unquote
 
 import httpx
+from pydantic import BaseModel
 
 from .client import SwigClient
 from .common import DEFAULT_BACKEND_URL, Network, WalletAuthority, normalize_network
@@ -29,6 +30,7 @@ from .wallets import (
     TransferTokenOperation,
     WalletReference,
 )
+from .x402 import validate_payment_required
 
 PostProxyRoute: TypeAlias = Literal[
     "wallet/create",
@@ -36,6 +38,7 @@ PostProxyRoute: TypeAlias = Literal[
     "transfer/sol",
     "transfer/spl-token",
     "swap/jupiter",
+    "x402/prepare",
     "ramp/quote",
     "ramp/sessions",
 ]
@@ -184,13 +187,26 @@ class SwigProxyHandler:
 
         required_wallet = _require_wallet(wallet)
         requester_authority = await self._requester_authority(context)
-        fee_payer = await self._fee_payer(context)
         handle = swig.wallets.use(
             required_wallet,
             network=network,
             requester_authority=requester_authority,
         )
+        if route == "x402/prepare":
+            accepted_index_value = body.get("acceptedIndex")
+            if accepted_index_value is not None and (
+                not isinstance(accepted_index_value, int)
+                or isinstance(accepted_index_value, bool)
+            ):
+                raise SwigProxyRouteError("acceptedIndex must be a non-negative uint32")
+            x402_prepared = await handle.x402._prepare_payment_required(
+                validate_payment_required(body.get("paymentRequired")),
+                accepted_index=accepted_index_value,
+            )
+            return {"prepared": x402_prepared}
+
         idempotency_key = _optional_string(body.get("idempotencyKey"))
+        fee_payer = await self._fee_payer(context)
         prepared: object
         if route == "prepare":
             prepared = await handle.prepare(
@@ -402,6 +418,7 @@ def create_swig_proxy_handler(
 def _resolve_post_route(path: str) -> PostProxyRoute:
     routes: tuple[PostProxyRoute, ...] = (
         "wallet/create",
+        "x402/prepare",
         "prepare",
         "transfer/sol",
         "transfer/spl-token",
@@ -697,6 +714,8 @@ def _read_env(*names: str) -> str | None:
 
 
 def _to_wire(value: object) -> object:
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True, exclude_unset=True)
     if is_dataclass(value) and not isinstance(value, type):
         result: dict[str, object] = {}
         for field in fields(value):

--- a/packages/developer-sdk/python/src/swig_developer_sdk/transactions.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/transactions.py
@@ -17,7 +17,7 @@ from .core import HttpClient
 
 TransactionEncoding = Literal["base64"]
 PreparedTransactionKind = Literal[
-    "create-swig-wallet", "add-authority", "configure-recovery"
+    "create-swig-wallet", "add-authority", "configure-recovery", "x402-payment"
 ]
 SignatureScheme = Literal["secp256r1", "secp256k1"]
 
@@ -257,6 +257,12 @@ def _normalize_kind(value: object) -> PreparedTransactionKind | None:
         3,
     ):
         return "configure-recovery"
+    if value in (
+        "x402-payment",
+        "PREPARED_TRANSACTION_KIND_X402_PAYMENT",
+        4,
+    ):
+        return "x402-payment"
     return None
 
 

--- a/packages/developer-sdk/python/src/swig_developer_sdk/wallets.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/wallets.py
@@ -24,6 +24,7 @@ from .transactions import (
     normalize_prepared_transaction,
     normalize_prepared_transactions_result,
 )
+from .x402 import WalletX402Client
 
 
 @dataclass(frozen=True, slots=True)
@@ -663,6 +664,13 @@ class WalletHandle:
         self.transfer = WalletTransferClient(wallets, self)
         self.swap = WalletSwapClient(wallets, self)
         self.recovery = WalletRecoveryClient(wallets, self)
+        self.x402 = WalletX402Client(
+            wallets._http,
+            swig_config_address=self.swig_config_address,
+            wallet_network=self.network,
+            default_network=wallets._default_network,
+            requester_authority=self.requester_authority,
+        )
 
     async def prepare(
         self,

--- a/packages/developer-sdk/python/src/swig_developer_sdk/x402.py
+++ b/packages/developer-sdk/python/src/swig_developer_sdk/x402.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import httpx
+from x402.http import (
+    PAYMENT_REQUIRED_HEADER,
+    PAYMENT_SIGNATURE_HEADER,
+    decode_payment_required_header,
+    encode_payment_signature_header,
+)
+from x402.schemas import PaymentPayload, PaymentRequired
+
+from .common import (
+    Network,
+    WalletAuthority,
+    require_network,
+    to_proto_network,
+    wallet_authority_to_wire,
+)
+from .core import HttpClient
+from .transactions import (
+    PreparedTransaction,
+    SignedPreparedTransaction,
+    normalize_prepared_transaction,
+)
+
+MAX_SOLANA_TRANSACTION_BYTES = 1_232
+MAX_PAYMENT_SIGNATURE_HEADER_BYTES = 8_000
+UINT32_MAX = 0xFFFF_FFFF
+
+X402_SOLANA_NETWORKS: Mapping[Network, str] = {
+    "devnet": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+    "mainnet": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class X402PreparationResult:
+    prepared_transaction: PreparedTransaction
+    payment_required: PaymentRequired
+    accepted_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class X402PaymentSubmission:
+    payment_payload: PaymentPayload
+    payment_signature_headers: Mapping[str, str]
+
+
+class WalletX402Client:
+    def __init__(
+        self,
+        http: HttpClient,
+        *,
+        swig_config_address: str,
+        wallet_network: Network | None,
+        default_network: Network | None,
+        requester_authority: WalletAuthority | None,
+    ) -> None:
+        self._http = http
+        self._swig_config_address = swig_config_address
+        self._wallet_network = wallet_network
+        self._default_network = default_network
+        self._requester_authority = requester_authority
+
+    async def prepare_from_response(
+        self,
+        response: httpx.Response,
+        *,
+        accepted_index: int | None = None,
+    ) -> X402PreparationResult:
+        payment_required = parse_payment_required_response(response)
+        return await self._prepare_payment_required(
+            payment_required,
+            accepted_index=accepted_index,
+        )
+
+    async def _prepare_payment_required(
+        self,
+        payment_required: PaymentRequired,
+        *,
+        accepted_index: int | None = None,
+    ) -> X402PreparationResult:
+        payment_required = validate_payment_required(payment_required)
+        network = require_network(self._wallet_network, self._default_network)
+        if self._requester_authority is None:
+            raise ValueError("requester_authority is required")
+
+        accepted_index = validate_accepted_index(accepted_index, payment_required)
+        response = await self._http.post(
+            "/transaction/payment/x402/prepare",
+            {
+                "paymentRequired": payment_required.model_dump(
+                    by_alias=True,
+                    exclude_unset=True,
+                ),
+                "acceptedIndex": accepted_index,
+                "network": to_proto_network(network),
+                "swigAddress": self._swig_config_address,
+                "requesterAuthority": wallet_authority_to_wire(
+                    self._requester_authority
+                ),
+            },
+        )
+        return normalize_x402_preparation_response(
+            response,
+            payment_required=payment_required,
+            requested_accepted_index=accepted_index,
+            network=network,
+            swig_config_address=self._swig_config_address,
+        )
+
+
+def parse_payment_required_response(response: httpx.Response) -> PaymentRequired:
+    if response.status_code != 402:
+        raise ValueError("x402 response must have status 402")
+    header = response.headers.get(PAYMENT_REQUIRED_HEADER)
+    if not header:
+        raise ValueError("x402 response is missing PAYMENT-REQUIRED")
+    try:
+        decoded = decode_payment_required_header(header)
+    except Exception:
+        raise ValueError("PAYMENT-REQUIRED is not valid x402 data") from None
+    if not isinstance(decoded, PaymentRequired):
+        raise ValueError("PAYMENT-REQUIRED must use x402 version 2")
+    return validate_payment_required(decoded)
+
+
+def validate_payment_required(value: object) -> PaymentRequired:
+    try:
+        payment_required = PaymentRequired.model_validate(value)
+    except Exception:
+        raise ValueError("PAYMENT-REQUIRED does not match x402 version 2") from None
+    if payment_required.x402_version != 2:
+        raise ValueError("PAYMENT-REQUIRED must use x402 version 2")
+    if payment_required.resource is None:
+        raise ValueError("PAYMENT-REQUIRED is missing resource")
+    return payment_required
+
+
+def validate_accepted_index(
+    accepted_index: int | None,
+    payment_required: PaymentRequired,
+) -> int | None:
+    if accepted_index is None:
+        return None
+    if (
+        not isinstance(accepted_index, int)
+        or isinstance(accepted_index, bool)
+        or accepted_index < 0
+        or accepted_index > UINT32_MAX
+    ):
+        raise ValueError("accepted_index must be a non-negative uint32")
+    if accepted_index >= len(payment_required.accepts):
+        raise ValueError("accepted_index is out of range")
+    return accepted_index
+
+
+def normalize_x402_preparation_response(
+    response: object,
+    *,
+    payment_required: PaymentRequired,
+    requested_accepted_index: int | None,
+    network: Network,
+    swig_config_address: str,
+) -> X402PreparationResult:
+    body = _mapping(response, "x402 preparation response")
+    prepared_wire = _pick(body, "preparedTransaction", "prepared_transaction")
+    if prepared_wire is None:
+        raise ValueError("x402 preparation response is missing preparedTransaction")
+
+    accepted_index = _response_accepted_index(
+        _pick(body, "acceptedIndex", "accepted_index")
+    )
+    if accepted_index >= len(payment_required.accepts):
+        raise ValueError("x402 preparation response acceptedIndex is out of range")
+    if (
+        requested_accepted_index is not None
+        and accepted_index != requested_accepted_index
+    ):
+        raise ValueError("x402 preparation response selected a different requirement")
+
+    accepted = payment_required.accepts[accepted_index]
+    if accepted.scheme != "exact" or accepted.network != X402_SOLANA_NETWORKS[network]:
+        raise ValueError(
+            "x402 preparation response selected an unsupported requirement"
+        )
+
+    prepared = normalize_prepared_transaction(prepared_wire)
+    if prepared.kind != "x402-payment":
+        raise ValueError("x402 preparation response has an invalid transaction kind")
+    if prepared.network != network:
+        raise ValueError("x402 preparation response has a different network")
+    if prepared.transaction_encoding != "base64":
+        raise ValueError("x402 preparation response must use base64")
+    if (
+        prepared.wallet is None
+        or prepared.wallet.swig_config_address != swig_config_address
+    ):
+        raise ValueError("x402 preparation response has a different Swig wallet")
+
+    return X402PreparationResult(
+        prepared_transaction=prepared,
+        payment_required=payment_required,
+        accepted_index=accepted_index,
+    )
+
+
+def create_x402_payment(
+    prepared: X402PreparationResult,
+    signed: SignedPreparedTransaction,
+) -> X402PaymentSubmission:
+    payment_required = validate_payment_required(prepared.payment_required)
+    accepted_index = validate_accepted_index(
+        prepared.accepted_index,
+        payment_required,
+    )
+    if accepted_index is None:
+        raise ValueError("accepted_index is required")
+
+    transaction = prepared.prepared_transaction
+    if transaction.kind != "x402-payment":
+        raise ValueError("prepared transaction is not an x402 payment")
+    network = transaction.network
+    if network is None:
+        raise ValueError("prepared x402 transaction is missing network")
+    accepted = payment_required.accepts[accepted_index]
+    if accepted.scheme != "exact" or accepted.network != X402_SOLANA_NETWORKS[network]:
+        raise ValueError("prepared x402 requirement does not match its network")
+    if signed.transaction_encoding != "base64":
+        raise ValueError("signed x402 transaction must use base64")
+    if signed.network is not None and signed.network != network:
+        raise ValueError("signed x402 transaction has a different network")
+
+    transaction_bytes = _decode_canonical_base64(signed.transaction)
+    if len(transaction_bytes) > MAX_SOLANA_TRANSACTION_BYTES:
+        raise ValueError("signed x402 transaction exceeds the Solana wire limit")
+
+    payload: dict[str, object] = {
+        "x402Version": payment_required.x402_version,
+        "resource": payment_required.resource,
+        "accepted": accepted,
+        "payload": {"transaction": signed.transaction},
+    }
+    if "extensions" in payment_required.model_fields_set:
+        payload["extensions"] = payment_required.extensions
+    try:
+        payment_payload = PaymentPayload.model_validate(payload)
+    except Exception:
+        raise ValueError("x402 payment payload is invalid") from None
+
+    payment_signature = encode_payment_signature_header(payment_payload)
+    if len(payment_signature.encode("utf-8")) > MAX_PAYMENT_SIGNATURE_HEADER_BYTES:
+        raise ValueError("PAYMENT-SIGNATURE exceeds the supported header size")
+
+    return X402PaymentSubmission(
+        payment_payload=payment_payload,
+        payment_signature_headers={PAYMENT_SIGNATURE_HEADER: payment_signature},
+    )
+
+
+def _response_accepted_index(value: object) -> int:
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value < 0
+        or value > UINT32_MAX
+    ):
+        raise ValueError("x402 preparation response has an invalid acceptedIndex")
+    return value
+
+
+def _decode_canonical_base64(value: str) -> bytes:
+    if not isinstance(value, str) or not value:
+        raise ValueError("signed x402 transaction is not canonical base64")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except ValueError:
+        raise ValueError("signed x402 transaction is not canonical base64") from None
+    if base64.b64encode(decoded).decode("ascii") != value:
+        raise ValueError("signed x402 transaction is not canonical base64")
+    if not decoded:
+        raise ValueError("signed x402 transaction is empty")
+    return decoded
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    raise ValueError(f"{label} must be an object")
+
+
+def _pick(body: Mapping[str, object], *keys: str) -> object | None:
+    for key in keys:
+        if key in body:
+            return body[key]
+    return None

--- a/packages/developer-sdk/python/tests/test_proxy.py
+++ b/packages/developer-sdk/python/tests/test_proxy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 import httpx
+from x402.schemas import PaymentRequired
 
 from swig_developer_sdk import (
     SwigProxyConfig,
@@ -101,3 +102,67 @@ async def test_proxy_rejects_non_positive_amount_before_backend() -> None:
     )
     assert response.status == 400
     assert response.body == {"error": "amount must be a positive integer string"}
+
+
+async def test_proxy_prepares_x402_without_requiring_a_fee_payer() -> None:
+    requests: list[httpx.Request] = []
+
+    def backend(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "acceptedIndex": 0,
+                    "preparedTransaction": {
+                        "transaction": "cHJlcGFyZWQ=",
+                        "transactionEncoding": "TRANSACTION_ENCODING_BASE64",
+                        "network": "NETWORK_DEVNET",
+                        "kind": "PREPARED_TRANSACTION_KIND_X402_PAYMENT",
+                        "wallet": {
+                            "swigConfigAddress": "swig",
+                            "walletAddress": "swig-wallet",
+                        },
+                    },
+                }
+            },
+        )
+
+    payment_required = PaymentRequired.model_validate(
+        {
+            "x402Version": 2,
+            "resource": {"url": "https://resource.example/weather"},
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+                    "asset": "mint",
+                    "amount": "1000",
+                    "payTo": "resource-provider",
+                    "maxTimeoutSeconds": 300,
+                    "extra": {"feePayer": "facilitator"},
+                }
+            ],
+        }
+    )
+    handler = create_swig_proxy_handler(
+        SwigProxyConfig(
+            api_key="secret",
+            transaction_api_url="https://backend.test",
+            network="devnet",
+            resolve_requester_pubkey=lambda _context: "developer",
+            transport=httpx.MockTransport(backend),
+        )
+    )
+    response = await handler.handle(
+        method="POST",
+        path="/api/swig/x402/prepare",
+        body={
+            "wallet": {"swigConfigAddress": "swig"},
+            "paymentRequired": payment_required.model_dump(by_alias=True),
+        },
+    )
+
+    assert response.status == 200
+    assert response.body["prepared"]["acceptedIndex"] == 0
+    assert requests[0].url.path == "/transaction/payment/x402/prepare"

--- a/packages/developer-sdk/python/tests/test_x402.py
+++ b/packages/developer-sdk/python/tests/test_x402.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+from x402.http import (
+    PAYMENT_REQUIRED_HEADER,
+    PAYMENT_SIGNATURE_HEADER,
+    decode_payment_signature_header,
+    encode_payment_required_header,
+)
+from x402.schemas import PaymentPayload, PaymentRequired
+
+from swig_developer_sdk import (
+    SignedPreparedTransaction,
+    SwigClient,
+    create_x402_payment,
+)
+
+DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+
+
+async def test_wallet_x402_prepares_from_response_without_an_index() -> None:
+    requests: list[httpx.Request] = []
+    payment_required = _payment_required()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"data": _prepared_response(accepted_index=1)},
+        )
+
+    wallet = _wallet(httpx.MockTransport(handler))
+    prepared = await wallet.x402.prepare_from_response(
+        _payment_required_response(payment_required)
+    )
+
+    assert prepared.accepted_index == 1
+    assert prepared.payment_required == payment_required
+    assert prepared.prepared_transaction.kind == "x402-payment"
+    assert requests[0].url.path == "/transaction/payment/x402/prepare"
+    assert json.loads(requests[0].content) == {
+        "paymentRequired": payment_required.model_dump(
+            by_alias=True, exclude_unset=True
+        ),
+        "network": "NETWORK_DEVNET",
+        "swigAddress": "swig-config",
+        "requesterAuthority": {"ed25519": {"publicKey": "developer"}},
+    }
+
+
+async def test_wallet_x402_forwards_an_explicit_index() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"data": _prepared_response(0)})
+
+    wallet = _wallet(httpx.MockTransport(handler))
+    prepared = await wallet.x402.prepare_from_response(
+        _payment_required_response(_payment_required(svm_first=True)),
+        accepted_index=0,
+    )
+
+    assert prepared.accepted_index == 0
+    assert json.loads(requests[0].content)["acceptedIndex"] == 0
+
+
+@pytest.mark.parametrize("accepted_index", [True, -1, 0x1_0000_0000])
+async def test_wallet_x402_rejects_an_invalid_index(accepted_index: int) -> None:
+    wallet = _wallet(httpx.MockTransport(lambda _request: httpx.Response(500)))
+    with pytest.raises(ValueError, match="non-negative uint32"):
+        await wallet.x402.prepare_from_response(
+            _payment_required_response(_payment_required()),
+            accepted_index=accepted_index,
+        )
+
+
+def test_create_x402_payment_uses_the_official_header_codec() -> None:
+    payment_required = _payment_required(svm_first=True)
+    prepared = _preparation_result(payment_required)
+    signed = SignedPreparedTransaction(
+        transaction=base64.b64encode(b"signed transaction").decode("ascii"),
+        transaction_encoding="base64",
+        network="devnet",
+    )
+
+    submission = create_x402_payment(prepared, signed)
+    decoded = decode_payment_signature_header(
+        submission.payment_signature_headers[PAYMENT_SIGNATURE_HEADER]
+    )
+
+    assert isinstance(decoded, PaymentPayload)
+    assert decoded.accepted.asset == payment_required.accepts[0].asset
+    assert decoded.payload == {"transaction": signed.transaction}
+
+
+def _wallet(transport: httpx.AsyncBaseTransport):
+    swig = SwigClient(
+        api_key="secret",
+        base_url="https://backend.test",
+        network="devnet",
+        transport=transport,
+    )
+    return swig.wallets.use(
+        "swig-config",
+        requester_authority={"ed25519": {"publicKey": "developer"}},
+    )
+
+
+def _payment_required(*, svm_first: bool = False) -> PaymentRequired:
+    svm = {
+        "scheme": "exact",
+        "network": DEVNET,
+        "asset": "So11111111111111111111111111111111111111112",
+        "amount": "1000",
+        "payTo": "resource-provider",
+        "maxTimeoutSeconds": 300,
+        "extra": {"feePayer": "facilitator"},
+    }
+    evm = {
+        "scheme": "exact",
+        "network": "eip155:8453",
+        "asset": "0x0000000000000000000000000000000000000001",
+        "amount": "1000",
+        "payTo": "0x0000000000000000000000000000000000000002",
+        "maxTimeoutSeconds": 300,
+        "extra": {},
+    }
+    return PaymentRequired.model_validate(
+        {
+            "x402Version": 2,
+            "resource": {
+                "url": "https://resource.example/weather",
+                "description": "Weather",
+                "mimeType": "application/json",
+            },
+            "accepts": [svm, evm] if svm_first else [evm, svm],
+        }
+    )
+
+
+def _payment_required_response(payment_required: PaymentRequired) -> httpx.Response:
+    return httpx.Response(
+        402,
+        headers={
+            PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required)
+        },
+    )
+
+
+def _prepared_response(accepted_index: int) -> dict[str, object]:
+    return {
+        "acceptedIndex": accepted_index,
+        "preparedTransaction": {
+            "transaction": base64.b64encode(b"prepared transaction").decode("ascii"),
+            "transactionEncoding": "TRANSACTION_ENCODING_BASE64",
+            "network": "NETWORK_DEVNET",
+            "kind": "PREPARED_TRANSACTION_KIND_X402_PAYMENT",
+            "wallet": {
+                "swigConfigAddress": "swig-config",
+                "walletAddress": "swig-wallet",
+            },
+            "signatureRequests": [],
+        },
+    }
+
+
+def _preparation_result(payment_required: PaymentRequired):
+    from swig_developer_sdk import X402PreparationResult
+    from swig_developer_sdk.transactions import normalize_prepared_transaction
+
+    return X402PreparationResult(
+        prepared_transaction=normalize_prepared_transaction(
+            _prepared_response(0)["preparedTransaction"]
+        ),
+        payment_required=payment_required,
+        accepted_index=0,
+    )

--- a/packages/developer-sdk/python/uv.lock
+++ b/packages/developer-sdk/python/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -228,7 +237,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -454,6 +463,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -487,6 +505,137 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -581,6 +730,7 @@ dependencies = [
     { name = "base58" },
     { name = "httpx" },
     { name = "solders" },
+    { name = "x402" },
 ]
 
 [package.dev-dependencies]
@@ -597,6 +747,7 @@ requires-dist = [
     { name = "base58", specifier = ">=2.1,<3" },
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "solders", specifier = ">=0.28,<0.29" },
+    { name = "x402", specifier = "==2.18.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -669,4 +820,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "x402"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nest-asyncio" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/8a/756c978d1c507ed6b65105affc630e31b7b6fe5783f60fc8d433554f20d8/x402-2.18.0.tar.gz", hash = "sha256:fb30d8de45c8add3a28109c38527843cd7038c9c4c764e761455fd58ccf58aa9", size = 2100275, upload-time = "2026-08-04T18:48:18.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/ba/1160d9b83d4fdc105dfa0972953845710d30a36f3773c6f7acec4dea7a02/x402-2.18.0-py3-none-any.whl", hash = "sha256:11c337ae202811916af0e241ee2510803bfd2a4da906f7373f2a6ad6a983219e", size = 2233019, upload-time = "2026-08-04T18:48:16.876Z" },
 ]


### PR DESCRIPTION
## Summary

Adds x402 payment preparation support to the Python Developer SDK, matching the TypeScript SDK flow and existing Python conventions.

## Changes

- Adds `wallet.x402.prepare_from_response()`.
- Supports omitted or explicit `accepted_index`.
- Adds `create_x402_payment()` for constructing the `PAYMENT-SIGNATURE` header.
- Uses the official `x402==2.18.0` Python models and header codecs.
- Reuses the existing generic Ed25519 and Secp256r1 signing helpers.
- Adds `x402-payment` prepared-transaction normalization.
- Adds `/api/swig/x402/prepare` proxy support.
- Exports the new x402 client and result types.
- Updates Python documentation and the SDK parity matrix.
- Adds focused request-capture, payload-assembly, and proxy tests.

## Validation

- `uv sync --frozen --all-groups`
- Ruff formatting and lint passed.
- Strict mypy passed.
- All 34 Python tests passed.
- Source distribution and wheel builds passed.
- `git diff --check` passed.

A temporary live integration also completed successfully against swig backend, the x402 resource server and facilitator, and Surfpool:

- The protected resource returned successfully.
- `PAYMENT-RESPONSE` was present.